### PR TITLE
New build to avoid errors related to libpnetcdf.so.4

### DIFF
--- a/GetWarmStartIC.csh
+++ b/GetWarmStartIC.csh
@@ -30,7 +30,7 @@ while ( $member <= ${nEnsDAMembers} )
         set innerFCDir = $CyclingFCDirs[$member]/Inner
         mkdir -p ${innerFCDir}
         set fcFile = $innerFCDir/${FCFilePrefix}.${nextFirstFileDate}.nc
-        set InitialMemberFC = "$firstFCDirOuter"`${memberDir} ens $member "${firstFCMemFmt}"`
+        set InitialMemberFC = "$firstFCDirInner"`${memberDir} ens $member "${firstFCMemFmt}"`
         ln -sfv ${InitialMemberFC}/${firstFCFilePrefix}.${nextFirstFileDate}.nc ${fcFile}${OrigFileSuffix}
         # rm ${fcFile}
         cp ${fcFile}${OrigFileSuffix} ${fcFile}

--- a/PrepVariational.csh
+++ b/PrepVariational.csh
@@ -366,8 +366,8 @@ while ( $member <= ${nEnsDAMembers} )
     #modify "Inner" initial forecast file
     # TODO: capture the naming convention for FirstCyclingFCDir somewhere else
     set memDir = `${memberDir} $DAType 1`
-    set FirstCyclingFCDir = ${CyclingFCWorkDir}/${prevFirstCycleDate}${memDir}/Inner
-    cp -v ${FirstCyclingFCDir}/${self_StatePrefix}.${FirstFileDate}.nc $tFile
+    set FirstCyclingFCDir = ${CyclingFCWorkDir}/${FirstCycleDate}${memDir}/Inner
+    cp -v ${FirstCyclingFCDir}/${self_StatePrefix}.${nextFirstFileDate}.nc $tFile
 
     # modify xtime
     echo "${updateXTIME} $tFile ${thisCycleDate}"

--- a/config/builds.csh
+++ b/config/builds.csh
@@ -13,7 +13,7 @@ setenv BuildCompiler 'gnu-openmpi'
 # Note: at this time, all executables should be built in the same environment, one that is
 # consistent with config/environment.csh
 
-set commonBuild = /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_03JAN2022
+set commonBuild = /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_09JAN2022
 
 # MPAS-JEDI
 # ---------

