### PR TITLE
Enable forecast precision to be user-configurable

### DIFF
--- a/PrepJEDI.csh
+++ b/PrepJEDI.csh
@@ -154,6 +154,7 @@ foreach StreamsFile_ ($StreamsFileList)
   sed -i 's@nCells@'$MPASnCellsList[$iMesh]'@' ${StreamsFile_}
   sed -i 's@TemplateFieldsPrefix@'${self_WorkDir}'/'${TemplateFieldsPrefix}'@' ${StreamsFile_}
   sed -i 's@StaticFieldsPrefix@'${self_WorkDir}'/'${localStaticFieldsPrefix}'@' ${StreamsFile_}
+  sed -i 's@forecastPrecision@'${forecastPrecision}'@' ${StreamsFile_}
 end
 
 ## copy/modify dynamic namelist file

--- a/PrepJEDI.csh
+++ b/PrepJEDI.csh
@@ -54,6 +54,7 @@ source config/mpas/variables.csh
 source config/mpas/${MPASGridDescriptor}/mesh.csh
 source config/appindex.csh
 source config/builds.csh
+source config/environment.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}

--- a/RTPPInflation.csh
+++ b/RTPPInflation.csh
@@ -90,13 +90,14 @@ cp -v $self_ModelConfigDir/${StreamsFile} .
 sed -i 's@nCells@'${MPASnCellsEnsemble}'@' ${StreamsFile}
 sed -i 's@TemplateFieldsPrefix@'${self_WorkDir}'/'${TemplateFieldsPrefix}'@' ${StreamsFile}
 sed -i 's@StaticFieldsPrefix@'${self_WorkDir}'/'${localStaticFieldsPrefix}'@' ${StreamsFile}
+sed -i 's@forecastPrecision@'${forecastPrecision}'@' ${StreamsFile}
 
 # determine analysis output precision
 ncdump -h ${firstANFile} | grep uReconstruct | grep double
 if ($status == 0) then
   set analysisPrecision=double
 else
-  ncdump -h ${bgFile} | grep uReconstruct | grep float
+  ncdump -h ${firstANFile} | grep uReconstruct | grep float
   if ($status == 0) then
     set analysisPrecision=single
   else

--- a/config/experiment.csh
+++ b/config/experiment.csh
@@ -181,6 +181,7 @@ setenv ExtendedMeanFCTimes T00,T12      # times of the day to run extended forec
 setenv ExtendedEnsFCTimes T00           # times of the day to run ensemble of extended forecasts
 setenv DAVFWindowHR ${CyclingWindowHR}  # window of observations included in AN/BG verification
 setenv FCVFWindowHR 6                   # window of observations included in forecast verification
+setenv forecastPrecision single         # floating-point precision of forecast output; options: [single, double]
 
 
 ########################

--- a/config/modeldata.csh
+++ b/config/modeldata.csh
@@ -126,10 +126,11 @@ setenv deterministicSeaAnaDir ${GFSAnaDirOuter}
 if ( "$DAType" =~ *"eda"* ) then
   # using member-specific sst/xice data from GEFS
   # stochastic - only 120km
-  setenv SeaAnaDir ${GEFSAnaDir}/${MPASGridDescriptorOuter}/GEFS/surface/000hr
+  setenv SeaAnaDir ${GEFSAnaDir}/${MPASGridDescriptorOuter}/GEFS/surface/000hr/${forecastPrecision}
   setenv seaMemFmt "${gefsMemFmt}"
 else
   # deterministic
+  # TODO: enable precision-specific Sea updates for deterministic experiments
   setenv SeaAnaDir ${deterministicSeaAnaDir}
   setenv seaMemFmt " "
 endif

--- a/config/mpas/forecast/streams.atmosphere
+++ b/config/mpas/forecast/streams.atmosphere
@@ -1,21 +1,21 @@
 <streams>
 <immutable_stream name="static"
                   type="input"
-                  precision="double"
+                  precision="single"
                   filename_template="StaticFieldsPrefix.nCells.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="input"
                   type="input"
-                  precision="double"
+                  precision="single"
                   filename_template="ICFilePrefix.$Y-$M-$D_$h.$m.$s.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="da_state"
                   type="output"
-                  precision="double"
+                  precision="single"
                   clobber_mode="truncate"
                   filename_template="FCFilePrefix.$Y-$M-$D_$h.$m.$s.nc"
                   io_type="pnetcdf,cdf5"
