### PR TITLE
Updates for ioda-v2

### DIFF
--- a/GenerateABEInflation.csh
+++ b/GenerateABEInflation.csh
@@ -56,7 +56,7 @@ set nInstAvailable = 0
 foreach inst ($self_ObsList)
   set missing = 0
   # TODO: define obsoutGlob construction in a different place
-  set obsoutGlob = "${dbPath}/obsout_${self_AppType}_${inst}_*.nc4"
+  set obsoutGlob = "${dbPath}/obsout_${self_AppType}_${inst}_*.h5"
   echo "Searching for ${obsoutGlob}"
   find ${obsoutGlob} -mindepth 0 -maxdepth 0
   if ($? > 0) then

--- a/clean-hofx.csh
+++ b/clean-hofx.csh
@@ -61,8 +61,8 @@ rm ${self_WorkDir}/${anDir}/${ANFilePrefix}.$fileDate.nc
 # Remove obs-database output files
 # ================================
 rm ${self_WorkDir}/${OutDBDir}/${obsPrefix}*.h5
-rm ${self_WorkDir}/${OutDBDir}/${geoPrefix}*.h5
-rm ${self_WorkDir}/${OutDBDir}/${diagPrefix}*.h5
+rm ${self_WorkDir}/${OutDBDir}/${geoPrefix}*.nc4
+rm ${self_WorkDir}/${OutDBDir}/${diagPrefix}*.nc4
 
 date
 

--- a/clean-hofx.csh
+++ b/clean-hofx.csh
@@ -60,9 +60,9 @@ rm ${self_WorkDir}/${anDir}/${ANFilePrefix}.$fileDate.nc
 
 # Remove obs-database output files
 # ================================
-rm ${self_WorkDir}/${OutDBDir}/${obsPrefix}*.nc4
-rm ${self_WorkDir}/${OutDBDir}/${geoPrefix}*.nc4
-rm ${self_WorkDir}/${OutDBDir}/${diagPrefix}*.nc4
+rm ${self_WorkDir}/${OutDBDir}/${obsPrefix}*.h5
+rm ${self_WorkDir}/${OutDBDir}/${geoPrefix}*.h5
+rm ${self_WorkDir}/${OutDBDir}/${diagPrefix}*.h5
 
 date
 

--- a/clean-variational.csh
+++ b/clean-variational.csh
@@ -28,9 +28,9 @@ if (${nEnsDAMembers} > 1) then
   set member = 1
   while ( $member <= ${nEnsDAMembers} )
     set memDir = `${memberDir} $DAType $member`
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${obsPrefix}*.nc4
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${geoPrefix}*.nc4
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${diagPrefix}*.nc4
+    rm ${self_WorkDir}/${OutDBDir}${memDir}/${obsPrefix}*.h5
+    rm ${self_WorkDir}/${OutDBDir}${memDir}/${geoPrefix}*.h5
+    rm ${self_WorkDir}/${OutDBDir}${memDir}/${diagPrefix}*.h5
     @ member++
   end
 endif

--- a/clean-variational.csh
+++ b/clean-variational.csh
@@ -29,8 +29,8 @@ if (${nEnsDAMembers} > 1) then
   while ( $member <= ${nEnsDAMembers} )
     set memDir = `${memberDir} $DAType $member`
     rm ${self_WorkDir}/${OutDBDir}${memDir}/${obsPrefix}*.h5
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${geoPrefix}*.h5
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${diagPrefix}*.h5
+    rm ${self_WorkDir}/${OutDBDir}${memDir}/${geoPrefix}*.nc4
+    rm ${self_WorkDir}/${OutDBDir}${memDir}/${diagPrefix}*.nc4
     @ member++
   end
 endif

--- a/config/ObsPlugs/hofx/aircraft.yaml
+++ b/config/ObsPlugs/hofx/aircraft.yaml
@@ -2,8 +2,10 @@
     name: Aircraft
     obsdatain:
       obsfile: InDBDir/aircraft_obs_2018041500.h5
+      max frame size: 40000
     obsdataout:
       obsfile: OutDBDir/obsPrefix_AppType_aircraft.h5
+      max frame size: 40000
     simulated variables: [air_temperature, eastward_wind, northward_wind, specific_humidity]
   obs operator:
     name: VertInterp

--- a/config/ObsPlugs/hofx/aircraft.yaml
+++ b/config/ObsPlugs/hofx/aircraft.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: Aircraft
     obsdatain:
-      obsfile: InDBDir/aircraft_obs_2018041500.nc4
+      obsfile: InDBDir/aircraft_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_aircraft.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_aircraft.h5
     simulated variables: [air_temperature, eastward_wind, northward_wind, specific_humidity]
   obs operator:
     name: VertInterp

--- a/config/ObsPlugs/hofx/allabi15X15.yaml
+++ b/config/ObsPlugs/hofx/allabi15X15.yaml
@@ -64,9 +64,9 @@
 #          err0: [2.06, 1.35, 3.10]
 #          err1: [27.64, 22.93, 21.59]
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_abi_g16.h5
+    filename: OutDBDir/geoPrefix_AppType_abi_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_abi_g16.h5
+    filename: OutDBDir/diagPrefix_AppType_abi_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/hofx/allabi15X15.yaml
+++ b/config/ObsPlugs/hofx/allabi15X15.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: abi_g16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_2018041500.nc4
+      obsfile: InDBDir/abi_g16_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_abi_g16.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_abi_g16.h5
     simulated variables: [brightness_temperature]
     channels: &abi_channels 7-16
   obs operator:
@@ -64,9 +64,9 @@
 #          err0: [2.06, 1.35, 3.10]
 #          err1: [27.64, 22.93, 21.59]
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_abi_g16.nc4
+    filename: OutDBDir/geoPrefix_AppType_abi_g16.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_abi_g16.nc4
+    filename: OutDBDir/diagPrefix_AppType_abi_g16.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/hofx/allabi59X59.yaml
+++ b/config/ObsPlugs/hofx/allabi59X59.yaml
@@ -56,9 +56,9 @@
 #deflate30%
 #          err1: [12.68, 11.86, 13.76, 12.95, 16.14, 13.97, 18.30, 18.07, 17.81, 15.69]
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_abi_g16.h5
+    filename: OutDBDir/geoPrefix_AppType_abi_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_abi_g16.h5
+    filename: OutDBDir/diagPrefix_AppType_abi_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/hofx/allabi59X59.yaml
+++ b/config/ObsPlugs/hofx/allabi59X59.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: abi_g16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_2018041500.nc4
+      obsfile: InDBDir/abi_g16_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_abi_g16.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_abi_g16.h5
     simulated variables: [brightness_temperature]
     channels: &abi_channels 7-16
   obs operator:
@@ -56,9 +56,9 @@
 #deflate30%
 #          err1: [12.68, 11.86, 13.76, 12.95, 16.14, 13.97, 18.30, 18.07, 17.81, 15.69]
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_abi_g16.nc4
+    filename: OutDBDir/geoPrefix_AppType_abi_g16.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_abi_g16.nc4
+    filename: OutDBDir/diagPrefix_AppType_abi_g16.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/hofx/allabi_SCI.yaml
+++ b/config/ObsPlugs/hofx/allabi_SCI.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: ABI-GOES16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_2018041500.nc4
+      obsfile: InDBDir/abi_g16_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_abi_g16.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_abi_g16.h5
     simulated variables: [brightness_temperature]
     channels: &abi_channels 8-10
   obs operator:
@@ -64,9 +64,9 @@
 #          err0: [2.06, 1.35, 3.10]
 #          err1: [27.64, 22.93, 21.59]
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_abi_g16.nc4
+    filename: OutDBDir/geoPrefix_AppType_abi_g16.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_abi_g16.nc4
+    filename: OutDBDir/diagPrefix_AppType_abi_g16.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/hofx/allabi_SCI.yaml
+++ b/config/ObsPlugs/hofx/allabi_SCI.yaml
@@ -64,9 +64,9 @@
 #          err0: [2.06, 1.35, 3.10]
 #          err1: [27.64, 22.93, 21.59]
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_abi_g16.h5
+    filename: OutDBDir/geoPrefix_AppType_abi_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_abi_g16.h5
+    filename: OutDBDir/diagPrefix_AppType_abi_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/hofx/allabi_constObsError.yaml
+++ b/config/ObsPlugs/hofx/allabi_constObsError.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: ABI-GOES16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_2018041500.nc4
+      obsfile: InDBDir/abi_g16_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_abi_g16.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_abi_g16.h5
     simulated variables: [brightness_temperature]
     channels: &abi_channels 7-11,13-16
   obs operator:
@@ -36,9 +36,9 @@
 ##            name: solar_zenith_angle@MetaData
 ##          maxvalue: 65.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_abi_g16.nc4
+    filename: OutDBDir/geoPrefix_AppType_abi_g16.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_abi_g16.nc4
+    filename: OutDBDir/diagPrefix_AppType_abi_g16.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/hofx/allabi_constObsError.yaml
+++ b/config/ObsPlugs/hofx/allabi_constObsError.yaml
@@ -36,9 +36,9 @@
 ##            name: solar_zenith_angle@MetaData
 ##          maxvalue: 65.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_abi_g16.h5
