### PR TITLE
Enable previous EDA forecasts to be used in 3denvar experiment

### DIFF
--- a/config/experiment.csh
+++ b/config/experiment.csh
@@ -69,6 +69,15 @@ if ( "$DAType" =~ *"eda"* ) then
   setenv nEnsDAMembers 20
 else
   setenv nEnsDAMembers 1
+  ## fixedEnsBType
+  # selection of data source for fixed ensemble background covariance members
+  # OPTIONS: GEFS(default), PreviousEDA
+  set fixedEnsBType = GEFS
+
+  # tertiary settings for when fixedEnsBType is set to PreviousEDA
+  set nPreviousEnsDAMembers = 20
+  set PreviousEDAForecastDir = \
+    /glade/scratch/guerrett/pandac/guerrett_eda_3denvar_NMEM${nPreviousEnsDAMembers}_LeaveOneOut_OIE120km/CyclingFC
 endif
 
 ## LeaveOneOutEDA

--- a/config/experiment.csh
+++ b/config/experiment.csh
@@ -69,9 +69,10 @@ if ( "$DAType" =~ *"eda"* ) then
   setenv nEnsDAMembers 20
 else
   setenv nEnsDAMembers 1
+
   ## fixedEnsBType
   # selection of data source for fixed ensemble background covariance members
-  # OPTIONS: GEFS(default), PreviousEDA
+  # OPTIONS: GEFS (default), PreviousEDA
   set fixedEnsBType = GEFS
 
   # tertiary settings for when fixedEnsBType is set to PreviousEDA

--- a/config/modeldata.csh
+++ b/config/modeldata.csh
@@ -64,39 +64,40 @@ endif
 # background covariance
 # ---------------------
 ## stochastic analysis (dynamic directory structure)
-setenv dynamicEnsBMemFmt "${flowMemFmt}"
-setenv dynamicEnsBNMembers ${nEnsDAMembers}
-setenv dynamicEnsBDir ${CyclingFCWorkDir}
-setenv dynamicEnsBFilePrefix ${FCFilePrefix}
-
-## deterministic analysis (static directory structure)
-# parse selections
-if ("$fixedEnsBType" == "GEFS") then
-  setenv fixedEnsBMemFmt "${gefsMemFmt}"
-  setenv fixedEnsBNMembers ${nGEFSMembers}
-  setenv fixedEnsBDir ${GEFS6hfcFOREnsBDir}
-  setenv fixedEnsBFilePrefix ${GEFS6hfcFOREnsBFilePrefix}
-else if ("$fixedEnsBType" == "PreviousEDA") then
-  setenv fixedEnsBMemFmt "${dynamicEnsBMemFmt}"
-  setenv fixedEnsBNMembers ${nPreviousEnsDAMembers}
-  setenv fixedEnsBDir ${PreviousEDAForecastDir}
-  setenv fixedEnsBFilePrefix ${dynamicEnsBFilePrefix}
-else
-  echo "ERROR in $0 : unrecognized value for fixedEnsBType --> ${fixedEnsBType}" >> ./FAIL
-  exit 1
-endif
+set dynamicEnsBMemFmt = "${flowMemFmt}"
+set dynamicEnsBFilePrefix = ${FCFilePrefix}
 
 ## select the ensPb settings based on DAType
 if ( "$DAType" =~ *"eda"* ) then
-  set ensPbDir = ${dynamicEnsBDir}
-  set ensPbFilePrefix = ${dynamicEnsBFilePrefix}
-  set ensPbMemFmt = "${dynamicEnsBMemFmt}"
-  set ensPbNMembers = ${dynamicEnsBNMembers}
+  set dynamicEnsBNMembers = ${nEnsDAMembers}
+  set dynamicEnsBDir = ${CyclingFCWorkDir}
+
+  setenv ensPbDir ${dynamicEnsBDir}
+  setenv ensPbFilePrefix ${dynamicEnsBFilePrefix}
+  setenv ensPbMemFmt "${dynamicEnsBMemFmt}"
+  setenv ensPbNMembers ${dynamicEnsBNMembers}
 else
