### PR TITLE
Add InitCyclingDA task, update README

### DIFF
--- a/README
+++ b/README
@@ -15,15 +15,17 @@ cd /fresh/path/for/submitting/experiments
 
 module load git
 
-git clone https://https://github.com/jjguerrette/MPAS-Workflow
+git clone https://github.com/NCAR/MPAS-Workflow
 
 modify configuration files as needed
 
-source env-setup/cheyenne
+source env-setup/cheyenne.csh
+OR
+source env-setup/cheyenne.sh
 
 ./drive.csh
 
-# It is required to set the work/run directories in ~/.cylc/global.rc as follows:
+# It is required to set the work/run directories in $HOME/.cylc/global.rc as follows:
 [hosts]
     [[localhost]]
         work directory = /glade/scratch/USERNAME/cylc-run
@@ -32,24 +34,30 @@ source env-setup/cheyenne
             [[[[pbs]]]]
                 job name length maximum = 236
 
-# It is recommended to also set 'job name length maximum'
+# It is recommended to also set 'job name length maximum' to a large value
 
+
+# Configuration Files (config/)
+-------------------------------
+
+The files in this directory describe the configuration for the entire workflow.  Some files are
+designed to be modified by users, and others only by developers.
 
 ## top-level configuration (config/*.csh)
 -----------------------------------------
 
 appindex.csh: controls re-usable templating for variational and hofx applications
 
-builds.csh: compiled code build directories
+builds.csh: describes the build directories for critical applications
 
 modeldata.csh: static model-space data file structure, including mesh-specific partition files,
 fixed ensemble forecast members for deterministic experiments, first guess files for the first cycle
 of an experiment, surface variable update files (sst and xice), and common static.nc file(s) to be
 used across all cycles.
 
-environment.csh: common executable run-time environment
+environment.csh: run-time environment used across compiled executables and python scripts
 
-experiment.csh: controls for independent experiments
+experiment.csh: primary control knobs for individualizing experiments
 
 filestructure.csh: workflow file structure
 
@@ -59,26 +67,34 @@ obsdata.csh: static observation-space data file structure
 
 tools.csh: initializes python tools for workflow task management
 
-verification.csh: post-processing and verification tool settings
+verification.csh: post-processing and verification script descriptions
 
 
-## MPAS-specific configuration
-------------------------------
-variables.csh: model/analysis variables relevant to the workflow
+## MPAS-specific configuration (config/mpas/)
+---------------------------------------------
+mpas/variables.csh: model/analysis variables used to generate YAML files for MPAS-JEDI applications
 
-$MPASGridDescriptor/mesh.csh: workflow-relevant mesh-related options
+mpas/$MPASGridDescriptor/mesh.csh: mesh-specific options that affect the workflow and application
+  behaviors
 
-$MPASGridDescriptor/job.csh: job durations and processor usages
+mpas/$MPASGridDescriptor/job.csh: job durations and processor usages
+
+In the above, MPASGridDescriptor describes the meshes that are used in the variational application. 
+See config/experiment.csh for more information.
 
 
 ## main driver: drive.csh
 -------------------------
-creates a new cylc suite, then runs it. There are options at the top of this file for begin/end
+Creates a new cylc suite file, then runs it. There are options at the top of this file for begin/end
 dates and various kinds of workflows with and without verification. The CriticalPathType determines
-whether the verification is performed concurrently, and depending on the critical path (Normal), or
-as a post-processing diagnostic step (Bypass). The Reanalysis or Reforecast settings are useful for
-running verification on existing sets of background or initial condition states, respectively.
-
+whether the verification is performed concurrently with and depends on the critical path (Normal),
+or as an independent post-processing diagnostic step (Bypass). The Reanalysis and Reforecast
+CriticalPathType's are two variations of "partial cycling", where the current cycle does not depend
+on the previous cycle. Reanalysis is used to perform the CyclingDA task on each cycle without
+re-running forecasts.  This requires the CyclingFC output files to already be present in the
+experiment directory, which might be added manually outside of the workflow.  Reforecast is used to
+perform forecasts from an existing set of analysis states, which are stored in the CyclingDA
+directory.  
 
 ## templated workflow components
 --------------------------------
@@ -91,11 +107,11 @@ Templated w.r.t. the application type (e.g., variational, hofx) and application 
 3denvar).
 
 variational.csh: used to generate CyclingDA.csh, which executes the mpasjedi_variational and
-mpasjedi_eda applications.  Templated w.r.t. the background state prefix and directory. Presently
-only reads output states from a CyclingFC task, as coded in SetupWorkflow.csh.
+mpasjedi_eda applications.  Templated w.r.t. the background state prefix and directory. Reads output
+states from a CyclingFC task, as coded in SetupWorkflow.csh.
 
-clean-variational.csh: used to generate CleanCyclingDA.csh, which cleans CyclingDA directories in
-order to reduce experiment disk resource requirements.
+clean-variational.csh: used to generate CleanCyclingDA.csh, which cleans CyclingDA working
+directories in order to reduce experiment disk resource requirements.
 
 forecast.csh: used to generate all forecast scripts, e.g., CyclingFC.csh and ExtendedMeanFC.csh,
 which perform mpas_atmosphere forecasts across a templated time range with state output at a
@@ -103,16 +119,18 @@ templated interval. Presently only takes analyses as initial conditions, which h
 ANFilePrefix and are produced by either CyclingDA or RTPPInflation.  self_icStatePrefix could be
 templated in order enable forecasts from other kinds of states, like cold-start files.
 