+    filename: OutDBDir/geoPrefix_AppType_abi_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_abi_g16.h5
+    filename: OutDBDir/diagPrefix_AppType_abi_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/hofx/allahi101X101.yaml
+++ b/config/ObsPlugs/hofx/allahi101X101.yaml
@@ -54,9 +54,9 @@
           err0: [3.28, 1.87, 1.85, 2.17, 3.53, 4.76, 4.19, 4.44, 2.79, 1.79]
           err1: [17.73, 12.72, 14.65, 15.36, 24.62, 16.82, 23.8, 25.14, 22.66, 19.3]
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_ahi_himawari8.h5
+    filename: OutDBDir/geoPrefix_AppType_ahi_himawari8.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_ahi_himawari8.h5
+    filename: OutDBDir/diagPrefix_AppType_ahi_himawari8.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *ahi_channels

--- a/config/ObsPlugs/hofx/allahi101X101.yaml
+++ b/config/ObsPlugs/hofx/allahi101X101.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: ahi_himawari8
     obsdatain:
-      obsfile: InDBDir/ahi_himawari8_obs_2018041500.nc4
+      obsfile: InDBDir/ahi_himawari8_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_ahi_himawari8.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_ahi_himawari8.h5
     simulated variables: [brightness_temperature]
     channels: &ahi_channels 7-16
   obs operator:
@@ -54,9 +54,9 @@
           err0: [3.28, 1.87, 1.85, 2.17, 3.53, 4.76, 4.19, 4.44, 2.79, 1.79]
           err1: [17.73, 12.72, 14.65, 15.36, 24.62, 16.82, 23.8, 25.14, 22.66, 19.3]
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_ahi_himawari8.nc4
+    filename: OutDBDir/geoPrefix_AppType_ahi_himawari8.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_ahi_himawari8.nc4
+    filename: OutDBDir/diagPrefix_AppType_ahi_himawari8.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *ahi_channels

--- a/config/ObsPlugs/hofx/allahi15X15.yaml
+++ b/config/ObsPlugs/hofx/allahi15X15.yaml
@@ -54,9 +54,9 @@
           err0: [3.86, 1.96, 1.95, 2.62, 3.53, 3.24, 3.02, 3.12, 2.75, 2.22]
           err1: [18.9, 13.1, 15.51, 17.16, 23.79, 18.86, 25.65, 25.72, 24.91, 21.39]
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_ahi_himawari8.h5
+    filename: OutDBDir/geoPrefix_AppType_ahi_himawari8.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_ahi_himawari8.h5
+    filename: OutDBDir/diagPrefix_AppType_ahi_himawari8.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *ahi_channels

--- a/config/ObsPlugs/hofx/allahi15X15.yaml
+++ b/config/ObsPlugs/hofx/allahi15X15.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: ahi_himawari8
     obsdatain:
-      obsfile: InDBDir/ahi_himawari8_obs_2018041500.nc4
+      obsfile: InDBDir/ahi_himawari8_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_ahi_himawari8.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_ahi_himawari8.h5
     simulated variables: [brightness_temperature]
     channels: &ahi_channels 7-16
   obs operator:
@@ -54,9 +54,9 @@
           err0: [3.86, 1.96, 1.95, 2.62, 3.53, 3.24, 3.02, 3.12, 2.75, 2.22]
           err1: [18.9, 13.1, 15.51, 17.16, 23.79, 18.86, 25.65, 25.72, 24.91, 21.39]
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_ahi_himawari8.nc4
+    filename: OutDBDir/geoPrefix_AppType_ahi_himawari8.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_ahi_himawari8.nc4
+    filename: OutDBDir/diagPrefix_AppType_ahi_himawari8.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *ahi_channels

--- a/config/ObsPlugs/hofx/allmhs.yaml
+++ b/config/ObsPlugs/hofx/allmhs.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: mhs_n19
     obsdatain:
-      obsfile: InDBDir/mhs_n19_obs_2018041500.nc4
+      obsfile: InDBDir/mhs_n19_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_mhs_n19.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_mhs_n19.h5
     simulated variables: [brightness_temperature]
     channels: &allmhs_channels 1-5
   obs error:
@@ -30,9 +30,9 @@
         name: water_area_fraction@GeoVaLs
       minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_mhs_n19.nc4
+    filename: OutDBDir/geoPrefix_AppType_mhs_n19.h5
   - filter: YDIAGsaver 
-    filename: OutDBDir/diagPrefix_AppType_mhs_n19.nc4
+    filename: OutDBDir/diagPrefix_AppType_mhs_n19.h5
     filter variables: &allmhsydiag
     - name: brightness_temperature_assuming_clear_sky
       channels: *allmhs_channels
@@ -53,9 +53,9 @@
 - obs space:
     name: mhs_n18
     obsdatain:
-      obsfile: InDBDir/mhs_n18_obs_2018041500.nc4
+      obsfile: InDBDir/mhs_n18_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_mhs_n18.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_mhs_n18.h5
     simulated variables: [brightness_temperature]
     channels: *allmhs_channels
   obs error:
@@ -75,18 +75,18 @@
         name: water_area_fraction@GeoVaLs
       minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_mhs_n18.nc4
+    filename: OutDBDir/geoPrefix_AppType_mhs_n18.h5
   - filter: YDIAGsaver 
-    filename: OutDBDir/diagPrefix_AppType_mhs_n18.nc4
+    filename: OutDBDir/diagPrefix_AppType_mhs_n18.h5
     filter variables: *allmhsydiag
   get values:
     interpolation type: InterpolationType
 - obs space:
     name: mhs_metop-a
     obsdatain:
-      obsfile: InDBDir/mhs_metop-a_obs_2018041500.nc4
+      obsfile: InDBDir/mhs_metop-a_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_mhs_metop-a.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_mhs_metop-a.h5
     simulated variables: [brightness_temperature]
     channels: *allmhs_channels
   obs error:
@@ -106,18 +106,18 @@
         name: water_area_fraction@GeoVaLs
       minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_mhs_metop-a.nc4
+    filename: OutDBDir/geoPrefix_AppType_mhs_metop-a.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_mhs_metop-a.nc4
+    filename: OutDBDir/diagPrefix_AppType_mhs_metop-a.h5
     filter variables: *allmhsydiag
   get values:
     interpolation type: InterpolationType
 - obs space:
     name: mhs_metop-b
     obsdatain:
-      obsfile: InDBDir/mhs_metop-b_obs_2018041500.nc4
+      obsfile: InDBDir/mhs_metop-b_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_mhs_metop-b.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_mhs_metop-b.h5
     simulated variables: [brightness_temperature]
     channels: *allmhs_channels
   obs error:
@@ -137,9 +137,9 @@
         name: water_area_fraction@GeoVaLs
       minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_mhs_metop-b.nc4
+    filename: OutDBDir/geoPrefix_AppType_mhs_metop-b.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_mhs_metop-b.nc4
+    filename: OutDBDir/diagPrefix_AppType_mhs_metop-b.h5
     filter variables: *allmhsydiag
   get values:
     interpolation type: InterpolationType

--- a/config/ObsPlugs/hofx/allmhs.yaml
+++ b/config/ObsPlugs/hofx/allmhs.yaml
@@ -30,9 +30,9 @@
         name: water_area_fraction@GeoVaLs
       minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_mhs_n19.h5
+    filename: OutDBDir/geoPrefix_AppType_mhs_n19.nc4
   - filter: YDIAGsaver 
-    filename: OutDBDir/diagPrefix_AppType_mhs_n19.h5
+    filename: OutDBDir/diagPrefix_AppType_mhs_n19.nc4
     filter variables: &allmhsydiag
     - name: brightness_temperature_assuming_clear_sky
       channels: *allmhs_channels
@@ -75,9 +75,9 @@
         name: water_area_fraction@GeoVaLs
       minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_mhs_n18.h5
+    filename: OutDBDir/geoPrefix_AppType_mhs_n18.nc4
   - filter: YDIAGsaver 
-    filename: OutDBDir/diagPrefix_AppType_mhs_n18.h5
+    filename: OutDBDir/diagPrefix_AppType_mhs_n18.nc4
     filter variables: *allmhsydiag
   get values:
     interpolation type: InterpolationType
@@ -106,9 +106,9 @@
         name: water_area_fraction@GeoVaLs
       minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_mhs_metop-a.h5
+    filename: OutDBDir/geoPrefix_AppType_mhs_metop-a.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_mhs_metop-a.h5
+    filename: OutDBDir/diagPrefix_AppType_mhs_metop-a.nc4
     filter variables: *allmhsydiag
   get values:
     interpolation type: InterpolationType
@@ -137,9 +137,9 @@
         name: water_area_fraction@GeoVaLs
       minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_mhs_metop-b.h5
+    filename: OutDBDir/geoPrefix_AppType_mhs_metop-b.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_mhs_metop-b.h5
+    filename: OutDBDir/diagPrefix_AppType_mhs_metop-b.nc4
     filter variables: *allmhsydiag
   get values:
     interpolation type: InterpolationType

--- a/config/ObsPlugs/hofx/cldamsua.yaml
+++ b/config/ObsPlugs/hofx/cldamsua.yaml
@@ -25,9 +25,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n19.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n19.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n19.h5
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n19.nc4
     filter variables: &cldamsuaydiag
     - name: brightness_temperature_assuming_clear_sky
       channels: *cldamsua_channels
@@ -73,9 +73,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n15.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n15.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n15.h5
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n15.nc4
     filter variables: 
     - name: brightness_temperature_assuming_clear_sky
       channels: *cldamsuan15_channels