@@ -23,7 +23,7 @@
 
 <immutable_stream name="iau"
                   type="input"
-                  precision="double"
+                  precision="single"
                   filename_template="x1.nCells.AmB.$Y-$M-$D_$h.$m.$s.nc"
                   filename_interval="none"
                   packages="iau"
@@ -37,6 +37,7 @@
 
 <stream name="diagnostics"
         type="output"
+        precision="single"
         filename_template="diag.$Y-$M-$D_$h.$m.$s.nc"
         io_type="pnetcdf,cdf5"
         clobber_mode="overwrite"
@@ -46,6 +47,7 @@
 
 <stream name="surface"
         type="input"
+        precision="single"
         filename_template="x1.nCells.sfc_update.nc"
         filename_interval="none"
         input_interval="none" >

--- a/config/mpas/forecast/streams.atmosphere
+++ b/config/mpas/forecast/streams.atmosphere
@@ -1,21 +1,21 @@
 <streams>
 <immutable_stream name="static"
                   type="input"
-                  precision="single"
+                  precision="forecastPrecision"
                   filename_template="StaticFieldsPrefix.nCells.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="input"
                   type="input"
-                  precision="single"
+                  precision="forecastPrecision"
                   filename_template="ICFilePrefix.$Y-$M-$D_$h.$m.$s.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="da_state"
                   type="output"
-                  precision="single"
+                  precision="forecastPrecision"
                   clobber_mode="truncate"
                   filename_template="FCFilePrefix.$Y-$M-$D_$h.$m.$s.nc"
                   io_type="pnetcdf,cdf5"
@@ -23,7 +23,7 @@
 
 <immutable_stream name="iau"
                   type="input"
-                  precision="single"
+                  precision="forecastPrecision"
                   filename_template="x1.nCells.AmB.$Y-$M-$D_$h.$m.$s.nc"
                   filename_interval="none"
                   packages="iau"
@@ -37,7 +37,7 @@
 
 <stream name="diagnostics"
         type="output"
-        precision="single"
+        precision="forecastPrecision"
         filename_template="diag.$Y-$M-$D_$h.$m.$s.nc"
         io_type="pnetcdf,cdf5"
         clobber_mode="overwrite"
@@ -47,7 +47,7 @@
 
 <stream name="surface"
         type="input"
-        precision="single"
+        precision="forecastPrecision"
         filename_template="x1.nCells.sfc_update.nc"
         filename_interval="none"
         input_interval="none" >

--- a/config/mpas/hofx/streams.atmosphere
+++ b/config/mpas/hofx/streams.atmosphere
@@ -1,21 +1,21 @@
 <streams>
 <immutable_stream name="static"
                   type="input"
-                  precision="single"
+                  precision="forecastPrecision"
                   filename_template="StaticFieldsPrefix.nCells.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="input"
                   type="input"
-                  precision="single"
+                  precision="forecastPrecision"
                   filename_template="TemplateFieldsPrefix.nCells.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="da_state"
                   type="output"
-                  precision="single"
+                  precision="forecastPrecision"
                   io_type="pnetcdf,cdf5"
                   filename_template="mpasout.$Y-$M-$D_$h.$m.$s.nc"
                   output_interval="none"
@@ -23,7 +23,7 @@
 
 <stream name="background"
         type="input;output"
-        precision="single"
+        precision="forecastPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="background.nc"
         input_interval="none"
@@ -34,7 +34,7 @@
 
 <stream name="analysis"
         type="output"
-        precision="single"
+        precision="forecastPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="analysis.nc"
         output_interval="none"
@@ -44,7 +44,7 @@
 
 <stream name="ensemble"
         type="input;output"
-        precision="single"
+        precision="forecastPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="ensemble.nc"
         input_interval="none"
@@ -55,7 +55,7 @@
 
 <stream name="control"
         type="input;output"
-        precision="single"
+        precision="forecastPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="control.nc"
         input_interval="none"

--- a/config/mpas/hofx/streams.atmosphere
+++ b/config/mpas/hofx/streams.atmosphere
@@ -1,21 +1,21 @@
 <streams>
 <immutable_stream name="static"
                   type="input"
-                  precision="double"
+                  precision="single"
                   filename_template="StaticFieldsPrefix.nCells.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="input"
                   type="input"
-                  precision="double"
+                  precision="single"
                   filename_template="TemplateFieldsPrefix.nCells.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="da_state"
                   type="output"
