### PR TITLE
New environment and build associated with that environment

### DIFF
--- a/config/builds.csh
+++ b/config/builds.csh
@@ -15,7 +15,7 @@ setenv BuildCompiler 'gnu-openmpi'
 # Note: at this time, all executables should be built in the same environment, one that is
 # consistent with config/environment.csh
 
-set commonBuild = /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_bugfix--out-nchans
+set commonBuild = /glade/scratch/guerrett/mpasbundletest/mpas-bundle_gnu-openmpi_12AUG2021
 
 # MPAS-JEDI
 # ---------

--- a/config/environment.csh
+++ b/config/environment.csh
@@ -7,10 +7,9 @@ source config/builds.csh
 #######################
 
 source /etc/profile.d/modules.csh
-setenv OPT /glade/work/miesch/modules
-module use $OPT/modulefiles/core
-
+setenv OPT /glade/work/jedipara/cheyenne/opt/modules
 module purge
+module use $OPT/modulefiles/core
 module load jedi/${BuildCompiler}
 
 ## CustomPIO

--- a/drive.csh
+++ b/drive.csh
@@ -175,7 +175,10 @@ cat >! suite.rc << EOF
 [scheduling]
   # Maximum number of simultaneous active dates;
   # useful for constraining non-blocking flows
-  max active cycle points = 40
+  # and to avoid over-utilization of login nodes
+  # hint: execute 'ps aux | grep $USER' to check your login node overhead
+  # default: 3
+  max active cycle points = 4
   initial cycle point = {{initialCyclePoint}}
   final cycle point   = {{finalCyclePoint}}
   [[dependencies]]


### PR DESCRIPTION
Introduces the new environment setup from https://github.com/JCSDA-internal/mpas-bundle/pull/106.

`config/environment.csh` in develop will not work with new builds.  This new environment is not backward compatible with old code versions.  Anybody using an old code version will need to use the old environment.

Also `drive.csh` is modified to limit the maximum number of active cycle points.  When many cycle points are active in complex workflows (i.e., eda_3denvar or "CriticalPathType==Bypass"), MPAS-Workflow consumes large quantities of login node resources.  This change reduces the maximum to 4 active cycle points (date-time combinations).