@@ -115,9 +115,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n18.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n18.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n18.h5
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n18.nc4
     filter variables: 
     - name: brightness_temperature_assuming_clear_sky
       channels: *cldamsuan18_channels
@@ -157,9 +157,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_metop-a.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_metop-a.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_metop-a.h5
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_metop-a.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *cldamsuama_channels
@@ -197,9 +197,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_metop-b.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_metop-b.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_metop-b.h5
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_metop-b.nc4
     filter variables: *cldamsuaydiag
   obs operator:
     <<: *cldamsuacrtm
@@ -235,9 +235,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_aqua.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_aqua.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_aqua.h5
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_aqua.nc4
     filter variables: *cldamsuaydiag
   obs operator:
     <<: *cldamsuacrtm

--- a/config/ObsPlugs/hofx/cldamsua.yaml
+++ b/config/ObsPlugs/hofx/cldamsua.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: amsua-cld_n19
     obsdatain:
-      obsfile: InDBDir/amsua_n19_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n19_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_n19.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_n19.h5
     simulated variables: [brightness_temperature]
     channels: &cldamsua_channels 1-4,15
 #    channels: &cldamsua_channels 1-15
@@ -25,9 +25,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n19.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n19.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n19.nc4
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n19.h5
     filter variables: &cldamsuaydiag
     - name: brightness_temperature_assuming_clear_sky
       channels: *cldamsua_channels
@@ -48,9 +48,9 @@
 - obs space:
     name: amsua-cld_n15
     obsdatain:
-      obsfile: InDBDir/amsua_n15_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n15_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_n15.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_n15.h5
     simulated variables: [brightness_temperature]
     channels: &cldamsuan15_channels 1-4,15
 #CHECK FPE ERRORS IN CRTM
@@ -73,9 +73,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n15.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n15.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n15.nc4
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n15.h5
     filter variables: 
     - name: brightness_temperature_assuming_clear_sky
       channels: *cldamsuan15_channels
@@ -90,9 +90,9 @@
 - obs space:
     name: amsua-cld_n18
     obsdatain:
-      obsfile: InDBDir/amsua_n18_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n18_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_n18.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_n18.h5
     simulated variables: [brightness_temperature]
     channels: &cldamsuan18_channels 1-4,15
 #CHECK FPE ERRORS IN CRTM
@@ -115,9 +115,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n18.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_n18.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n18.nc4
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_n18.h5
     filter variables: 
     - name: brightness_temperature_assuming_clear_sky
       channels: *cldamsuan18_channels
@@ -132,9 +132,9 @@
 - obs space:
     name: amsua-cld_metop-a
     obsdatain:
-      obsfile: InDBDir/amsua_metop-a_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_metop-a_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_metop-a.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_metop-a.h5
     simulated variables: [brightness_temperature]
     channels: &cldamsuama_channels 1-4,15
 #CHECK FPE ERRORS IN CRTM
@@ -157,9 +157,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_metop-a.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_metop-a.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_metop-a.nc4
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_metop-a.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *cldamsuama_channels
@@ -174,9 +174,9 @@
 - obs space:
     name: amsua-cld_metop-b
     obsdatain:
-      obsfile: InDBDir/amsua_metop-b_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_metop-b_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_metop-b.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_metop-b.h5
     simulated variables: [brightness_temperature]
     channels: *cldamsua_channels
   obs error:
@@ -197,9 +197,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_metop-b.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_metop-b.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_metop-b.nc4
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_metop-b.h5
     filter variables: *cldamsuaydiag
   obs operator:
     <<: *cldamsuacrtm
@@ -212,9 +212,9 @@
 - obs space:
     name: amsua-cld_aqua
     obsdatain:
-      obsfile: InDBDir/amsua_aqua_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_aqua_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_aqua.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua-cld_aqua.h5
     simulated variables: [brightness_temperature]
     channels: *cldamsua_channels
   obs error:
@@ -235,9 +235,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua-cld_aqua.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua-cld_aqua.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_amsua-cld_aqua.nc4
+    filename: OutDBDir/diagPrefix_AppType_amsua-cld_aqua.h5
     filter variables: *cldamsuaydiag
   obs operator:
     <<: *cldamsuacrtm

--- a/config/ObsPlugs/hofx/clrabi.yaml
+++ b/config/ObsPlugs/hofx/clrabi.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: abi-clr_g16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_2018041500.nc4
+      obsfile: InDBDir/abi_g16_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_abi-clr_g16.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_abi-clr_g16.h5
     simulated variables: [brightness_temperature]
     channels: &clrabi_channels 7-16
   obs operator:
@@ -26,9 +26,9 @@
         name: sensor_zenith_angle@MetaData
       maxvalue: 65.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_abi-clr_g16.nc4
+    filename: OutDBDir/geoPrefix_AppType_abi-clr_g16.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_abi-clr_g16.nc4
+    filename: OutDBDir/diagPrefix_AppType_abi-clr_g16.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrabi_channels

--- a/config/ObsPlugs/hofx/clrabi.yaml
+++ b/config/ObsPlugs/hofx/clrabi.yaml
@@ -26,9 +26,9 @@
         name: sensor_zenith_angle@MetaData
       maxvalue: 65.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_abi-clr_g16.h5
+    filename: OutDBDir/geoPrefix_AppType_abi-clr_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_abi-clr_g16.h5
+    filename: OutDBDir/diagPrefix_AppType_abi-clr_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrabi_channels

--- a/config/ObsPlugs/hofx/clrahi.yaml
+++ b/config/ObsPlugs/hofx/clrahi.yaml
@@ -26,9 +26,9 @@
         name: sensor_zenith_angle@MetaData
       maxvalue: 65.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_ahi-clr_himawari8.h5
+    filename: OutDBDir/geoPrefix_AppType_ahi-clr_himawari8.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_ahi-clr_himawari8.h5
+    filename: OutDBDir/diagPrefix_AppType_ahi-clr_himawari8.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrahi_channels

--- a/config/ObsPlugs/hofx/clrahi.yaml
+++ b/config/ObsPlugs/hofx/clrahi.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: ahi-clr_himawari8
     obsdatain:
-      obsfile: InDBDir/ahi_himawari8_obs_2018041500.nc4
+      obsfile: InDBDir/ahi_himawari8_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_ahi-clr_himawari8.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_ahi-clr_himawari8.h5
     simulated variables: [brightness_temperature]
     channels: &clrahi_channels 7-16
   obs operator:
@@ -26,9 +26,9 @@
         name: sensor_zenith_angle@MetaData
       maxvalue: 65.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_ahi-clr_himawari8.nc4
+    filename: OutDBDir/geoPrefix_AppType_ahi-clr_himawari8.h5
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_AppType_ahi-clr_himawari8.nc4
+    filename: OutDBDir/diagPrefix_AppType_ahi-clr_himawari8.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrahi_channels

--- a/config/ObsPlugs/hofx/clramsua.yaml
+++ b/config/ObsPlugs/hofx/clramsua.yaml
@@ -20,7 +20,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_n19.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua_n19.nc4
   obs operator: &clramsuacrtm
     name: CRTM
     SurfaceWindGeoVars: uv
@@ -55,7 +55,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_n15.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua_n15.nc4
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -85,7 +85,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_n18.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua_n18.nc4
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -115,7 +115,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_metop-a.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua_metop-a.nc4
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -145,7 +145,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_metop-b.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua_metop-b.nc4
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -175,7 +175,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_aqua.h5
+    filename: OutDBDir/geoPrefix_AppType_amsua_aqua.nc4
   obs operator:
     <<: *clramsuacrtm
     obs options:

--- a/config/ObsPlugs/hofx/clramsua.yaml
+++ b/config/ObsPlugs/hofx/clramsua.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: amsua_n19
     obsdatain:
-      obsfile: InDBDir/amsua_n19_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n19_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua_n19.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua_n19.h5
     simulated variables: [brightness_temperature]
     channels: &clramsua_channels 5-14
   obs error:
@@ -20,7 +20,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_n19.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua_n19.h5
   obs operator: &clramsuacrtm
     name: CRTM
     SurfaceWindGeoVars: uv
@@ -36,9 +36,9 @@
 - obs space:
     name: amsua_n15
     obsdatain:
-      obsfile: InDBDir/amsua_n15_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n15_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua_n15.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua_n15.h5
     simulated variables: [brightness_temperature]
     channels: *clramsua_channels
   obs error:
@@ -55,7 +55,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_n15.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua_n15.h5
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -66,9 +66,9 @@
 - obs space:
     name: amsua_n18
     obsdatain:
-      obsfile: InDBDir/amsua_n18_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n18_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua_n18.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua_n18.h5
     simulated variables: [brightness_temperature]
     channels: *clramsua_channels
   obs error:
@@ -85,7 +85,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_n18.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua_n18.h5
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -96,9 +96,9 @@
 - obs space:
     name: amsua_metop-a
     obsdatain:
-      obsfile: InDBDir/amsua_metop-a_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_metop-a_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua_metop-a.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua_metop-a.h5
     simulated variables: [brightness_temperature]
     channels: *clramsua_channels
   obs error:
@@ -115,7 +115,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_metop-a.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua_metop-a.h5
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -126,9 +126,9 @@
 - obs space:
     name: amsua_metop-b
     obsdatain:
-      obsfile: InDBDir/amsua_metop-b_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_metop-b_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua_metop-b.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua_metop-b.h5
     simulated variables: [brightness_temperature]
     channels: *clramsua_channels
   obs error:
@@ -145,7 +145,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_metop-b.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua_metop-b.h5
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -156,9 +156,9 @@
 - obs space:
     name: amsua_aqua
     obsdatain:
-      obsfile: InDBDir/amsua_aqua_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_aqua_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_amsua_aqua.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_amsua_aqua.h5
     simulated variables: [brightness_temperature]
     channels: *clramsua_channels
   obs error:
@@ -175,7 +175,7 @@
 #  - filter: PreQC
 #    maxvalue: 0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_AppType_amsua_aqua.nc4
+    filename: OutDBDir/geoPrefix_AppType_amsua_aqua.h5
   obs operator:
     <<: *clramsuacrtm
     obs options:

--- a/config/ObsPlugs/hofx/gnssroref.yaml
+++ b/config/ObsPlugs/hofx/gnssroref.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: GnssroRef
     obsdatain:
-      obsfile: InDBDir/gnssro_obs_2018041500.nc4
+      obsfile: InDBDir/gnssro_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_gnssroref.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_gnssroref.h5
     simulated variables: [refractivity]
   obs operator:
     name: GnssroRef

--- a/config/ObsPlugs/hofx/satwind.yaml
+++ b/config/ObsPlugs/hofx/satwind.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: Satwind
     obsdatain:
-      obsfile: InDBDir/satwind_obs_2018041500.nc4
+      obsfile: InDBDir/satwind_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_satwind.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_satwind.h5
     simulated variables: [eastward_wind, northward_wind]
   obs operator:
     name: VertInterp

--- a/config/ObsPlugs/hofx/satwind.yaml
+++ b/config/ObsPlugs/hofx/satwind.yaml
@@ -2,8 +2,10 @@
     name: Satwind
     obsdatain:
       obsfile: InDBDir/satwind_obs_2018041500.h5
+      max frame size: 80000
     obsdataout:
       obsfile: OutDBDir/obsPrefix_AppType_satwind.h5
+      max frame size: 80000
     simulated variables: [eastward_wind, northward_wind]
   obs operator:
     name: VertInterp

--- a/config/ObsPlugs/hofx/sfcp.yaml
+++ b/config/ObsPlugs/hofx/sfcp.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: SfcPCorrected
     obsdatain:
-      obsfile: InDBDir/sfc_obs_2018041500.nc4
+      obsfile: InDBDir/sfc_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_sfc.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_sfc.h5
     simulated variables: [surface_pressure]
   obs operator:
     name: SfcPCorrected

--- a/config/ObsPlugs/hofx/sondes-2018043006.yaml
+++ b/config/ObsPlugs/hofx/sondes-2018043006.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: Radiosonde
     obsdatain:
-      obsfile: InDBDir/sondes_obs_2018041500.nc4
+      obsfile: InDBDir/sondes_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_sondes.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_sondes.h5
     simulated variables: [air_temperature, virtual_temperature, eastward_wind, northward_wind]
   obs operator:
     name: VertInterp

--- a/config/ObsPlugs/hofx/sondes-2018043006.yaml
+++ b/config/ObsPlugs/hofx/sondes-2018043006.yaml
@@ -12,5 +12,13 @@
   obs filters:
   - filter: PreQC
     maxvalue: 3
+# avoids large ObsError values polluting plots of ObsError
+  - filter: Bounds Check
+    filter variables:
+    - name: specific_humidity
+    test variables:
+    - name: specific_humidity@ObsErrorData
+    minvalue: 0.0
+    maxvalue: 1.0
   get values:
     interpolation type: InterpolationType

--- a/config/ObsPlugs/hofx/sondes-2018043006.yaml
+++ b/config/ObsPlugs/hofx/sondes-2018043006.yaml
@@ -12,13 +12,5 @@
   obs filters:
   - filter: PreQC
     maxvalue: 3
-# avoids large ObsError values polluting plots of ObsError
-  - filter: Bounds Check
-    filter variables:
-    - name: specific_humidity
-    test variables:
-    - name: specific_humidity@ObsErrorData
-    minvalue: 0.0
-    maxvalue: 1.0
   get values:
     interpolation type: InterpolationType

--- a/config/ObsPlugs/hofx/sondes.yaml
+++ b/config/ObsPlugs/hofx/sondes.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: Radiosonde
     obsdatain:
-      obsfile: InDBDir/sondes_obs_2018041500.nc4
+      obsfile: InDBDir/sondes_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_AppType_sondes.nc4
+      obsfile: OutDBDir/obsPrefix_AppType_sondes.h5
     simulated variables: [air_temperature, virtual_temperature, eastward_wind, northward_wind, specific_humidity]
   obs operator:
     name: VertInterp

--- a/config/ObsPlugs/hofx/sondes.yaml
+++ b/config/ObsPlugs/hofx/sondes.yaml
@@ -12,6 +12,7 @@
   obs filters:
   - filter: PreQC
     maxvalue: 3
+# avoids large ObsError values polluting plots of ObsError
   - filter: Bounds Check
     filter variables:
     - name: specific_humidity

--- a/config/ObsPlugs/variational/aircraft.yaml
+++ b/config/ObsPlugs/variational/aircraft.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: Aircraft
     obsdatain:
-      obsfile: InDBDir/aircraft_obs_2018041500.nc4
+      obsfile: InDBDir/aircraft_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_aircraft.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_aircraft.h5
     simulated variables: [air_temperature, eastward_wind, northward_wind, specific_humidity]
     obs perturbations seed: MemberSeed
   obs operator:

--- a/config/ObsPlugs/variational/aircraft.yaml
+++ b/config/ObsPlugs/variational/aircraft.yaml
@@ -2,8 +2,10 @@
     name: Aircraft
     obsdatain:
       obsfile: InDBDir/aircraft_obs_2018041500.h5
+      max frame size: 40000
     obsdataout:
       obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_aircraft.h5
+      max frame size: 40000
     simulated variables: [air_temperature, eastward_wind, northward_wind, specific_humidity]
     obs perturbations seed: MemberSeed
   obs operator:

--- a/config/ObsPlugs/variational/allabi15X15.yaml
+++ b/config/ObsPlugs/variational/allabi15X15.yaml
@@ -81,9 +81,9 @@
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.h5
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/variational/allabi15X15.yaml
+++ b/config/ObsPlugs/variational/allabi15X15.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: abi_g16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_2018041500.nc4
+      obsfile: InDBDir/abi_g16_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_abi_g16.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_abi_g16.h5
     simulated variables: [brightness_temperature]
     channels: &abi_channels 8-10
 #    channels: &abi_channels 8-10,13-16
@@ -81,9 +81,9 @@
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.h5
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.nc4
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/variational/allabi59X59.yaml
+++ b/config/ObsPlugs/variational/allabi59X59.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: abi_g16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_2018041500.nc4
+      obsfile: InDBDir/abi_g16_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_abi_g16.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_abi_g16.h5
     simulated variables: [brightness_temperature]
     channels: &abi_channels 8-10
 #    channels: &abi_channels 8-10,13-16
@@ -95,9 +95,9 @@
 #      name: assign error
 #      error parameter: 1000.0
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.h5
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.nc4
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/variational/allabi59X59.yaml
+++ b/config/ObsPlugs/variational/allabi59X59.yaml
@@ -95,9 +95,9 @@
 #      name: assign error
 #      error parameter: 1000.0
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.h5
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/variational/allahi101X101.yaml
+++ b/config/ObsPlugs/variational/allahi101X101.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: ahi_himawari8
     obsdatain:
-      obsfile: InDBDir/ahi_himawari8_obs_2018041500.nc4
+      obsfile: InDBDir/ahi_himawari8_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_ahi_himawari8.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_ahi_himawari8.h5
     simulated variables: [brightness_temperature]
     channels: &ahi_channels 8-10
     obs perturbations seed: MemberSeed
@@ -65,9 +65,9 @@
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.h5
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.nc4
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *ahi_channels

--- a/config/ObsPlugs/variational/allahi101X101.yaml
+++ b/config/ObsPlugs/variational/allahi101X101.yaml
@@ -65,9 +65,9 @@
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.nc4
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.h5
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *ahi_channels

--- a/config/ObsPlugs/variational/allahi15X15.yaml
+++ b/config/ObsPlugs/variational/allahi15X15.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: ahi_himawari8
     obsdatain:
-      obsfile: InDBDir/ahi_himawari8_obs_2018041500.nc4
+      obsfile: InDBDir/ahi_himawari8_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_ahi_himawari8.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_ahi_himawari8.h5
     simulated variables: [brightness_temperature]
     channels: &ahi_channels 8-10
     obs perturbations seed: MemberSeed
@@ -65,9 +65,9 @@
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.h5
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.nc4
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *ahi_channels

--- a/config/ObsPlugs/variational/allahi15X15.yaml
+++ b/config/ObsPlugs/variational/allahi15X15.yaml
@@ -65,9 +65,9 @@
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.nc4
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.h5
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *ahi_channels

--- a/config/ObsPlugs/variational/cldamsua.yaml
+++ b/config/ObsPlugs/variational/cldamsua.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: amsua_n19
     obsdatain:
-      obsfile: InDBDir/amsua_n19_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n19_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n19_cld.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n19_cld.h5
     simulated variables: [brightness_temperature]
     channels: 1-5,15
     obs perturbations seed: MemberSeed