-  set ensPbDir = ${fixedEnsBDir}
-  set ensPbFilePrefix = ${fixedEnsBFilePrefix}
-  set ensPbMemFmt = "${fixedEnsBMemFmt}"
-  set ensPbNMembers = ${fixedEnsBNMembers}
+  ## deterministic analysis (static directory structure)
+  # parse selections
+  if ("$fixedEnsBType" == "GEFS") then
+    set fixedEnsBMemFmt = "${gefsMemFmt}"
+    set fixedEnsBNMembers = ${nGEFSMembers}
+    set fixedEnsBDir = ${GEFS6hfcFOREnsBDir}
+    set fixedEnsBFilePrefix = ${GEFS6hfcFOREnsBFilePrefix}
+  else if ("$fixedEnsBType" == "PreviousEDA") then
+    set fixedEnsBMemFmt = "${dynamicEnsBMemFmt}"
+    set fixedEnsBNMembers = ${nPreviousEnsDAMembers}
+    set fixedEnsBDir = ${PreviousEDAForecastDir}
+    set fixedEnsBFilePrefix = ${dynamicEnsBFilePrefix}
+  else
+    echo "ERROR in $0 : unrecognized value for fixedEnsBType --> ${fixedEnsBType}" >> ./FAIL
+    exit 1
+  endif
+
+  setenv ensPbDir ${fixedEnsBDir}
+  setenv ensPbFilePrefix ${fixedEnsBFilePrefix}
+  setenv ensPbMemFmt "${fixedEnsBMemFmt}"
+  setenv ensPbNMembers ${fixedEnsBNMembers}
 endif
 
 

--- a/config/modeldata.csh
+++ b/config/modeldata.csh
@@ -63,17 +63,28 @@ endif
 
 # background covariance
 # ---------------------
-## deterministic (static)
-setenv fixedEnsBMemFmt "${gefsMemFmt}"
-setenv fixedEnsBNMembers ${nGEFSMembers}
-setenv fixedEnsBDir ${GEFS6hfcFOREnsBDir}
-setenv fixedEnsBFilePrefix ${GEFS6hfcFOREnsBFilePrefix}
-
-## stochastic (dynamic)
+## stochastic analysis (dynamic directory structure)
 setenv dynamicEnsBMemFmt "${flowMemFmt}"
 setenv dynamicEnsBNMembers ${nEnsDAMembers}
 setenv dynamicEnsBDir ${CyclingFCWorkDir}
 setenv dynamicEnsBFilePrefix ${FCFilePrefix}
+
+## deterministic analysis (static directory structure)
+# parse selections
+if ("$fixedEnsBType" == "GEFS") then
+  setenv fixedEnsBMemFmt "${gefsMemFmt}"
+  setenv fixedEnsBNMembers ${nGEFSMembers}
+  setenv fixedEnsBDir ${GEFS6hfcFOREnsBDir}
+  setenv fixedEnsBFilePrefix ${GEFS6hfcFOREnsBFilePrefix}
+else if ("$fixedEnsBType" == "PreviousEDA") then
+  setenv fixedEnsBMemFmt "${dynamicEnsBMemFmt}"
+  setenv fixedEnsBNMembers ${nPreviousEnsDAMembers}
+  setenv fixedEnsBDir ${PreviousEDAForecastDir}
+  setenv fixedEnsBFilePrefix ${dynamicEnsBFilePrefix}
+else
+  echo "ERROR in $0 : unrecognized value for fixedEnsBType --> ${fixedEnsBType}" >> ./FAIL
+  exit 1
+endif
 
 ## select the ensPb settings based on DAType
 if ( "$DAType" =~ *"eda"* ) then


### PR DESCRIPTION
For an example, see `/glade/scratch/guerrett/pandac/guerrett_3denvar_OIE120km_PreviousEDALeave20`.