-hofx.csh: used to generate all HofX* (observation-minus-model) scripts, e.g., HofXBG.csh,
-HofXMeanFC.csh, HofXEnsMeanBG.csh, which run the mpasjedi_hofx_nomodel application. Templated w.r.t.
-the input state directory and prefix, allowing it to read any "da_state"-compatible model state.
+hofx.csh: used to generate all HofX* scripts, e.g., HofXBG.csh, HofXMeanFC.csh, HofXEnsMeanBG.csh,
+which run the mpasjedi_hofx3d application. Templated w.r.t. the input state directory and prefix,
+allowing it to read any forecast state written through the "da_state" stream.
 
-clean-hofx.csh: used to generate CleanHofX*.csh scripts, which clean HofX* directories
+clean-hofx.csh: used to generate CleanHofX*.csh scripts, which clean HofX* working directories
 in order to reduce experiment disk resource requirements.
 
-verifyobs.csh: used to generate scripts that verify observation-database output from hofx jobs.
+verifyobs.csh: used to generate scripts that verify observation-database output from HofX* and
+CyclingDA tasks.
 
-verifymodel.csh: used to generate scripts that verify model states with respect to GFS analyses.
+verifymodel.csh: used to generate scripts that verify model forecast states with respect to GFS
+analyses.
 
 
 ## non-templated workflow components
@@ -123,16 +141,16 @@ MeanBackground.csh: calculates the mean of ensemble background states
 
 MeanAnalysis.csh: calculates the mean of ensemble analysis states
 
-RTPPInflation.csh: performs Relaxation To Prior Perturbation (RTPP) inflation
-for an ensemble of analysis states.
+RTPPInflation.csh: performs Relaxation To Prior Perturbation (RTPP) inflation, taking as input two
+ensembles, one each of background states and analysis states.
 
-GenerateABEInflation.csh: generates Adaptiave Background Error Inflation (ABEI) factors, based on
-all-sky IR brightness temperature H(x_mean) and H_clear(x_mean).
+GenerateABEInflation.csh: generates Adaptiave Background Error Inflation (ABEI) factors based on
+all-sky IR brightness temperature H(x_mean) and H_clear(x_mean) from GOES-16 ABI and Himawari-8 AHI.
 
 
 ## MPAS-JEDI application configuration files
 --------------------------------------------
-config/applicationBase/*.yaml: MPAS-JEDI application-specific templates
+config/applicationBase/*.yaml: MPAS-JEDI application-specific YAML templates
 
 config/ObsPlugs/variational/*.yaml: observation yaml stubs that get plugged into all variational
 applications, e.g., 3denvar and eda_3denvar

--- a/README
+++ b/README
@@ -5,8 +5,8 @@ MPAS-Workflow
 A tool for cycling forecast and data assimilation experiments with the MPAS-Atmosphere model and the
 MPAS-JEDI data assimilation package.
 
-## starting a cycling experiment on the Cheyenne HPC
-----------------------------------------------------
+# starting a cycling experiment on the Cheyenne HPC
+---------------------------------------------------
 login to Cheyenne
 
 mkdir -p /fresh/path/for/submitting/experiments
@@ -41,7 +41,7 @@ source env-setup/cheyenne.sh
 -------------------------------
 
 The files in this directory describe the configuration for the entire workflow.  Some files are
-designed to be modified by users, and others only by developers.
+designed to be modified by users, and others mostly by developers.
 
 ## top-level configuration (config/*.csh)
 -----------------------------------------
@@ -117,7 +117,7 @@ forecast.csh: used to generate all forecast scripts, e.g., CyclingFC.csh and Ext
 which perform mpas_atmosphere forecasts across a templated time range with state output at a
 templated interval. Presently only takes analyses as initial conditions, which have the
 ANFilePrefix and are produced by either CyclingDA or RTPPInflation.  self_icStatePrefix could be
-templated in order enable forecasts from other kinds of states, like cold-start files.
+templated in order to enable forecasts from other kinds of states, like cold-start files.
 
 hofx.csh: used to generate all HofX* scripts, e.g., HofXBG.csh, HofXMeanFC.csh, HofXEnsMeanBG.csh,
 which run the mpasjedi_hofx3d application. Templated w.r.t. the input state directory and prefix,
@@ -144,7 +144,7 @@ MeanAnalysis.csh: calculates the mean of ensemble analysis states
 RTPPInflation.csh: performs Relaxation To Prior Perturbation (RTPP) inflation, taking as input two
 ensembles, one each of background states and analysis states.
 
-GenerateABEInflation.csh: generates Adaptiave Background Error Inflation (ABEI) factors based on
+GenerateABEInflation.csh: generates Adaptive Background Error Inflation (ABEI) factors based on
 all-sky IR brightness temperature H(x_mean) and H_clear(x_mean) from GOES-16 ABI and Himawari-8 AHI.
 
 

--- a/config/experiment.csh
+++ b/config/experiment.csh
@@ -100,7 +100,7 @@ setenv storeOriginalRTPPAnalyses False
 ## ABEIInflation, whether to utilize adaptive background error inflation (ABEI) in cloud-affected scenes
 #  as measured by ABI and AHI observations
 # OPTIONS: True/False
-setenv ABEInflation True
+setenv ABEInflation False
 
 ## ABEIChannel
 # OPTIONS: 8, 9, 10


### PR DESCRIPTION
Creates a new `InitCyclingDA` cylc task that allows the yaml sed substitution to be carried out in the share queue instead of on the many nodes/processors reserved for EDA applications.  Saves significant compute resources.

The README is updated also.

Partially addresses #20 