@@ -16,7 +16,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n19_cld.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n19_cld.h5
   obs operator: &cldamsuacrtm
     name: CRTM
     SurfaceWindGeoVars: uv
@@ -34,9 +34,9 @@
 - obs space:
     name: amsua_n15
     obsdatain:
-      obsfile: InDBDir/amsua_n15_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n15_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n15_cld.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n15_cld.h5
     simulated variables: [brightness_temperature]
     channels: 1-5,15
     obs perturbations seed: MemberSeed
@@ -49,7 +49,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n15_cld.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n15_cld.h5
   obs operator:
     <<: *cldamsuacrtm
     obs options:
@@ -60,9 +60,9 @@
 - obs space:
     name: amsua_n18
     obsdatain:
-      obsfile: InDBDir/amsua_n18_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n18_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n18_cld.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n18_cld.h5
     simulated variables: [brightness_temperature]
     channels: 1-5,15
     obs perturbations seed: MemberSeed
@@ -75,7 +75,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n18_cld.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n18_cld.h5
   obs operator:
     <<: *cldamsuacrtm
     obs options:
@@ -86,9 +86,9 @@
 - obs space:
     name: amsua_metop-a
     obsdatain:
-      obsfile: InDBDir/amsua_metop-a_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_metop-a_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_metop-a_cld.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_metop-a_cld.h5
     simulated variables: [brightness_temperature]
     channels: 1-5,15
     obs perturbations seed: MemberSeed
@@ -101,7 +101,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-a_cld.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-a_cld.h5
   obs operator:
     <<: *cldamsuacrtm
     obs options:
@@ -112,9 +112,9 @@
 - obs space:
     name: amsua_metop-b
     obsdatain:
-      obsfile: InDBDir/amsua_metop-b_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_metop-b_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_metop-b_cld.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_metop-b_cld.h5
     simulated variables: [brightness_temperature]
     channels: 1-5,15
     obs perturbations seed: MemberSeed
@@ -127,7 +127,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-b_cld.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-b_cld.h5
   obs operator:
     <<: *cldamsuacrtm
     obs options:
@@ -138,9 +138,9 @@
 - obs space:
     name: amsua_aqua
     obsdatain:
-      obsfile: InDBDir/amsua_aqua_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_aqua_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_aqua_cld.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_aqua_cld.h5
     simulated variables: [brightness_temperature]
     channels: 1-5,15
     obs perturbations seed: MemberSeed
@@ -153,7 +153,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_aqua_cld.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_aqua_cld.h5
   obs operator:
     <<: *cldamsuacrtm
     obs options:

--- a/config/ObsPlugs/variational/cldamsua.yaml
+++ b/config/ObsPlugs/variational/cldamsua.yaml
@@ -16,7 +16,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n19_cld.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n19_cld.nc4
   obs operator: &cldamsuacrtm
     name: CRTM
     SurfaceWindGeoVars: uv
@@ -49,7 +49,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n15_cld.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n15_cld.nc4
   obs operator:
     <<: *cldamsuacrtm
     obs options:
@@ -75,7 +75,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n18_cld.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n18_cld.nc4
   obs operator:
     <<: *cldamsuacrtm
     obs options:
@@ -101,7 +101,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-a_cld.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-a_cld.nc4
   obs operator:
     <<: *cldamsuacrtm
     obs options:
@@ -127,7 +127,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-b_cld.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-b_cld.nc4
   obs operator:
     <<: *cldamsuacrtm
     obs options:
@@ -153,7 +153,7 @@
     threshold: 3
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_aqua_cld.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_aqua_cld.nc4
   obs operator:
     <<: *cldamsuacrtm
     obs options:

--- a/config/ObsPlugs/variational/clrabi.yaml
+++ b/config/ObsPlugs/variational/clrabi.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: abi-clr_g16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_2018041500.nc4
+      obsfile: InDBDir/abi_g16_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_abi_g16.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_abi_g16.h5
     simulated variables: [brightness_temperature]
     channels: &clrabi_channels 8-10
     obs perturbations seed: MemberSeed
@@ -43,9 +43,9 @@
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.h5
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.nc4
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrabi_channels

--- a/config/ObsPlugs/variational/clrabi.yaml
+++ b/config/ObsPlugs/variational/clrabi.yaml
@@ -43,9 +43,9 @@
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_abi_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.h5
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_abi_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrabi_channels

--- a/config/ObsPlugs/variational/clrahi.yaml
+++ b/config/ObsPlugs/variational/clrahi.yaml
@@ -34,9 +34,9 @@
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.nc4
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.h5
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrahi_channels

--- a/config/ObsPlugs/variational/clrahi.yaml
+++ b/config/ObsPlugs/variational/clrahi.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: ahi-clr_himawari8
     obsdatain:
-      obsfile: InDBDir/ahi_himawari8_obs_2018041500.nc4
+      obsfile: InDBDir/ahi_himawari8_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_ahi_himawari8.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_ahi_himawari8.h5
     simulated variables: [brightness_temperature]
     channels: &clrahi_channels 7-16
     obs perturbations seed: MemberSeed
@@ -34,9 +34,9 @@
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_ahi_himawari8.h5
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.nc4
+    filename: OutDBDirOOPSMemberDir/diagPrefix_AppType_ahi_himawari8.h5
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrahi_channels

--- a/config/ObsPlugs/variational/clramsua.yaml
+++ b/config/ObsPlugs/variational/clramsua.yaml
@@ -21,7 +21,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n19.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n19.nc4
   obs operator: &clramsuacrtm
     name: CRTM
     SurfaceWindGeoVars: uv
@@ -57,7 +57,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n15.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n15.nc4
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -88,7 +88,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n18.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n18.nc4
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -119,7 +119,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-a.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-a.nc4
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -150,7 +150,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
 #  - filter: GOMsaver
-#    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-b.h5
+#    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-b.nc4
 #  obs operator:
 #    <<: *clramsuacrtm
 #    obs options:
@@ -181,7 +181,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_aqua.h5
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_aqua.nc4
   obs operator:
     <<: *clramsuacrtm
     obs options:

--- a/config/ObsPlugs/variational/clramsua.yaml
+++ b/config/ObsPlugs/variational/clramsua.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: amsua_n19
     obsdatain:
-      obsfile: InDBDir/amsua_n19_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n19_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n19.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n19.h5
     simulated variables: [brightness_temperature]
     channels: 5-7,9
     obs perturbations seed: MemberSeed
@@ -21,7 +21,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n19.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n19.h5
   obs operator: &clramsuacrtm
     name: CRTM
     SurfaceWindGeoVars: uv
@@ -37,9 +37,9 @@
 - obs space:
     name: amsua_n15
     obsdatain:
-      obsfile: InDBDir/amsua_n15_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n15_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n15.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n15.h5
     simulated variables: [brightness_temperature]
     channels: 5-9
     obs perturbations seed: MemberSeed
@@ -57,7 +57,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n15.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n15.h5
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -68,9 +68,9 @@
 - obs space:
     name: amsua_n18
     obsdatain:
-      obsfile: InDBDir/amsua_n18_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_n18_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n18.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_n18.h5
     simulated variables: [brightness_temperature]
     channels: 5-9
     obs perturbations seed: MemberSeed
@@ -88,7 +88,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n18.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_n18.h5
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -99,9 +99,9 @@
 - obs space:
     name: amsua_metop-a
     obsdatain:
-      obsfile: InDBDir/amsua_metop-a_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_metop-a_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_metop-a.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_metop-a.h5
     simulated variables: [brightness_temperature]
     channels: 5,6,9
     obs perturbations seed: MemberSeed
@@ -119,7 +119,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-a.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-a.h5
   obs operator:
     <<: *clramsuacrtm
     obs options:
@@ -130,9 +130,9 @@
 #- obs space:
 #    name: amsua_metop-b
 #    obsdatain:
-#      obsfile: InDBDir/amsua_metop-b_obs_2018041500.nc4
+#      obsfile: InDBDir/amsua_metop-b_obs_2018041500.h5
 #    obsdataout:
-#      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_metop-b.nc4
+#      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_metop-b.h5
 #    simulated variables: [brightness_temperature]
 #    channels: 8,9
 #    obs perturbations seed: MemberSeed
@@ -150,7 +150,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
 #  - filter: GOMsaver
-#    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-b.nc4
+#    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_metop-b.h5
 #  obs operator:
 #    <<: *clramsuacrtm
 #    obs options:
@@ -161,9 +161,9 @@
 - obs space:
     name: amsua_aqua
     obsdatain:
-      obsfile: InDBDir/amsua_aqua_obs_2018041500.nc4
+      obsfile: InDBDir/amsua_aqua_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_aqua.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_amsua_aqua.h5
     simulated variables: [brightness_temperature]
     channels: 8,9
     obs perturbations seed: MemberSeed
@@ -181,7 +181,7 @@
 #  - filter: Gaussian_Thinning
 #    horizontal_mesh: RADTHINDISTANCE #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_aqua.nc4
+    filename: OutDBDirOOPSMemberDir/geoPrefix_AppType_amsua_aqua.h5
   obs operator:
     <<: *clramsuacrtm
     obs options:

--- a/config/ObsPlugs/variational/gnssroref.yaml
+++ b/config/ObsPlugs/variational/gnssroref.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: GnssroRef
     obsdatain:
-      obsfile: InDBDir/gnssro_obs_2018041500.nc4
+      obsfile: InDBDir/gnssro_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_gnssroref.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_gnssroref.h5
     simulated variables: [refractivity]
     obs perturbations seed: MemberSeed
   obs operator:

