### PR TITLE
Fix clean tasks

### DIFF
--- a/clean-hofx.csh
+++ b/clean-hofx.csh
@@ -37,6 +37,7 @@ endif
 # =================
 source config/experiment.csh
 source config/filestructure.csh
+source config/tools.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}

--- a/drive.csh
+++ b/drive.csh
@@ -334,7 +334,11 @@ cat >! suite.rc << EOF
       -l = select=1:ncpus=36:mpiprocs=36
   [[CleanBase]]
     [[[job]]]
-      batch system = background
+      execution time limit = PT5M
+    [[[directives]]]
+      -q = share
+      -A = ${VFAccountNumber}
+      -l = select=1:ncpus=1
 #Cycling components
   [[CyclingDA]]
     env-script = cd ${mainScriptDir}; ./jediPrepCyclingDA.csh "1" "0" "DA"

--- a/drive.csh
+++ b/drive.csh
@@ -141,7 +141,7 @@ cat >! suite.rc << EOF
 {% elif CriticalPathType == "Reanalysis" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingDA => CyclingDAFinished" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingFCFinished" %}
-  {% set SecondaryCPGraph = SecondaryCPGraph + "\\n        CyclingDAFinished => CleanCyclingDA" %}
+  {% set SecondaryCPGraph = SecondaryCPGraph + "\\n        CyclingDA => CleanCyclingDA" %}
 {% elif CriticalPathType == "Reforecast" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingFC" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingFC:succeed-all => CyclingFCFinished" %}
@@ -161,7 +161,7 @@ cat >! suite.rc << EOF
   {% set PrimaryCPGraph = PrimaryCPGraph + " => CyclingDAFinished" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingDAFinished => CyclingFC" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingFC:succeed-all => CyclingFCFinished" %}
-  {% set SecondaryCPGraph = SecondaryCPGraph + "\\n        CyclingDAFinished => CleanCyclingDA" %}
+  {% set SecondaryCPGraph = SecondaryCPGraph + "\\n        CyclingDA => CleanCyclingDA" %}
 {# else #}
 #TODO: indicate invalid CriticalPathType
 {% endif %}

--- a/hofx.csh
+++ b/hofx.csh
@@ -99,7 +99,7 @@ rm ${anFile}
 
 set copyDiags = 0
 foreach var ({$MPASJEDIDiagVariables})
-  ncdump -h ${bgFileOther} | grep -q $var
+  ncdump -h ${bgFileOther} | grep $var
   if ( $status != 0 ) then
     @ copyDiags++
     echo "Copying MPASJEDIDiagVariables to background state"

--- a/variational.csh
+++ b/variational.csh
@@ -76,7 +76,7 @@ while ( $member <= ${nEnsDAMembers} )
   # ======================================================
   set copyDiags = 0
   foreach var ({$MPASJEDIDiagVariables})
-    ncdump -h ${bgFileOther} | grep -q $var
+    ncdump -h ${bgFileOther} | grep $var
     if ( $status != 0 ) then
       @ copyDiags++
       echo "Copying MPASJEDIDiagVariables to background state"


### PR DESCRIPTION
`Clean*` tasks were previously run in the background on the same node as where `drive.csh` is executed.  That causes lagging when deleting large numbers of files simultaneously, i.e., when cleaning up from verification of large numbers of ensemble members simultaneously.

Rightfully, that makes HPC managers very unhappy, and can result in being kicked off when drive.csh is run from a login node.  Now those cleaning tasks are submitted to single processors on the `share` queue.

Also there was a missing `source config/tools.csh` in `clean-hofx.csh`, and a `-q` flag to grep was causing background files to be duplicated unnecessarily. Those are fixed.