### PR TITLE
Add missing linkage of geovars.yaml for RTPP application

### DIFF
--- a/RTPPInflation.csh
+++ b/RTPPInflation.csh
@@ -91,6 +91,11 @@ sed -i 's@nCells@'${MPASnCellsEnsemble}'@' $NamelistFile
 sed -i 's@modelDT@'${MPASTimeStep}'@' $NamelistFile
 sed -i 's@diffusionLengthScale@'${MPASDiffusionLengthScale}'@' $NamelistFile
 
+## MPASJEDI variable configs
+foreach file ($MPASJEDIVariablesFiles)
+  ln -sfv ${ModelConfigDir}/${file} .
+end
+
 # =============
 # Generate yaml
 # =============


### PR DESCRIPTION
Previously the geovars.yaml file became a requirement for all mpas-jedi applications.  I was not using the the RTPP application for some time, because the LeaveOneOut approach for EDA was sufficient.  Now I need to run some RTPP situations for producing new figures, and found that geovars.yaml is never linked into the inflation application work directory.  Here the linking step is added.