--- a/config/ObsPlugs/variational/satwind.yaml
+++ b/config/ObsPlugs/variational/satwind.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: Satwind
     obsdatain:
-      obsfile: InDBDir/satwind_obs_2018041500.nc4
+      obsfile: InDBDir/satwind_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_satwind.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_satwind.h5
     simulated variables: [eastward_wind, northward_wind]
     obs perturbations seed: MemberSeed
   obs operator:

--- a/config/ObsPlugs/variational/satwind.yaml
+++ b/config/ObsPlugs/variational/satwind.yaml
@@ -2,8 +2,10 @@
     name: Satwind
     obsdatain:
       obsfile: InDBDir/satwind_obs_2018041500.h5
+      max frame size: 80000
     obsdataout:
       obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_satwind.h5
+      max frame size: 80000
     simulated variables: [eastward_wind, northward_wind]
     obs perturbations seed: MemberSeed
   obs operator:

--- a/config/ObsPlugs/variational/satwind.yaml
+++ b/config/ObsPlugs/variational/satwind.yaml
@@ -18,6 +18,15 @@
   - filter: Background Check
     threshold: 3.0
     apply at iterations: 0, 1
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    test variables:
+    - name: eastward_wind@ObsErrorData
+    - name: northward_wind@ObsErrorData
+    minvalue: 0.0
+    maxvalue: 200.0
 #  - filter: Thinning
 #    amount: RADTHINAMOUNT
 #    random_seed: 0

--- a/config/ObsPlugs/variational/sfcp.yaml
+++ b/config/ObsPlugs/variational/sfcp.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: SfcPCorrected
     obsdatain:
-      obsfile: InDBDir/sfc_obs_2018041500.nc4
+      obsfile: InDBDir/sfc_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_sfc.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_sfc.h5
     simulated variables: [surface_pressure]
     obs perturbations seed: MemberSeed
   obs operator:

--- a/config/ObsPlugs/variational/sondes-2018043006.yaml
+++ b/config/ObsPlugs/variational/sondes-2018043006.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: Radiosonde
     obsdatain:
-      obsfile: InDBDir/sondes_obs_2018041500.nc4
+      obsfile: InDBDir/sondes_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_sondes.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_sondes.h5
     simulated variables: [air_temperature, virtual_temperature, eastward_wind, northward_wind]
     obs perturbations seed: MemberSeed
   obs operator:

--- a/config/ObsPlugs/variational/sondes-2018043006.yaml
+++ b/config/ObsPlugs/variational/sondes-2018043006.yaml
@@ -16,13 +16,5 @@
   - filter: Background Check
     threshold: 3.0
     apply at iterations: 0, 1
-# avoids large ObsError values polluting plots of ObsError
-  - filter: Bounds Check
-    filter variables:
-    - name: specific_humidity
-    test variables:
-    - name: specific_humidity@ObsErrorData
-    minvalue: 0.0
-    maxvalue: 1.0
   get values:
     interpolation type: InterpolationType

--- a/config/ObsPlugs/variational/sondes-2018043006.yaml
+++ b/config/ObsPlugs/variational/sondes-2018043006.yaml
@@ -16,5 +16,13 @@
   - filter: Background Check
     threshold: 3.0
     apply at iterations: 0, 1
+# avoids large ObsError values polluting plots of ObsError
+  - filter: Bounds Check
+    filter variables:
+    - name: specific_humidity
+    test variables:
+    - name: specific_humidity@ObsErrorData
+    minvalue: 0.0
+    maxvalue: 1.0
   get values:
     interpolation type: InterpolationType

--- a/config/ObsPlugs/variational/sondes.yaml
+++ b/config/ObsPlugs/variational/sondes.yaml
@@ -16,5 +16,13 @@
   - filter: Background Check
     threshold: 3.0
     apply at iterations: 0, 1
+# avoids large ObsError values polluting plots of ObsError
+  - filter: Bounds Check
+    filter variables:
+    - name: specific_humidity
+    test variables:
+    - name: specific_humidity@ObsErrorData
+    minvalue: 0.0
+    maxvalue: 1.0
   get values:
     interpolation type: InterpolationType

--- a/config/ObsPlugs/variational/sondes.yaml
+++ b/config/ObsPlugs/variational/sondes.yaml
@@ -1,9 +1,9 @@
 - obs space:
     name: Radiosonde
     obsdatain:
-      obsfile: InDBDir/sondes_obs_2018041500.nc4
+      obsfile: InDBDir/sondes_obs_2018041500.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_sondes.nc4
+      obsfile: OutDBDirOOPSMemberDir/obsPrefix_AppType_sondes.h5
     simulated variables: [air_temperature, virtual_temperature, eastward_wind, northward_wind, specific_humidity]
     obs perturbations seed: MemberSeed
   obs operator:

--- a/config/builds.csh
+++ b/config/builds.csh
@@ -15,7 +15,7 @@ setenv BuildCompiler 'gnu-openmpi'
 # Note: at this time, all executables should be built in the same environment, one that is
 # consistent with config/environment.csh
 
-set commonBuild = /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_feature--ioda-v2
+set commonBuild = /glade/scratch/guerrett/mpasbundletest/mpas-bundle_gnu-openmpi_01JUN2021
 
 # MPAS-JEDI
 # ---------

--- a/config/builds.csh
+++ b/config/builds.csh
@@ -15,7 +15,7 @@ setenv BuildCompiler 'gnu-openmpi'
 # Note: at this time, all executables should be built in the same environment, one that is
 # consistent with config/environment.csh
 
-set commonBuild = /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_30APR2021
+set commonBuild = /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_feature--ioda-v2
 
 # MPAS-JEDI
 # ---------

--- a/config/builds.csh
+++ b/config/builds.csh
@@ -15,7 +15,7 @@ setenv BuildCompiler 'gnu-openmpi'
 # Note: at this time, all executables should be built in the same environment, one that is
 # consistent with config/environment.csh
 
-set commonBuild = /glade/scratch/guerrett/mpasbundletest/mpas-bundle_gnu-openmpi_01JUN2021
+set commonBuild = /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_bugfix--out-nchans
 
 # MPAS-JEDI
 # ---------

--- a/config/experiment.csh
+++ b/config/experiment.csh
@@ -36,7 +36,7 @@ set benchmarkObsList = (sondes aircraft satwind gnssroref sfcp clramsua)
 
 ## ExpSuffix
 # a unique suffix to distinguish this experiment from others
-set ExpSuffix = '_ioda-v2'
+set ExpSuffix = ''
 
 ##############
 ## DA settings
@@ -110,8 +110,7 @@ set ahi = ahi$AHISuperOb[$hofxIndex]
 #TODO: separate amsua and mhs config for each instrument_satellite combo
 
 #TODO: upgrade abi and ahi data
-#set hofxObsList = ($benchmarkObsList cldamsua allmhs all$abi all$ahi)
-set hofxObsList = ($benchmarkObsList cldamsua allmhs)
+set hofxObsList = ($benchmarkObsList cldamsua allmhs all$abi all$ahi)
 
 
 #GEFS reference case (override above settings)

--- a/config/experiment.csh
+++ b/config/experiment.csh
@@ -36,7 +36,7 @@ set benchmarkObsList = (sondes aircraft satwind gnssroref sfcp clramsua)
 
 ## ExpSuffix
 # a unique suffix to distinguish this experiment from others
-set ExpSuffix = ''
+set ExpSuffix = '_ioda-v2'
 
 ##############
 ## DA settings
@@ -109,7 +109,9 @@ set ahi = ahi$AHISuperOb[$hofxIndex]
 # OPTIONS: $benchmarkObsList, cldamsua, allmhs, clr$abi, all$abi, clr$ahi, all$ahi
 #TODO: separate amsua and mhs config for each instrument_satellite combo
 
-set hofxObsList = ($benchmarkObsList cldamsua allmhs all$abi all$ahi)
+#TODO: upgrade abi and ahi data
+#set hofxObsList = ($benchmarkObsList cldamsua allmhs all$abi all$ahi)
+set hofxObsList = ($benchmarkObsList cldamsua allmhs)
 
 
 #GEFS reference case (override above settings)

--- a/config/mpas/O30kmIE120km/job.csh
+++ b/config/mpas/O30kmIE120km/job.csh
@@ -20,7 +20,11 @@ setenv HofXNodes 32
 setenv HofXPEPerNode 16
 setenv HofXMemory 109
 
-setenv VerifyObsJobMinutes 5
+set DeterministicVerifyObsJobMinutes = 5
+set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
+set EnsembleVerifyObsEnsMeanMembersPerJobMinute = 10
+@ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} / ${EnsembleVerifyObsEnsMeanMembersPerJobMinute}
+@ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
 setenv VerifyObsNodes 1
 setenv VerifyObsPEPerNode 36
 

--- a/config/mpas/OIE120km/job.csh
+++ b/config/mpas/OIE120km/job.csh
@@ -19,7 +19,11 @@ setenv HofXNodes 1
 setenv HofXPEPerNode 36
 setenv HofXMemory 109
 
-setenv VerifyObsJobMinutes 5
+set DeterministicVerifyObsJobMinutes = 5
+set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
+set EnsembleVerifyObsEnsMeanMembersPerJobMinute = 10
+@ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} / ${EnsembleVerifyObsEnsMeanMembersPerJobMinute}
+@ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
 setenv VerifyObsNodes 1
 setenv VerifyObsPEPerNode 36
 