--- a/config/experiment.csh_30-60kmliuz
+++ b/config/experiment.csh_30-60kmliuz
@@ -1,0 +1,272 @@
+#!/bin/csh -f
+
+##################################
+## Fundamental experiment settings
+##################################
+## MPASGridDescriptor
+# used to distinguish betwen MPAS meshes across experiments
+# O = variational Outer loop, forecast, HofX
+# I = variational Inner loop
+# E = variational Ensemble
+# OPTIONS:
+#   + OIE120km -- 3denvar, eda_3denvar
+#   + O30kmIE120km -- dual-resolution 3denvar
+#   + OIE60km -- eda_3denvar only
+#   + TODO: OIE60km -- 3denvar, requires generating MPASSeaVariables update files from GFS analyses
+#   + O30kmIE60km -- dual-resolution 3denvar
+#   + TODO: "OIE30km" 3denvar
+#   + TODO: "O30kmIE60km" dual-resolution eda_3denvar with 60km ensemble, 30km deterministic
+#   + TODO: "OE30kmI60km" dual-resolution eda_3denvar with 30km ensemble, no deterministic?
+#   + TODO: "OIE120km" 4denvar
+#   + TODO: "OIE60km" 4denvar
+#   + TODO: "O30kmIE60km" dual-resolution 4denvar
+setenv MPASGridDescriptor O30kmIE60km
+
+## FirstCycleDate
+# initial date of this experiment
+# OPTIONS:
+#   + 2018041500
+#   + 2020072300 --> experimental
+#     - TODO: standardize GFS and observation source data
+#     - TODO: enable QC
+#     - TODO: enable VarBC
+setenv FirstCycleDate 2018041418
+
+## benchmarkObsList
+# base set of observation types assimilated in all experiments
+set l = ()
+set l = ($l sondes)
+set l = ($l aircraft)
+set l = ($l satwind)
+set l = ($l gnssroref)
+set l = ($l sfcp)
+set l = ($l amsua_n19)
+set l = ($l amsua_n18)
+set l = ($l amsua_n15)
+set l = ($l amsua_aqua)
+set l = ($l amsua_metop-a)
+set l = ($l amsua_metop-b)
+set benchmarkObsList = ($l)
+
+## ExpSuffix
+# a unique suffix to distinguish this experiment from others
+set ExpSuffix = '_B-LOO80+RTPP80'
+set ExpSuffix = '_FROMliuz'
+
+##############
+## DA settings
+##############
+## variationalObsList
+# observation types assimilated in variational application instances
+# OPTIONS: see list below
+# Abbreviations:
+#   clr == clear-sky
+#   cld == cloudy-sky
+set l = ()
+set l = ($l $benchmarkObsList)
+#set l = ($l abi_g16)
+#set l = ($l ahi_himawari8)
+#set l = ($l abi-clr_g16)
+#set l = ($l ahi-clr_himawari8)
+# TODO: add scene-dependent ObsErrors to amsua-cld_* ObsSpaces
+# TODO: combine amsua_* and amsua-cld_* similar to jedi-gdas
+#set l = ($l amsua-cld_n19)
+#set l = ($l amsua-cld_n18)
+#set l = ($l amsua-cld_n15)
+#set l = ($l amsua-cld_aqua)
+#set l = ($l amsua-cld_metop-a)
+#set l = ($l amsua-cld_metop-b)
+set variationalObsList = ($l)
+
+## DAType
+# OPTIONS: 3denvar, eda_3denvar, 3dvarId, 3denvar-specific_multivariate
+setenv DAType 3denvar
+
+## nInnerIterations
+# list of inner iteration counts across all outer iterations
+set nInnerIterations = (60 60)
+
+## MinimizerAlgorithm
+# OPTIONS: DRIPCG, DRPLanczos, DRPBlockLanczos
+# see classes derived from oops/src/oops/assimilation/Minimizer.h for all options
+# Notes about DRPBlockLanczos:
+# + still experimental, and not reliable for this experiment
+# + only available when EDASize > 1
+setenv BlockEDA DRPBlockLanczos
+setenv MinimizerAlgorithm DRIPCG
+
+if ( "$DAType" =~ *"eda"* ) then
+  ## EDASize
+  # ensemble size of each DA instance
+  # OPTIONS:
+  #   1: ensemble of nDAInstances independent Variational applications (nEnsDAMembers jobs), each
+  #      with 1 background state member per DA job
+  # > 1: ensemble of nDAInstances independent EnsembleOfVariational applications, each with EDASize
+  #      background state members per DA job
+  # In both cases, nEnsDAMembers forecasts are used for the flow-dependent background error
+  setenv EDASize 1
+
+  ## nDAInstances
+  setenv nDAInstances 20
+
+  ## nEnsDAMembers
+  # total number of ensemble DA members, product of EDASize and nDAInstances
+  # Should be between 2 and $firstEnsFCNMembers, depends on data source in config/modeldata.csh
+  @ nEnsDAMembers = $EDASize * $nDAInstances
+else
+  ## fixedEnsBType
+  # selection of data source for fixed ensemble background covariance members
+  # OPTIONS: GEFS (default), PreviousEDA
+  set fixedEnsBType = GEFS
+
+  # tertiary settings for when fixedEnsBType is set to PreviousEDA
+  set nPreviousEnsDAMembers = 80
+  set PreviousEDAForecastDir = \
+    /glade/scratch/guerrett/pandac/guerrett_eda_3denvar_NMEM${nPreviousEnsDAMembers}_RTPP0.80_LeaveOneOut_OIE120km_memberSpecificTemplate_GEFSSeaUpdate/CyclingFC
+#    /glade/scratch/guerrett/pandac/guerrett_eda_3denvar-60-iter_NMEM80_RTPP0.80_LeaveOneOut_OIE60km/CyclingFC
+
+  # override settings for EDASize, nDAInstances, and nEnsDAMembers for non-eda setups
+  # TODO: make DAType setting agnostic of eda_3denvar vs. 3denvar
+  #       and use EDASize and nDAInstances instead
+  setenv EDASize 1
+  setenv nDAInstances 1
+  @ nEnsDAMembers = $EDASize * $nDAInstances
+endif
+
+if ($EDASize == 1 && $MinimizerAlgorithm == $BlockEDA) then
+  echo "WARNING: MinimizerAlgorithm cannot be $BlockEDA when EDASize is 1, re-setting to DRPLanczos"
+  setenv MinimizerAlgorithm DRPLanczos
+endif
+
+## LeaveOneOutEDA, whether to use self-exclusion in the EnVar ensemble B during EDA cycling
+# OPTIONS: True/False
+setenv LeaveOneOutEDA True
+
+## RTPPInflationFactor, relaxation parameter for the relaxation to prior perturbation (RTPP) inflation mechanism
+# Typical Values: 0.0 or 0.50 to 0.90
+setenv RTPPInflationFactor 0.80
+
+## storeOriginalRTPPAnalyses, whether to store the analyses taken as inputs to RTPP for diagnostic purposes
+# OPTIONS: True/False
+setenv storeOriginalRTPPAnalyses False
+
+## ABEIInflation, whether to utilize adaptive background error inflation (ABEI) in cloud-affected scenes
+#  as measured by ABI and AHI observations
+# OPTIONS: True/False
+setenv ABEInflation False
+
+## ABEIChannel
+# OPTIONS: 8, 9, 10
+setenv ABEIChannel 8
+
+################
+## HofX settings
+################
+## hofxObsList
+# observation types simulated in hofx application instances for verification
+# OPTIONS: see list below
+# Abbreviations:
+#   clr == clear-sky
+#   cld == cloudy-sky
+set l = ()
+#set l = ($l sondes)
+#set l = ($l aircraft)
+#set l = ($l satwind)
+#set l = ($l gnssroref)
+#set l = ($l sfcp)
+#set l = ($l amsua_n19)
+#set l = ($l amsua_n18)
+#set l = ($l amsua_n15)
+#set l = ($l amsua_aqua)
+#set l = ($l amsua_metop-a)
+#set l = ($l amsua_metop-b)
+#set l = ($l amsua-cld_n19)
+#set l = ($l amsua-cld_n18)
+#set l = ($l amsua-cld_n15)
+#set l = ($l amsua-cld_aqua)
+#set l = ($l amsua-cld_metop-a)
+#set l = ($l amsua-cld_metop-b)
+#set l = ($l mhs_n19)
+#set l = ($l mhs_n18)
+#set l = ($l mhs_metop-a)
+#set l = ($l mhs_metop-b)
+set l = ($l abi_g16)
+set l = ($l ahi_himawari8)
+#set l = ($l abi-clr_g16)
+#set l = ($l ahi-clr_himawari8)
+set hofxObsList = ($l)
+
+
+#GEFS reference case (override above settings)
+#====================================================
+#set ExpSuffix = _GEFSVerify
+#setenv DAType eda_3denvar
+#setenv EDASize 1
+#setenv nDAInstances 20
+#setenv nEnsDAMembers 20
+#setenv RTPPInflationFactor 0.0
+#setenv LeaveOneOutEDA False
+#set variationalObsList = ($benchmarkObsList)
+#set nInnerIterations = ()
+#====================================================
+
+## nOuterIterations, automatically determined from length of nInnerIterations
+setenv nOuterIterations ${#nInnerIterations}
+
+##################################
+## analysis and forecast intervals
+##################################
+setenv CyclingWindowHR 6                # forecast interval between CyclingDA analyses
+setenv ExtendedFCWindowHR 240           # length of verification forecasts
+setenv ExtendedFC_DT_HR 12              # interval between OMF verification times of an individual forecast
+setenv ExtendedMeanFCTimes T00,T12      # times of the day to run extended forecast from mean analysis
+setenv ExtendedEnsFCTimes T00           # times of the day to run ensemble of extended forecasts
+setenv DAVFWindowHR ${CyclingWindowHR}  # window of observations included in AN/BG verification
+setenv FCVFWindowHR 6                   # window of observations included in forecast verification
+setenv forecastPrecision single         # floating-point precision of forecast output; options: [single, double]
+
+
+########################
+## experiment name parts
+########################
+
+## derive experiment title parts from above settings
+
+#(1) ensemble-related settings
+set ExpEnsSuffix = ''
+if ($nEnsDAMembers > 1) then
+  if ($EDASize > 1) then
+    set ExpEnsSuffix = '_NMEM'${nDAInstances}x${EDASize}
+    if ($MinimizerAlgorithm == $BlockEDA) then
+      set ExpEnsSuffix = ${ExpEnsSuffix}Block
+    endif
+  else
+    set ExpEnsSuffix = '_NMEM'${nEnsDAMembers}
+  endif
+  if (${RTPPInflationFactor} != "0.0") set ExpEnsSuffix = ${ExpEnsSuffix}_RTPP${RTPPInflationFactor}
+  if (${LeaveOneOutEDA} == True) set ExpEnsSuffix = ${ExpEnsSuffix}_LeaveOneOut
+  if (${ABEInflation} == True) set ExpEnsSuffix = ${ExpEnsSuffix}_ABEI_BT${ABEIChannel}
+endif
+
+#(2) observation selection
+setenv ExpObsSuffix ''
+foreach obs ($variationalObsList)
+  set isBench = False
+  foreach benchObs ($benchmarkObsList)
+    if ("$obs" =~ *"$benchObs"*) then
+      set isBench = True
+    endif
+  end
+  if ( $isBench == False ) then
+    setenv ExpObsSuffix ${ExpObsSuffix}_${obs}
+  endif
+end
+
+#(3) inner iteration counts
+set ExpIterSuffix = ''
+foreach nInner ($nInnerIterations)
+  set ExpIterSuffix = ${ExpIterSuffix}-${nInner}
+end
+if ( $nOuterIterations > 0 ) then
+  set ExpIterSuffix = ${ExpIterSuffix}-iter
+endif

--- a/config/experiment.csh_Bloo80
+++ b/config/experiment.csh_Bloo80
@@ -1,0 +1,272 @@
+#!/bin/csh -f
+
+##################################
+## Fundamental experiment settings
+##################################
+## MPASGridDescriptor
+# used to distinguish betwen MPAS meshes across experiments
+# O = variational Outer loop, forecast, HofX
+# I = variational Inner loop
+# E = variational Ensemble
+# OPTIONS:
+#   + OIE120km -- 3denvar, eda_3denvar
+#   + O30kmIE120km -- dual-resolution 3denvar
+#   + OIE60km -- eda_3denvar only
+#   + TODO: OIE60km -- 3denvar, requires generating MPASSeaVariables update files from GFS analyses
+#   + O30kmIE60km -- dual-resolution 3denvar
+#   + TODO: "OIE30km" 3denvar
+#   + TODO: "O30kmIE60km" dual-resolution eda_3denvar with 60km ensemble, 30km deterministic
+#   + TODO: "OE30kmI60km" dual-resolution eda_3denvar with 30km ensemble, no deterministic?
+#   + TODO: "OIE120km" 4denvar
+#   + TODO: "OIE60km" 4denvar
+#   + TODO: "O30kmIE60km" dual-resolution 4denvar
+setenv MPASGridDescriptor OIE120km
+
+## FirstCycleDate
+# initial date of this experiment
+# OPTIONS:
+#   + 2018041500
+#   + 2020072300 --> experimental
+#     - TODO: standardize GFS and observation source data
+#     - TODO: enable QC
+#     - TODO: enable VarBC
+setenv FirstCycleDate 2018041418
+
+## benchmarkObsList
+# base set of observation types assimilated in all experiments
+set l = ()
+set l = ($l sondes)
+set l = ($l aircraft)
+set l = ($l satwind)
+set l = ($l gnssroref)
+set l = ($l sfcp)
+set l = ($l amsua_n19)
+set l = ($l amsua_n18)
+set l = ($l amsua_n15)
+set l = ($l amsua_aqua)
+set l = ($l amsua_metop-a)
+set l = ($l amsua_metop-b)
+set benchmarkObsList = ($l)
+
+## ExpSuffix
+# a unique suffix to distinguish this experiment from others
+set ExpSuffix = '_B-LOO80+RTPP80'
+#set ExpSuffix = '_FROMliuz'
+
+##############
+## DA settings
+##############
+## variationalObsList
+# observation types assimilated in variational application instances
+# OPTIONS: see list below
+# Abbreviations:
+#   clr == clear-sky
+#   cld == cloudy-sky
+set l = ()
+set l = ($l $benchmarkObsList)
+#set l = ($l abi_g16)
+#set l = ($l ahi_himawari8)
+#set l = ($l abi-clr_g16)
+#set l = ($l ahi-clr_himawari8)
+# TODO: add scene-dependent ObsErrors to amsua-cld_* ObsSpaces
+# TODO: combine amsua_* and amsua-cld_* similar to jedi-gdas
+#set l = ($l amsua-cld_n19)
+#set l = ($l amsua-cld_n18)
+#set l = ($l amsua-cld_n15)
+#set l = ($l amsua-cld_aqua)
+#set l = ($l amsua-cld_metop-a)
+#set l = ($l amsua-cld_metop-b)
+set variationalObsList = ($l)
+
+## DAType
+# OPTIONS: 3denvar, eda_3denvar, 3dvarId, 3denvar-specific_multivariate
+setenv DAType 3denvar
+
+## nInnerIterations
+# list of inner iteration counts across all outer iterations
+set nInnerIterations = (60)
+
+## MinimizerAlgorithm
+# OPTIONS: DRIPCG, DRPLanczos, DRPBlockLanczos
+# see classes derived from oops/src/oops/assimilation/Minimizer.h for all options
+# Notes about DRPBlockLanczos:
+# + still experimental, and not reliable for this experiment
+# + only available when EDASize > 1
+setenv BlockEDA DRPBlockLanczos
+setenv MinimizerAlgorithm DRIPCG
+
+if ( "$DAType" =~ *"eda"* ) then
+  ## EDASize
+  # ensemble size of each DA instance
+  # OPTIONS:
+  #   1: ensemble of nDAInstances independent Variational applications (nEnsDAMembers jobs), each
+  #      with 1 background state member per DA job
+  # > 1: ensemble of nDAInstances independent EnsembleOfVariational applications, each with EDASize
+  #      background state members per DA job
+  # In both cases, nEnsDAMembers forecasts are used for the flow-dependent background error
+  setenv EDASize 1
+
+  ## nDAInstances
+  setenv nDAInstances 20
+
+  ## nEnsDAMembers
+  # total number of ensemble DA members, product of EDASize and nDAInstances
+  # Should be between 2 and $firstEnsFCNMembers, depends on data source in config/modeldata.csh
+  @ nEnsDAMembers = $EDASize * $nDAInstances
+else
+  ## fixedEnsBType
+  # selection of data source for fixed ensemble background covariance members
+  # OPTIONS: GEFS (default), PreviousEDA
+  set fixedEnsBType = PreviousEDA
+
+  # tertiary settings for when fixedEnsBType is set to PreviousEDA
+  set nPreviousEnsDAMembers = 80
+  set PreviousEDAForecastDir = \
+    /glade/scratch/guerrett/pandac/guerrett_eda_3denvar_NMEM${nPreviousEnsDAMembers}_RTPP0.80_LeaveOneOut_OIE120km_memberSpecificTemplate_GEFSSeaUpdate/CyclingFC
+#    /glade/scratch/guerrett/pandac/guerrett_eda_3denvar-60-iter_NMEM80_RTPP0.80_LeaveOneOut_OIE60km/CyclingFC
+
+  # override settings for EDASize, nDAInstances, and nEnsDAMembers for non-eda setups
+  # TODO: make DAType setting agnostic of eda_3denvar vs. 3denvar
+  #       and use EDASize and nDAInstances instead
+  setenv EDASize 1
+  setenv nDAInstances 1
+  @ nEnsDAMembers = $EDASize * $nDAInstances
+endif
+
+if ($EDASize == 1 && $MinimizerAlgorithm == $BlockEDA) then
+  echo "WARNING: MinimizerAlgorithm cannot be $BlockEDA when EDASize is 1, re-setting to DRPLanczos"
+  setenv MinimizerAlgorithm DRPLanczos
+endif
+
+## LeaveOneOutEDA, whether to use self-exclusion in the EnVar ensemble B during EDA cycling
+# OPTIONS: True/False
+setenv LeaveOneOutEDA True
+
+## RTPPInflationFactor, relaxation parameter for the relaxation to prior perturbation (RTPP) inflation mechanism
+# Typical Values: 0.0 or 0.50 to 0.90
+setenv RTPPInflationFactor 0.80
+
+## storeOriginalRTPPAnalyses, whether to store the analyses taken as inputs to RTPP for diagnostic purposes
+# OPTIONS: True/False
+setenv storeOriginalRTPPAnalyses False
+
+## ABEIInflation, whether to utilize adaptive background error inflation (ABEI) in cloud-affected scenes
+#  as measured by ABI and AHI observations
+# OPTIONS: True/False
+setenv ABEInflation False
+
+## ABEIChannel
+# OPTIONS: 8, 9, 10
+setenv ABEIChannel 8
+
+################
+## HofX settings
+################
+## hofxObsList
+# observation types simulated in hofx application instances for verification
+# OPTIONS: see list below
+# Abbreviations:
+#   clr == clear-sky
+#   cld == cloudy-sky
+set l = ()
+#set l = ($l sondes)
+#set l = ($l aircraft)
+#set l = ($l satwind)
+#set l = ($l gnssroref)
+#set l = ($l sfcp)
+#set l = ($l amsua_n19)
+#set l = ($l amsua_n18)
+#set l = ($l amsua_n15)
+#set l = ($l amsua_aqua)
+#set l = ($l amsua_metop-a)
+#set l = ($l amsua_metop-b)
+#set l = ($l amsua-cld_n19)
+#set l = ($l amsua-cld_n18)
+#set l = ($l amsua-cld_n15)
+#set l = ($l amsua-cld_aqua)
+#set l = ($l amsua-cld_metop-a)
+#set l = ($l amsua-cld_metop-b)
+#set l = ($l mhs_n19)
+#set l = ($l mhs_n18)
+#set l = ($l mhs_metop-a)
+#set l = ($l mhs_metop-b)
+set l = ($l abi_g16)
+set l = ($l ahi_himawari8)
+#set l = ($l abi-clr_g16)
+#set l = ($l ahi-clr_himawari8)
+set hofxObsList = ($l)
+
+
+#GEFS reference case (override above settings)
+#====================================================
+#set ExpSuffix = _GEFSVerify
+#setenv DAType eda_3denvar
+#setenv EDASize 1
+#setenv nDAInstances 20
+#setenv nEnsDAMembers 20
+#setenv RTPPInflationFactor 0.0
+#setenv LeaveOneOutEDA False
+#set variationalObsList = ($benchmarkObsList)
+#set nInnerIterations = ()
+#====================================================
+
+## nOuterIterations, automatically determined from length of nInnerIterations
+setenv nOuterIterations ${#nInnerIterations}
+
+##################################
+## analysis and forecast intervals
+##################################
+setenv CyclingWindowHR 6                # forecast interval between CyclingDA analyses
+setenv ExtendedFCWindowHR 240           # length of verification forecasts
+setenv ExtendedFC_DT_HR 12              # interval between OMF verification times of an individual forecast
+setenv ExtendedMeanFCTimes T00,T12      # times of the day to run extended forecast from mean analysis
+setenv ExtendedEnsFCTimes T00           # times of the day to run ensemble of extended forecasts
+setenv DAVFWindowHR ${CyclingWindowHR}  # window of observations included in AN/BG verification
+setenv FCVFWindowHR 6                   # window of observations included in forecast verification
+setenv forecastPrecision single         # floating-point precision of forecast output; options: [single, double]
+
+
+########################
+## experiment name parts
+########################
+
+## derive experiment title parts from above settings
+
+#(1) ensemble-related settings
+set ExpEnsSuffix = ''
+if ($nEnsDAMembers > 1) then
+  if ($EDASize > 1) then
+    set ExpEnsSuffix = '_NMEM'${nDAInstances}x${EDASize}
+    if ($MinimizerAlgorithm == $BlockEDA) then
+      set ExpEnsSuffix = ${ExpEnsSuffix}Block
+    endif
+  else
+    set ExpEnsSuffix = '_NMEM'${nEnsDAMembers}
+  endif
+  if (${RTPPInflationFactor} != "0.0") set ExpEnsSuffix = ${ExpEnsSuffix}_RTPP${RTPPInflationFactor}
+  if (${LeaveOneOutEDA} == True) set ExpEnsSuffix = ${ExpEnsSuffix}_LeaveOneOut
+  if (${ABEInflation} == True) set ExpEnsSuffix = ${ExpEnsSuffix}_ABEI_BT${ABEIChannel}
+endif
+
+#(2) observation selection
+setenv ExpObsSuffix ''
+foreach obs ($variationalObsList)
+  set isBench = False
+  foreach benchObs ($benchmarkObsList)
+    if ("$obs" =~ *"$benchObs"*) then
+      set isBench = True
+    endif
+  end
+  if ( $isBench == False ) then
+    setenv ExpObsSuffix ${ExpObsSuffix}_${obs}
+  endif
+end
+
+#(3) inner iteration counts
+set ExpIterSuffix = ''
+#foreach nInner ($nInnerIterations)
+#  set ExpIterSuffix = ${ExpIterSuffix}-${nInner}
+#end
+#if ( $nOuterIterations > 0 ) then
+#  set ExpIterSuffix = ${ExpIterSuffix}-iter
+#endif

--- a/config/mpas/geovars.yaml
+++ b/config/mpas/geovars.yaml
@@ -187,7 +187,13 @@ fields:
     mpas template field: u10
     mpas identity field: v10
 
-  - field name: land_type_index
+  - field name: surface_wind_speed
+    mpas template field: u10
+
+  - field name: land_type_index_USGS
+    mpas template field: ivgtyp
+
+  - field name: land_type_index_IGBP
     mpas template field: ivgtyp
 
   - field name: vegetation_type_index


### PR DESCRIPTION
Over the weekend errors started showing up that look like this:
```
./mpasjedi_hofx3d.x: error while loading shared libraries: libpnetcdf.so.4: cannot open shared object file: No such file or directory
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
```

The same errors occurred in the bundle build directory when running ctests.  Rebuilding that old directory or making an entirely new build solve the problem, although I do not know why.

List of changes:
- This PR uses a new build from 09JAN2022.
- `config/mpas/geovars.yaml` is updated to be consistent with `mpas-jedi:develop`.
- Fixes #60 