### PR TITLE
Updated localization matrix and build version

### DIFF
--- a/config/applicationBase/3denvar.yaml
+++ b/config/applicationBase/3denvar.yaml
@@ -49,8 +49,7 @@ cost function:
         datadir: bumpLocDir
         prefix: bumpLocPrefix
         strategy: common
-        load_nicas: 1
-        mpicom: 2
+        load_nicas_local: 1
     variables: *incvars
     members:
 EnsemblePbMembers

--- a/config/applicationBase/eda_3denvar.yaml
+++ b/config/applicationBase/eda_3denvar.yaml
@@ -49,8 +49,7 @@ cost function:
         datadir: bumpLocDir
         prefix: bumpLocPrefix
         strategy: common
-        load_nicas: 1
-        mpicom: 2
+        load_nicas_local: 1
     variables: *incvars
     members:
 EnsemblePbMembers

--- a/config/builds.csh
+++ b/config/builds.csh
@@ -15,7 +15,7 @@ setenv BuildCompiler 'gnu-openmpi'
 # Note: at this time, all executables should be built in the same environment, one that is
 # consistent with config/environment.csh
 
-set commonBuild = /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_bugfix--out-nchans
+set commonBuild = /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_feature--static_b
 
 # MPAS-JEDI
 # ---------

--- a/config/environment.csh
+++ b/config/environment.csh
@@ -7,10 +7,9 @@ source config/builds.csh
 #######################
 
 source /etc/profile.d/modules.csh
-setenv OPT /glade/work/miesch/modules
-module use $OPT/modulefiles/core
-
+setenv OPT /glade/work/jedipara/cheyenne/opt/modules
 module purge
+module use $OPT/modulefiles/core
 module load jedi/${BuildCompiler}
 
 ## CustomPIO

--- a/config/mpas/O30kmIE120km/mesh.csh
+++ b/config/mpas/O30kmIE120km/mesh.csh
@@ -16,5 +16,5 @@ setenv RADTHINAMOUNT      "0.75"
 ## Background Error
 # Last updated 08 Feb 2021
 # works for 36pe/128pe and 120km domain
-setenv bumpLocDir /glade/scratch/bjung/x_bumploc_20210208
+setenv bumpLocDir /glade/scratch/bjung/x_bumploc_20210811
 setenv bumpLocPrefix bumploc_2000_5

--- a/config/mpas/O30kmIE120km/mesh.csh
+++ b/config/mpas/O30kmIE120km/mesh.csh
@@ -16,5 +16,5 @@ setenv RADTHINAMOUNT      "0.75"
 ## Background Error
 # Last updated 08 Feb 2021
 # works for 36pe/128pe and 120km domain
-setenv bumpLocDir /glade/scratch/bjung/x_bumploc_20210811
+setenv bumpLocDir /glade/p/mmm/parc/bjung/pandac_common/bumploc/20210811
 setenv bumpLocPrefix bumploc_2000_5

--- a/config/mpas/OIE120km/mesh.csh
+++ b/config/mpas/OIE120km/mesh.csh
@@ -16,5 +16,5 @@ setenv RADTHINAMOUNT       "0.98"
 ## Background Error
 # Last updated 08 Feb 2021
 # works for 36pe/128pe and 120km domain
-setenv bumpLocDir /glade/scratch/bjung/x_bumploc_20210208
+setenv bumpLocDir /glade/scratch/bjung/x_bumploc_20210811
 setenv bumpLocPrefix bumploc_2000_5

--- a/config/mpas/OIE120km/mesh.csh
+++ b/config/mpas/OIE120km/mesh.csh
@@ -16,5 +16,5 @@ setenv RADTHINAMOUNT       "0.98"
 ## Background Error
 # Last updated 08 Feb 2021
 # works for 36pe/128pe and 120km domain
-setenv bumpLocDir /glade/scratch/bjung/x_bumploc_20210811
+setenv bumpLocDir /glade/p/mmm/parc/bjung/pandac_common/bumploc/20210811
 setenv bumpLocPrefix bumploc_2000_5


### PR DESCRIPTION
Updates needed to use the workflow with the BUMP changes corresponding to https://github.com/JCSDA-internal/mpas-jedi/pull/596.