--- a/config/mpas/OIE120km/job.csh
+++ b/config/mpas/OIE120km/job.csh
@@ -24,7 +24,7 @@ setenv HofXNodes 2
 setenv HofXPEPerNode 18
 setenv HofXMemory 109
 
-setenv VerifyObsJobMinutes 7
+setenv VerifyObsJobMinutes 5
 setenv VerifyObsNodes 1
 setenv VerifyObsPEPerNode 36
 

--- a/config/mpas/OIE120km/job.csh
+++ b/config/mpas/OIE120km/job.csh
@@ -14,12 +14,17 @@ setenv CyclingFCPEPerNode 32
 setenv ExtendedFCNodes ${CyclingFCNodes}
 setenv ExtendedFCPEPerNode ${CyclingFCPEPerNode}
 
-setenv HofXJobMinutes 10
-setenv HofXNodes 1
-setenv HofXPEPerNode 36
+setenv HofXJobMinutes 20
+
+#IODA-v2 crashes/times out on 1 node, not memory limited
+#try again after timing bug fix in ioda?
+#setenv HofXNodes 1
+#setenv HofXPEPerNode 36
+setenv HofXNodes 2
+setenv HofXPEPerNode 18
 setenv HofXMemory 109
 
-setenv VerifyObsJobMinutes 5
+setenv VerifyObsJobMinutes 7
 setenv VerifyObsNodes 1
 setenv VerifyObsPEPerNode 36
 
@@ -28,12 +33,12 @@ setenv VerifyModelNodes 1
 setenv VerifyModelPEPerNode 36
 
 
-set DeterministicDAJobMinutes = 5
+set DeterministicDAJobMinutes = 10
 set EnsembleDAMembersPerJobMinute = 5
 @ CyclingDAJobMinutes = ${nEnsDAMembers} / ${EnsembleDAMembersPerJobMinute}
 @ CyclingDAJobMinutes = ${CyclingDAJobMinutes} + ${DeterministicDAJobMinutes}
 setenv CyclingDAMemory 45
-#setenv CyclingDAMemory 109
+setenv CyclingDAMemory 109
 if ( "$DAType" =~ *"eda"* ) then
   setenv CyclingDANodesPerMember 2
   setenv CyclingDAPEPerNode      18

--- a/config/mpas/OIE120km/job.csh
+++ b/config/mpas/OIE120km/job.csh
@@ -14,14 +14,9 @@ setenv CyclingFCPEPerNode 32
 setenv ExtendedFCNodes ${CyclingFCNodes}
 setenv ExtendedFCPEPerNode ${CyclingFCPEPerNode}
 
-setenv HofXJobMinutes 20
-
-#IODA-v2 crashes/times out on 1 node, not memory limited
-#try again after timing bug fix in ioda?
-#setenv HofXNodes 1
-#setenv HofXPEPerNode 36
-setenv HofXNodes 2
-setenv HofXPEPerNode 18
+setenv HofXJobMinutes 10
+setenv HofXNodes 1
+setenv HofXPEPerNode 36
 setenv HofXMemory 109
 
 setenv VerifyObsJobMinutes 5
@@ -33,12 +28,12 @@ setenv VerifyModelNodes 1
 setenv VerifyModelPEPerNode 36
 
 
-set DeterministicDAJobMinutes = 10
+set DeterministicDAJobMinutes = 5
 set EnsembleDAMembersPerJobMinute = 5
 @ CyclingDAJobMinutes = ${nEnsDAMembers} / ${EnsembleDAMembersPerJobMinute}
 @ CyclingDAJobMinutes = ${CyclingDAJobMinutes} + ${DeterministicDAJobMinutes}
 setenv CyclingDAMemory 45
-setenv CyclingDAMemory 109
+#setenv CyclingDAMemory 109
 if ( "$DAType" =~ *"eda"* ) then
   setenv CyclingDANodesPerMember 2
   setenv CyclingDAPEPerNode      18

--- a/config/mpas/OIE30km/job.csh
+++ b/config/mpas/OIE30km/job.csh
@@ -19,7 +19,11 @@ setenv HofXNodes 32
 setenv HofXPEPerNode 16
 setenv HofXMemory 109
 
-setenv VerifyObsJobMinutes 5
+set DeterministicVerifyObsJobMinutes = 5
+set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
+set EnsembleVerifyObsEnsMeanMembersPerJobMinute = 10
+@ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} / ${EnsembleVerifyObsEnsMeanMembersPerJobMinute}
+@ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
 setenv VerifyObsNodes 1
 setenv VerifyObsPEPerNode 36
 

--- a/config/obsdata.csh
+++ b/config/obsdata.csh
@@ -40,10 +40,10 @@ foreach application (${applicationIndex})
     ${basePolarMWObsDir} \
   )
 end
-set PolarMWObsDir[$variationalIndex] = $PolarMWObsDir[$variationalIndex]$PolarMWBiasCorrect
+set PolarMWObsDir[$variationalIndex] = $PolarMWObsDir[$variationalIndex]/$PolarMWBiasCorrect
 
 # no bias correction for hofx
-set PolarMWObsDir[$hofxIndex] = $PolarMWObsDir[$hofxIndex]$PolarMWNoBias
+set PolarMWObsDir[$hofxIndex] = $PolarMWObsDir[$hofxIndex]/$PolarMWNoBias
 
 ## Geostationary IR (abi, ahi)
 # bias correction

--- a/config/obsdata.csh
+++ b/config/obsdata.csh
@@ -65,7 +65,7 @@ foreach obs ($variationalObsList)
 end
 
 # abi directories
-set ABITopObsDir = /glade/work/guerrett/pandac/obs/ABIASR
+set ABITopObsDir = /glade/work/guerrett/pandac/obs/ABIASR/ioda-v2
 set baseABIObsDir = ${ABITopObsDir}/IODANC_THIN15KM_SUPEROB
 set ABIObsDir = ()
 foreach SuperOb ($ABISuperOb)
@@ -79,7 +79,7 @@ set ABIObsDir[$variationalIndex] = $ABIObsDir[$variationalIndex]$ABIBiasCorrect
 set ABIObsDir[$hofxIndex] = $ABIObsDir[$hofxIndex]$GEOIRNoBias
 
 # ahi directories
-set AHITopObsDir = /glade/work/guerrett/pandac/obs/AHIASR
+set AHITopObsDir = /glade/work/guerrett/pandac/obs/AHIASR/ioda-v2
 set baseAHIObsDir = ${AHITopObsDir}/IODANC_SUPEROB
 #Note: AHI is linked from /glade/work/wuyl/pandac/work/fix_input/AHI_OBS
 set AHIObsDir = ()

--- a/config/obsdata.csh
+++ b/config/obsdata.csh
@@ -24,7 +24,7 @@ setenv INITIAL_VARBC_TABLE ${FixedInput}/satbias/satbias_crtm_in
 ##########################
 
 ## Conventional instruments
-setenv ConventionalObsDir /glade/scratch/jban/pandac/newobs_2018/conv_obs
+setenv ConventionalObsDir /glade/p/mmm/parc/liuz/pandac_common/ioda_obs_v2/2018/conv_obs
 
 ## Polar MW (amsua, mhs)
 # bias correction
@@ -33,7 +33,7 @@ set PolarMWGSIBC = bias_corr
 setenv PolarMWBiasCorrect $PolarMWGSIBC
 
 # directories
