### PR TITLE
Use default ncar_pylib to avoid verification errors

### DIFF
--- a/GenerateABEInflation.csh
+++ b/GenerateABEInflation.csh
@@ -100,7 +100,7 @@ while ( $success != 0 )
   set success = $?
 
   if ( $success != 0 ) then
-    source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib.csh
+    source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib.csh default
     sleep 3
   endif
 end

--- a/config/builds.csh
+++ b/config/builds.csh
@@ -1,7 +1,5 @@
 #!/bin/csh -f
 
-source config/experiment.csh
-
 #############################
 ## build directory structures
 #############################

--- a/config/environment.csh
+++ b/config/environment.csh
@@ -30,8 +30,8 @@ setenv GFORTRAN_CONVERT_UNIT 'big_endian:101-200'
 setenv F_UFMTENDIAN 'big:101-200'
 setenv OMP_NUM_THREADS 1
 
-module load python/3.7.5
-source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib.csh
+module load python
+source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib.csh default
 
 module load nccmp
 

--- a/env-setup/cheyenne.csh
+++ b/env-setup/cheyenne.csh
@@ -1,6 +1,6 @@
 source /etc/profile.d/modules.csh
-module load python/3.7.5
-source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib.csh
+module load python
+source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib.csh default
 module load cylc
 module load git
 git lfs install

--- a/env-setup/cheyenne.sh
+++ b/env-setup/cheyenne.sh
@@ -1,6 +1,6 @@
 source /etc/profile.d/modules.sh
-module load python/3.7.5
-source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib
+module load python
+source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib default
 module load cylc
 module load git
 git lfs install

--- a/verifymodel.csh
+++ b/verifymodel.csh
@@ -81,7 +81,7 @@ while ( $success != 0 )
   ${baseCommand} >& log.$mainScript
   set success = $?
   if ( $success != 0 ) then
-    source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib.csh
+    source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib.csh default
     sleep 3
   endif
 end

--- a/verifyobs.csh
+++ b/verifyobs.csh
@@ -75,11 +75,6 @@ set NUMPROC=`cat $PBS_NODEFILE | wc -l`
 set success = 1
 while ( $success != 0 )
 
-  if ( $success != 0 ) then
-    source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib.csh
-    sleep 3
-  endif
-
   mv log.${mainScript} log.${mainScript}_LAST
   setenv baseCommand "python ${mainScript}.py -n ${NUMPROC} -p ${self_WorkDir}/${OutDBDir} -o ${obsPrefix} -g ${geoPrefix} -d ${diagPrefix} -app $self_jediAppName -nout $self_nOuter"
 
@@ -90,9 +85,11 @@ while ( $success != 0 )
     echo "${baseCommand}"
     ${baseCommand} >& log.${mainScript}
   endif
-
   set success = $?
-
+  if ( $success != 0 ) then
+    source /glade/u/apps/ch/opt/usr/bin/npl/ncar_pylib.csh default
+    sleep 3
+  endif
 end
 cd -
 


### PR DESCRIPTION
Fixes bug reported by @ibanos90 in #38

When `ncar_pylib.csh` or `ncar_pylib` (bash) are sourced, they take any command-line arguments that are given to the parent scripts where the source occurs.

For example,


`script0.csh`:
```
./script1.csh arg1
```

`script1.csh`:
```
source ncar_pylib.csh
```

When `script0.csh` is executed,
```
./script0.csh
```
ncar_pylib.csh will receive the argument `arg1`.  The same is true through multiple layers of `source`.  The arguments to `ncar_pylib` have very specific meanings.  Here the solution is to always give `ncar_pylib` a single argument of `default`, which overrides the arguments given to the parent script.

This issue showed up recently, because CISL removed the previously default behavior of propagating the login environment to job scripts.  So the ncar_pylib environment on a login node no longer transfers to the job environment.  We could instead issue the -V PBS flag to `VerifyObs` and `VerifyModel` job scripts, which I have confirmed also works.  However, it is better to declare the entire environment needed for those tasks instead of depending on the user to set up the environment before submitting the cylc suite.