-                  precision="double"
+                  precision="single"
                   io_type="pnetcdf,cdf5"
                   filename_template="mpasout.$Y-$M-$D_$h.$m.$s.nc"
                   output_interval="none"
@@ -23,7 +23,7 @@
 
 <stream name="background"
         type="input;output"
-        precision="double"
+        precision="single"
         io_type="pnetcdf,cdf5"
         filename_template="background.nc"
         input_interval="none"
@@ -34,7 +34,7 @@
 
 <stream name="analysis"
         type="output"
-        precision="double"
+        precision="single"
         io_type="pnetcdf,cdf5"
         filename_template="analysis.nc"
         output_interval="none"
@@ -44,7 +44,7 @@
 
 <stream name="ensemble"
         type="input;output"
-        precision="double"
+        precision="single"
         io_type="pnetcdf,cdf5"
         filename_template="ensemble.nc"
         input_interval="none"
@@ -55,7 +55,7 @@
 
 <stream name="control"
         type="input;output"
-        precision="double"
+        precision="single"
         io_type="pnetcdf,cdf5"
         filename_template="control.nc"
         input_interval="none"

--- a/config/mpas/rtpp/streams.atmosphere
+++ b/config/mpas/rtpp/streams.atmosphere
@@ -1,21 +1,21 @@
 <streams>
 <immutable_stream name="static"
                   type="input"
-                  precision="double"
+                  precision="single"
                   filename_template="StaticFieldsPrefix.nCells.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="input"
                   type="input"
-                  precision="double"
+                  precision="single"
                   filename_template="TemplateFieldsPrefix.nCells.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="da_state"
                   type="output"
-                  precision="double"
+                  precision="single"
                   io_type="pnetcdf,cdf5"
                   filename_template="mpasout.$Y-$M-$D_$h.$m.$s.nc"
                   output_interval="none"
@@ -23,7 +23,7 @@
 
 <stream name="background"
         type="input;output"
-        precision="double"
+        precision="single"
         io_type="pnetcdf,cdf5"
         filename_template="background.nc"
         input_interval="none"
@@ -34,7 +34,7 @@
 
 <stream name="analysis"
         type="output"
-        precision="double"
+        precision="analysisPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="analysis.nc"
         output_interval="none"
@@ -44,7 +44,7 @@
 
 <stream name="ensemble"
         type="input;output"
-        precision="double"
+        precision="single"
         io_type="pnetcdf,cdf5"
         filename_template="ensemble.nc"
         input_interval="none"
@@ -55,7 +55,7 @@
 
 <stream name="control"
         type="input;output"
-        precision="double"
+        precision="single"
         io_type="pnetcdf,cdf5"
         filename_template="control.nc"
         input_interval="none"

--- a/config/mpas/rtpp/streams.atmosphere
+++ b/config/mpas/rtpp/streams.atmosphere
@@ -1,21 +1,21 @@
 <streams>
 <immutable_stream name="static"
                   type="input"
-                  precision="single"
+                  precision="forecastPrecision"
                   filename_template="StaticFieldsPrefix.nCells.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="input"
                   type="input"
-                  precision="single"
+                  precision="forecastPrecision"
                   filename_template="TemplateFieldsPrefix.nCells.nc"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="da_state"
                   type="output"
-                  precision="single"
+                  precision="forecastPrecision"
                   io_type="pnetcdf,cdf5"
                   filename_template="mpasout.$Y-$M-$D_$h.$m.$s.nc"
                   output_interval="none"
@@ -23,7 +23,7 @@
 
 <stream name="background"
         type="input;output"
-        precision="single"
+        precision="forecastPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="background.nc"
         input_interval="none"
@@ -44,7 +44,7 @@
 
 <stream name="ensemble"
         type="input;output"
-        precision="single"
+        precision="forecastPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="ensemble.nc"
         input_interval="none"
@@ -55,7 +55,7 @@
 
 <stream name="control"
         type="input;output"
-        precision="single"
+        precision="forecastPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="control.nc"
         input_interval="none"

--- a/config/mpas/variational/streams.atmosphere
+++ b/config/mpas/variational/streams.atmosphere
@@ -1,21 +1,21 @@
 <streams>
 <immutable_stream name="static"
                   type="input"
-                  precision="double"
+                  precision="single"
                   filename_template="StaticFieldsPrefix.nCells.ncTemplateFieldsMember"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="input"
                   type="input"
