### PR TITLE
Delete zeroth forecast and diag files

### DIFF
--- a/SetupWorkflow.csh
+++ b/SetupWorkflow.csh
@@ -107,6 +107,7 @@ sed -e 's@WorkDirsTEMPLATE@CyclingFCDirs@' \
     -e 's@StateDirsTEMPLATE@CyclingDAOutDirs@' \
     -e 's@fcLengthHRTEMPLATE@'${CyclingWindowHR}'@' \
     -e 's@fcIntervalHRTEMPLATE@'${CyclingWindowHR}'@' \
+    -e 's@deleteZerothForecastTEMPLATE@True@' \
     forecast.csh > ${JobScript}
 chmod 744 ${JobScript}
 
@@ -118,6 +119,7 @@ sed -e 's@WorkDirsTEMPLATE@ExtendedMeanFCDirs@' \
     -e 's@StateDirsTEMPLATE@MeanAnalysisDirs@' \
     -e 's@fcLengthHRTEMPLATE@'${ExtendedFCWindowHR}'@' \
     -e 's@fcIntervalHRTEMPLATE@'${ExtendedFC_DT_HR}'@' \
+    -e 's@deleteZerothForecastTEMPLATE@False@' \
     forecast.csh > ${JobScript}
 chmod 744 ${JobScript}
 
@@ -129,6 +131,7 @@ sed -e 's@WorkDirsTEMPLATE@ExtendedEnsFCDirs@' \
     -e 's@StateDirsTEMPLATE@CyclingDAOutDirs@' \
     -e 's@fcLengthHRTEMPLATE@'${ExtendedFCWindowHR}'@' \
     -e 's@fcIntervalHRTEMPLATE@'${ExtendedFC_DT_HR}'@' \
+    -e 's@deleteZerothForecastTEMPLATE@False@' \
     forecast.csh > ${JobScript}
 chmod 744 ${JobScript}
 

--- a/forecast.csh
+++ b/forecast.csh
@@ -171,6 +171,8 @@ if ( "$deleteZerothForecast" == "True" ) then
   set fcFileExt = ${fcFileDate}.nc
   set fcFile = ${FCFilePrefix}.${fcFileExt}
   rm ${fcFile}
+  set diagFile = ${DIAGFilePrefix}.${fcFileExt}
+  rm ${diagFile}
 endif
 
 # Update/add fields to output for DA

--- a/forecast.csh
+++ b/forecast.csh
@@ -48,6 +48,7 @@ set self_fcLengthHR = fcLengthHRTEMPLATE
 set self_fcIntervalHR = fcIntervalHRTEMPLATE
 set config_run_duration = 0_${self_fcLengthHR}:00:00
 set output_interval = 0_${self_fcIntervalHR}:00:00
+set deleteZerothForecast = deleteZerothForecastTEMPLATE
 
 # static variables
 set self_icStatePrefix = ${ANFilePrefix}
@@ -158,6 +159,19 @@ else
   ln -sfv ${memberStaticFieldsFile} ${localStaticFieldsFile}
 endif
 
+if ( "$deleteZerothForecast" == "True" ) then
+  # Optionally remove initial forecast file
+  # =======================================
+  set fcDate = ${thisValidDate}
+  set yy = `echo ${fcDate} | cut -c 1-4`
+  set mm = `echo ${fcDate} | cut -c 5-6`
+  set dd = `echo ${fcDate} | cut -c 7-8`
+  set hh = `echo ${fcDate} | cut -c 9-10`
+  set fcFileDate  = ${yy}-${mm}-${dd}_${hh}.00.00
+  set fcFileExt = ${fcFileDate}.nc
+  set fcFile = ${FCFilePrefix}.${fcFileExt}
+  rm ${fcFile}
+endif
 
 # Update/add fields to output for DA
 # ==================================


### PR DESCRIPTION
The zero duration forecast and diagnostics files from the MPAS-Atmosphere integration are not presently used in cycling.  They account for roughly half the disk space in the CyclingFC directory, which is substantial as the number of ensemble members grows.  This PR removes those unneeded files.

The zero duration forecast files from extended forecasts are used for 0-hr (analysis state) verification, and so cannot be deleted.  However, they account for relatively less disk space.