### PR TITLE
Move the default cylc-run directory location

### DIFF
--- a/README
+++ b/README
@@ -23,6 +23,16 @@ source env-setup/cheyenne
 
 ./drive.csh
 
+# It is required to set the work/run directories in ~/.cylc/global.rc as follows:
+[hosts]
+    [[localhost]]
+        work directory = /glade/scratch/USERNAME/cylc-run
+        run directory = /glade/scratch/USERNAME/cylc-run
+        [[[batch systems]]]
+            [[[[pbs]]]]
+                job name length maximum = 236
+
+# It is recommended to also set 'job name length maximum'
 
 ## top-level configuration (config/*.csh)
 -----------------------------------------

--- a/drive.csh
+++ b/drive.csh
@@ -95,7 +95,8 @@ module purge
 module load cylc
 module load graphviz
 
-rm -fr ${HOME}/cylc-run/${ExperimentName}
+set cylcWorkDir = /glade/scratch/${USER}/cylc-run
+rm -fr ${cylcWorkDir}/${ExperimentName}
 echo "creating suite.rc"
 cat >! suite.rc << EOF
 #!Jinja2


### PR DESCRIPTION
Updated README and drive.csh for a new default cylc-run location.  Need to modify ~/.cylc/global.rc in order to keep using this Repo.