-                  precision="double"
+                  precision="single"
                   filename_template="TemplateFieldsPrefix.nCells.ncTemplateFieldsMember"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="da_state"
                   type="output"
-                  precision="double"
+                  precision="single"
                   io_type="pnetcdf,cdf5"
                   filename_template="mpasout.$Y-$M-$D_$h.$m.$s.nc"
                   output_interval="none"
@@ -23,7 +23,7 @@
 
 <stream name="background"
         type="input;output"
-        precision="double"
+        precision="single"
         io_type="pnetcdf,cdf5"
         filename_template="background.nc"
         input_interval="none"
@@ -34,7 +34,7 @@
 
 <stream name="analysis"
         type="output"
-        precision="double"
+        precision="analysisPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="analysis.nc"
         output_interval="none"
@@ -44,7 +44,7 @@
 
 <stream name="ensemble"
         type="input;output"
-        precision="double"
+        precision="single"
         io_type="pnetcdf,cdf5"
         filename_template="ensemble.nc"
         input_interval="none"
@@ -55,7 +55,7 @@
 
 <stream name="control"
         type="input;output"
-        precision="double"
+        precision="single"
         io_type="pnetcdf,cdf5"
         filename_template="control.nc"
         input_interval="none"

--- a/config/mpas/variational/streams.atmosphere
+++ b/config/mpas/variational/streams.atmosphere
@@ -1,21 +1,21 @@
 <streams>
 <immutable_stream name="static"
                   type="input"
-                  precision="single"
+                  precision="forecastPrecision"
                   filename_template="StaticFieldsPrefix.nCells.ncTemplateFieldsMember"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="input"
                   type="input"
-                  precision="single"
+                  precision="forecastPrecision"
                   filename_template="TemplateFieldsPrefix.nCells.ncTemplateFieldsMember"
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <immutable_stream name="da_state"
                   type="output"
-                  precision="single"
+                  precision="forecastPrecision"
                   io_type="pnetcdf,cdf5"
                   filename_template="mpasout.$Y-$M-$D_$h.$m.$s.nc"
                   output_interval="none"
@@ -23,7 +23,7 @@
 
 <stream name="background"
         type="input;output"
-        precision="single"
+        precision="forecastPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="background.nc"
         input_interval="none"
@@ -44,7 +44,7 @@
 
 <stream name="ensemble"
         type="input;output"
-        precision="single"
+        precision="forecastPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="ensemble.nc"
         input_interval="none"
@@ -55,7 +55,7 @@
 
 <stream name="control"
         type="input;output"
-        precision="single"
+        precision="forecastPrecision"
         io_type="pnetcdf,cdf5"
         filename_template="control.nc"
         input_interval="none"

--- a/forecast.csh
+++ b/forecast.csh
@@ -99,6 +99,7 @@ sed -i 's@outputInterval@'${output_interval}'@' ${StreamsFile}
 sed -i 's@StaticFieldsPrefix@'${localStaticFieldsPrefix}'@' ${StreamsFile}
 sed -i 's@ICFilePrefix@'${ICFilePrefix}'@' ${StreamsFile}
 sed -i 's@FCFilePrefix@'${FCFilePrefix}'@' ${StreamsFile}
+sed -i 's@forecastPrecision@'${forecastPrecision}'@' ${StreamsFile}
 
 ## copy/modify dynamic namelist
 rm ${NamelistFile}


### PR DESCRIPTION
A new option, `forecastPrecision`, is added to `config/experiment.csh`, which allows the user to select the precision of MPAS-Atmosphere forecast output.  The Variational and HofX jobs are similar configured to read the same precision.  The Variational job will write analysis fields with the same precision as the input background files.  The default precision is `single`.

As discussed in #22, the problem is mostly solved by setting `precision=single` in all `streams.atmosphere` files.  The one exception is for the first cycle, where the Variational and RTPP jobs MUST output the same precision as is used in the first cycle background file, because the analysis files are initially created as copies of the backgrounds with the same precision.  There are automated precision checks in PrepVariational.csh and RTPPInflation.csh that ensure the correct `analysisPrecision` is used.

Closes #22 

Tests conducted: completed 2 cycles of `eda_3denvar-60-iter_NMEM5_RTPP0.80_LeaveOneOut_OIE120km` for two experiments.  One with `forecastPrecision` set to `single` and another with `forecastPrecision` set to `double`.