-set basePolarMWObsDir = /glade/scratch/jban/pandac/newobs_2018/
+set basePolarMWObsDir = /glade/p/mmm/parc/liuz/pandac_common/ioda_obs_v2/2018
 set PolarMWObsDir = ()
 foreach application (${applicationIndex})
   set PolarMWObsDir = ($PolarMWObsDir \

--- a/config/obsdata.csh
+++ b/config/obsdata.csh
@@ -23,11 +23,8 @@ setenv INITIAL_VARBC_TABLE ${FixedInput}/satbias/satbias_crtm_in
 # Cycle-dependent Datasets
 ##########################
 
-set ObsUser = guerrett
-set TopObsDir = /glade/work/${ObsUser}/pandac/obs
-
 ## Conventional instruments
-setenv ConventionalObsDir ${TopObsDir}/conv
+setenv ConventionalObsDir /glade/scratch/jban/pandac/newobs_2018/conv_obs
 
 ## Polar MW (amsua, mhs)
 # bias correction
@@ -36,7 +33,7 @@ set PolarMWGSIBC = bias_corr
 setenv PolarMWBiasCorrect $PolarMWGSIBC
 
 # directories
-set basePolarMWObsDir = /glade/p/mmm/parc/vahl/gsi_ioda/
+set basePolarMWObsDir = /glade/scratch/jban/pandac/newobs_2018/
 set PolarMWObsDir = ()
 foreach application (${applicationIndex})
   set PolarMWObsDir = ($PolarMWObsDir \
@@ -68,7 +65,8 @@ foreach obs ($variationalObsList)
 end
 
 # abi directories
-set baseABIObsDir = ${TopObsDir}/ABIASR/IODANC_THIN15KM_SUPEROB
+set ABITopObsDir = /glade/work/guerrett/pandac/obs/ABIASR
+set baseABIObsDir = ${ABITopObsDir}/IODANC_THIN15KM_SUPEROB
 set ABIObsDir = ()
 foreach SuperOb ($ABISuperOb)
   set ABIObsDir = ($ABIObsDir \
@@ -81,7 +79,8 @@ set ABIObsDir[$variationalIndex] = $ABIObsDir[$variationalIndex]$ABIBiasCorrect
 set ABIObsDir[$hofxIndex] = $ABIObsDir[$hofxIndex]$GEOIRNoBias
 
 # ahi directories
-set baseAHIObsDir = ${TopObsDir}/AHIASR/IODANC_SUPEROB
+set AHITopObsDir = /glade/work/guerrett/pandac/obs/AHIASR
+set baseAHIObsDir = ${AHITopObsDir}/IODANC_SUPEROB
 #Note: AHI is linked from /glade/work/wuyl/pandac/work/fix_input/AHI_OBS
 set AHIObsDir = ()
 foreach SuperOb ($AHISuperOb)

--- a/config/verification.csh
+++ b/config/verification.csh
@@ -4,6 +4,6 @@
 ## Verification tools
 #####################
 #TODO: add these to the repo, possibly under a verification directory
-set commonVerificationDir = /glade/work/guerrett/pandac/fixed_input/graphics_obs+model_ioda-v2
+set commonVerificationDir = /glade/work/guerrett/pandac/fixed_input/graphics_obs+model
 setenv pyObsDir ${commonVerificationDir}
 setenv pyModelDir ${commonVerificationDir}

--- a/config/verification.csh
+++ b/config/verification.csh
@@ -4,6 +4,6 @@
 ## Verification tools
 #####################
 #TODO: add these to the repo, possibly under a verification directory
-set commonVerificationDir = /glade/work/guerrett/pandac/fixed_input/graphics_obs+model
+set commonVerificationDir = /glade/work/guerrett/pandac/fixed_input/graphics_obs+model_ioda-v2
 setenv pyObsDir ${commonVerificationDir}
 setenv pyModelDir ${commonVerificationDir}

--- a/drive.csh
+++ b/drive.csh
@@ -32,6 +32,7 @@ set CriticalPathType = Normal
 
 ## VerifyDeterministicDA: whether to run verification scripts for
 #    obs feedback files from DA.  Does not work for ensemble DA.
+#    Only works when CriticalPathType == Normal.
 # OPTIONS: True/False
 set VerifyDeterministicDA = True
 
@@ -145,7 +146,7 @@ cat >! suite.rc << EOF
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingFC" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingFC:succeed-all => CyclingFCFinished" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingDAFinished" %}
-{% else %}
+{% elif CriticalPathType == "Normal" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingFCFinished[-PT${CyclingWindowHR}H]" %}
   {% if (ABEInflation and nEnsDAMembers > 1) %}
     {% set PrimaryCPGraph = PrimaryCPGraph + " => MeanBackground" %}
@@ -161,6 +162,8 @@ cat >! suite.rc << EOF
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingDAFinished => CyclingFC" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingFC:succeed-all => CyclingFCFinished" %}
   {% set SecondaryCPGraph = SecondaryCPGraph + "\\n        CyclingDAFinished => CleanCyclingDA" %}
+{# else #}
+#TODO: indicate invalid CriticalPathType
 {% endif %}
 # verification and extended forecast controls
 {% set ExtendedFCLengths = range(0, ${ExtendedFCWindowHR}+${ExtendedFC_DT_HR}, ${ExtendedFC_DT_HR}) %}
@@ -186,7 +189,7 @@ cat >! suite.rc << EOF
       graph = '''{{PrimaryCPGraph}}{{SecondaryCPGraph}}
       '''
 ## Many kinds of verification
-{% if VerifyDeterministicDA and nEnsDAMembers < 2 %}
+{% if CriticalPathType == "Normal" and VerifyDeterministicDA and nEnsDAMembers < 2 %}
 #TODO: enable VerifyObsDA to handle more than one ensemble member
 #      and use feedback files from EDA for VerifyEnsMeanBG
 ## Verification of deterministic DA with observations (BG+AN together)

--- a/drive.csh
+++ b/drive.csh
@@ -516,6 +516,8 @@ cat >! suite.rc << EOF
     inherit = VerifyObsBase
 {% if DiagnoseEnsSpreadBG %}
     script = \$origin/VerifyObsEnsMeanBG.csh "1" "0" "BG" "{{nEnsDAMembers}}"
+    [[[job]]]
+      execution time limit = PT${VerifyObsEnsMeanJobMinutes}M
 {% else %}
     script = \$origin/VerifyObsEnsMeanBG.csh "1" "0" "BG" "0"
 {% endif %}

--- a/jediPrep.csh
+++ b/jediPrep.csh
@@ -186,24 +186,24 @@ end
 
 # Link conventional data
 # ======================
-ln -sfv $ConventionalObsDir/${thisValidDate}/aircraft_obs*.nc4 ${InDBDir}/
-ln -sfv $ConventionalObsDir/${thisValidDate}/gnssro_obs*.nc4 ${InDBDir}/
-ln -sfv $ConventionalObsDir/${thisValidDate}/satwind_obs*.nc4 ${InDBDir}/
-ln -sfv $ConventionalObsDir/${thisValidDate}/sfc_obs*.nc4 ${InDBDir}/
-ln -sfv $ConventionalObsDir/${thisValidDate}/sondes_obs*.nc4 ${InDBDir}/
+ln -sfv $ConventionalObsDir/${thisValidDate}/aircraft_obs*.h5 ${InDBDir}/
+ln -sfv $ConventionalObsDir/${thisValidDate}/gnssro_obs*.h5 ${InDBDir}/
+ln -sfv $ConventionalObsDir/${thisValidDate}/satwind_obs*.h5 ${InDBDir}/
+ln -sfv $ConventionalObsDir/${thisValidDate}/sfc_obs*.h5 ${InDBDir}/
+ln -sfv $ConventionalObsDir/${thisValidDate}/sondes_obs*.h5 ${InDBDir}/
 
 # Link AMSUA+MHS data
 # ==============
-ln -sfv $PolarMWObsDir[$myAppIndex]/${thisValidDate}/amsua*_obs_*.nc4 ${InDBDir}/
-ln -sfv $PolarMWObsDir[$myAppIndex]/${thisValidDate}/mhs*_obs_*.nc4 ${InDBDir}/
+ln -sfv $PolarMWObsDir[$myAppIndex]/${thisValidDate}/amsua*_obs_*.h5 ${InDBDir}/
+ln -sfv $PolarMWObsDir[$myAppIndex]/${thisValidDate}/mhs*_obs_*.h5 ${InDBDir}/
 
 # Link ABI data
 # ============
-ln -sfv $ABIObsDir[$myAppIndex]/${thisValidDate}/abi*_obs_*.nc4 ${InDBDir}/
+ln -sfv $ABIObsDir[$myAppIndex]/${thisValidDate}/abi*_obs_*.h5 ${InDBDir}/
 
 # Link AHI data
 # ============
-ln -sfv $AHIObsDir[$myAppIndex]/${thisValidDate}/ahi*_obs_*.nc4 ${InDBDir}/
+ln -sfv $AHIObsDir[$myAppIndex]/${thisValidDate}/ahi*_obs_*.h5 ${InDBDir}/
 
 
 # Link VarBC prior
@@ -241,11 +241,11 @@ foreach obs ($self_ObsList)
   # check that obs string matches at least one non-broken observation file link
   foreach inst ($checkForMissingObs)
     if ( "$obs" =~ *"${inst}"* ) then
-      find ${InDBDir}/${inst}*_obs_*.nc4 -mindepth 0 -maxdepth 0
+      find ${InDBDir}/${inst}*_obs_*.h5 -mindepth 0 -maxdepth 0
       if ($? > 0) then
         @ missing++
       else
-        set brokenLinks=( `find ${InDBDir}/${inst}*_obs_*.nc4 -mindepth 0 -maxdepth 0 -type l -exec test ! -e {} \; -print` )
+        set brokenLinks=( `find ${InDBDir}/${inst}*_obs_*.h5 -mindepth 0 -maxdepth 0 -type l -exec test ! -e {} \; -print` )
         foreach link ($brokenLinks)
           @ missing++
         end


### PR DESCRIPTION
This PR gives the same functionality with ioda-v2 as was available for ioda-v1.

The main changes are updates to the observation data directories in `config/obsdata.csh`, for which @junmeiban performed the upgrade.  The ObsSpace file types (as opposed to geovals or ydiags) now have an h5 extension, which affects all `config/ObsPlugs` yaml stubs, `jediPrep.csh`, and `clean-*.csh` scripts.

The default build in `config/builds.csh` is set to a bugfix build that includes changes in [IODA#304](https://github.com/JCSDA-internal/ioda/pull/304).  That bugfix is needed for ABI and AHI data for observation-space verification.

A new QC filter is added to `config/ObsPlugs/variational/sondes.yaml` to filter out `specific_humidity` observations with non-realistic ObsErrorData values:
```yaml
# avoids large ObsError values polluting plots of ObsError
  - filter: Bounds Check
    filter variables:
    - name: specific_humidity
    test variables:
    - name: specific_humidity@ObsErrorData
    minvalue: 0.0
    maxvalue: 1.0
```
A similar filter is added to `config/ObsPlugs/variational/satwind.yaml`.  These are useful to avoid including very large values of ObsError when generating diagnostic plots.  There are some ObsError values above 10^8, presumably to allow monitoring of those locations while still providing a good PreQC flag from GSI.