### PR TITLE
Enable multiple EDA instances

### DIFF
--- a/PrepVariational.csh
+++ b/PrepVariational.csh
@@ -121,8 +121,8 @@ set prevYAML = $thisYAML
 
 # Minimization algorithm configuration element
 # ================================================
-# performs sed substitution for MinimizerAlgorithm
-set algorithmsed = MinimizerAlgorithm
+# performs sed substitution for VariationalMinimizer
+set algorithmsed = VariationalMinimizer
 set thisSEDF = ${algorithmsed}SEDF.yaml
 cat >! ${thisSEDF} << EOF
 /${algorithmsed}/c\

--- a/PrepVariational.csh
+++ b/PrepVariational.csh
@@ -78,7 +78,7 @@ rm prevPrep.yaml
 mv $appyaml prevPrep.yaml
 set prevYAML = prevPrep.yaml
 
-# Add outer iterations configuration elements
+# Outer iterations configuration elements
 # ===========================================
 # performs sed substitution for VariationalIterations
 set iterationssed = VariationalIterations
@@ -118,6 +118,35 @@ sed -f ${thisSEDF} $prevYAML >! $thisYAML
 rm ${thisSEDF}
 set prevYAML = $thisYAML
 
+
+# Minimization algorithm configuration element
+# ================================================
+# performs sed substitution for MinimizerAlgorithm
+set algorithmsed = MinimizerAlgorithm
+set thisSEDF = ${algorithmsed}SEDF.yaml
+cat >! ${thisSEDF} << EOF
+/${algorithmsed}/c\
+EOF
+
+set nAlgorithmIndent = 4
+set indent = "`${nSpaces} $nAlgorithmIndent`"
+if ($MinimizerAlgorithm == $BlockEDA) then
+cat >>! ${thisSEDF} << EOF
+${indent}algorithm: $MinimizerAlgorithm\
+${indent}members: $EDASize
+EOF
+
+else
+cat >>! ${thisSEDF} << EOF
+${indent}algorithm: $MinimizerAlgorithm
+EOF
+
+endif
+
+set thisYAML = insertAlgorithm.yaml
+sed -f ${thisSEDF} $prevYAML >! $thisYAML
+rm ${thisSEDF}
+set prevYAML = $thisYAML
 
 
 # Ensemble Jb components

--- a/Variational.csh
+++ b/Variational.csh
@@ -1,7 +1,8 @@
 #!/bin/csh -f
 
-# Carry out variational minimization for
-# single first guess state
+# Carry out variational minimization for single first guess state
+# ARGUMENTS:
+# ArgMember - member index among nEnsDAMembers
 
 date
 
@@ -9,7 +10,6 @@ date
 # =================
 ## args
 # ArgMember: int, ensemble member [>= 1]
-# note: not currently used, but will be for independent EDA members
 set ArgMember = "$1"
 
 ## arg checks
@@ -26,6 +26,7 @@ endif
 
 # Setup environment
 # =================
+source config/experiment.csh
 source config/builds.csh
 source config/environment.csh
 source config/mpas/variables.csh
@@ -45,6 +46,11 @@ cd ${self_WorkDir}
 set myBuildDir = ${VariationalBuildDir}
 set myEXE = ${VariationalEXE}
 set myYAML = ${self_WorkDir}/variational_${ArgMember}.yaml
+
+if ( $ArgMember > $nEnsDAMembers ) then
+  echo "ERROR in $0 : ArgMember ($ArgMember) must be <= nEnsDAMembers ($nEnsDAMembers)" > ./FAIL
+  exit 1
+endif
 
 # ================================================================================================
 

--- a/config/applicationBase/3denvar.yaml
+++ b/config/applicationBase/3denvar.yaml
@@ -22,7 +22,7 @@ output:
   stream name: analysis
 variational:
   minimizer:
-MinimizerAlgorithm
+VariationalMinimizer
   iterations:
 VariationalIterations
 final:

--- a/config/applicationBase/3denvar.yaml
+++ b/config/applicationBase/3denvar.yaml
@@ -6,6 +6,13 @@ iteration: &iterationConfig
     interpolation type: unstructured
   gradient norm reduction: 1e-3
   obs perturbations: ObsPerturbations
+  #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
+#  online diagnostics:
+#    tlm taylor test: true
+#    tlm approx test: true
+#    adj tlm test: true
+#    adj obs test: true
+#    online adj test: true
 member: &memberConfig
   date: &analysisDate '2018-04-15T00:00:00Z'
   state variables: &incvars [AnalysisVariables]
@@ -15,7 +22,7 @@ output:
   stream name: analysis
 variational:
   minimizer:
-    algorithm: DRIPCG
+MinimizerAlgorithm
   iterations:
 VariationalIterations
 final:

--- a/config/applicationBase/3dvarId.yaml
+++ b/config/applicationBase/3dvarId.yaml
@@ -11,7 +11,7 @@ output:
   stream name: analysis
 variational:
   minimizer:
-    algorithm: DRIPCG
+VariationalMinimizer
   iterations:
 VariationalIterations
 final:

--- a/config/filestructure.csh
+++ b/config/filestructure.csh
@@ -57,6 +57,7 @@ setenv ConfigDir ${mainScriptDir}/config
 ## directory string formatter for EDA members
 # third argument to memberDir.py
 setenv flowMemFmt "/mem{:03d}"
+setenv flowInstFmt "/instance{:03d}"
 setenv flowMemFileFmt "_{:03d}"
 
 ## appyaml: universal yaml file name for all jedi applications

--- a/config/mpas/O30kmIE120km/job.csh
+++ b/config/mpas/O30kmIE120km/job.csh
@@ -61,7 +61,7 @@ set EnsembleDAMembersPerJobMinute = 6
 setenv EnsOfVariationalMemory 109
 setenv EnsOfVariationalNodesPerMember 3
 setenv EnsOfVariationalPEPerNode      12
-@ EnsOfVariationalNodes = ${EnsOfVariationalNodesPerMember} * ${nEnsDAMembers}
+@ EnsOfVariationalNodes = ${EnsOfVariationalNodesPerMember} * ${EDASize}
 setenv EnsOfVariationalNodes ${EnsOfVariationalNodes}
 
 # inflation, e.g., RTPP


### PR DESCRIPTION
With this PR, the EDA members are configured using `EDASize` and `nDAInstances` instead of `nEnsDAMembers`, which is the product of those two new settings.  When `EDASize == 1` (default), an ensemble of independent Variational applications is conducted just as before.  When `EDASize > 1`, multiple instances of the EnsembleOfVariational application are initiated, each with `EDASize` members.

Users now have the option to configure the minimization algorithm in config/experiment.csh as well.  Although one could use `DRPBlockLanczos` (block EDA) for each of the EDA instances, so far that algorithm is not working for our 120km benchmark experiment.  Full testing/investigation remains for future work.

Closes #33 