### PR TITLE
Refactor job accounting

### DIFF
--- a/PrepJEDI.csh
+++ b/PrepJEDI.csh
@@ -24,11 +24,6 @@ set ArgDT = "$2"
 # ArgStateType: str, FC if this is a forecasted state, activates ArgDT in directory naming
 set ArgStateType = "$3"
 
-# ArgPrepObsOn: boolean, determines the data source
-#         True: link observations generated online in the workflow
-#        False: link pre-generated observations
-set ArgPrepObsOn = "$4"
-
 ## arg checks
 set test = `echo $ArgMember | grep '^[0-9]*$'`
 set isNotInt = ($status)
@@ -205,7 +200,7 @@ while ( $member <= ${nEnsDAMembers} )
   @ member++
 end
 
-if ( $ArgPrepObsOn == True ) then
+if ( $PreprocessObs == True ) then
   # conventional
   # ============
   ln -sfv ${ObsDir}/aircraft_obs*.h5 ${InDBDir}/

--- a/config/experiment.csh
+++ b/config/experiment.csh
@@ -25,7 +25,7 @@ setenv InitializationType WarmStart
 # or use pre-converted observation files, the latter only being available for
 # specific time periods
 # OPTIONS: True/False
-setenv PreprocessObs = False
+setenv PreprocessObs False
 
 
 ##################################

--- a/config/experiment.csh
+++ b/config/experiment.csh
@@ -1,5 +1,33 @@
 #!/bin/csh -f
 
+####################
+# workflow controls
+####################
+## FirstCycleDate
+# initial date of this experiment
+# OPTIONS:
+#   + 2018041500
+#   + 2020072300 --> experimental
+#     - TODO: standardize GFS and observation source data
+#     - TODO: enable QC
+#     - TODO: enable VarBC
+setenv FirstCycleDate 2018041418
+
+## InitializationType
+# Indicates the type of initialization at the initial cycle: cold or warm start
+# OPTIONS:
+#   ColdStart - generate first forecast online from an external GFS analysis
+#   WarmStart - copy a pre-generated forecast
+setenv InitializationType WarmStart
+
+## PreprocessObs
+# Whether to convert RDA archived BUFR observations to IODA on the fly (True)
+# or use pre-converted observation files, the latter only being available for
+# specific time periods
+# OPTIONS: True/False
+setenv PreprocessObs = False
+
+
 ##################################
 ## Fundamental experiment settings
 ##################################
@@ -21,28 +49,6 @@
 #   + TODO: "OIE60km" 4denvar
 #   + TODO: "O30kmIE60km" dual-resolution 4denvar
 setenv MPASGridDescriptor OIE120km
-
-## FirstCycleDate
-# initial date of this experiment
-# OPTIONS:
-#   + 2018041500
-#   + 2020072300 --> experimental
-#     - TODO: standardize GFS and observation source data
-#     - TODO: enable QC
-#     - TODO: enable VarBC
-setenv FirstCycleDate 2018041418
-
-
-#######################
-# workflow date control
-#######################
-## InitializationType
-# Indicates the type of initialization at the initial cycle: cold or warm start
-# OPTIONS:
-#   ColdStart - generate first forecast online from an external GFS analysis
-#   WarmStart - copy a pre-generated forecast
-setenv InitializationType WarmStart
-
 
 ## benchmarkObsList
 # base set of observation types assimilated in all experiments

--- a/config/job.csh
+++ b/config/job.csh
@@ -8,21 +8,36 @@ source config/experiment.csh
 
 ## *AccountNumber
 # OPTIONS: NMMM0015, NMMM0043
-setenv StandardAccountNumber NMMM0043
-setenv CYAccountNumber ${StandardAccountNumber}
-setenv VFAccountNumber ${StandardAccountNumber}
+setenv CheyenneAccountNumber NMMM0043
+setenv CasperAccountNumber NMMM0015
+#Note: NMMM0043 is not available on casper
 
 ## *QueueName
-# OPTIONS: economy, regular, premium
-setenv CYQueueName regular
-setenv VFQueueName economy
+# Cheyenne Options: economy, regular, premium
+# Casper Options: casper@casper-pbs
+
+# CP*: used for all critical path jobs, single or multi-node, multi-processor only
+setenv CPAccountNumber ${CheyenneAccountNumber}
+setenv CPQueueName regular
+
+# NCP*: used non-critical path jobs, single or multi-node, multi-processor only
+setenv NCPAccountNumber ${CheyenneAccountNumber}
+setenv NCPQueueName economy
+
+# SingleProc*: used for single-processor jobs, both critical and non-critical paths
+# IMPORTANT: must NOT be executed on login node to comply with CISL requirements
+#setenv SingleProcAccountNumber ${CheyenneAccountNumber}
+#setenv SingleProcQueueName share
+setenv SingleProcAccountNumber ${CasperAccountNumber}
+setenv SingleProcQueueName "casper@casper-pbs"
+
 
 if ($ABEInflation == True) then
-  setenv EnsMeanBGQueueName ${CYQueueName}
-  setenv EnsMeanBGAccountNumber ${CYAccountNumber}
+  setenv EnsMeanBGQueueName ${CPQueueName}
+  setenv EnsMeanBGAccountNumber ${CPAccountNumber}
 else
-  setenv EnsMeanBGQueueName ${VFQueueName}
-  setenv EnsMeanBGAccountNumber ${VFAccountNumber}
+  setenv EnsMeanBGQueueName ${NCPQueueName}
+  setenv EnsMeanBGAccountNumber ${NCPAccountNumber}
 endif
 
 setenv InitializationRetry '2*PT30S'

--- a/config/mpas/O30kmIE120km/job.csh
+++ b/config/mpas/O30kmIE120km/job.csh
@@ -10,11 +10,6 @@ setenv InitICJobMinutes 1
 setenv InitICNodes 1
 setenv InitICPEPerNode 36
 
-setenv ObstoIODAJobMinutes 10
-setenv ObstoIODANodes 1
-setenv ObstoIODAPEPerNode 1
-setenv ObstoIODAMemory 109
-
 @ CyclingFCJobMinutes = 2 + (7 * $CyclingWindowHR / 6)
 setenv CyclingFCNodes 16
 setenv CyclingFCPEPerNode 32
@@ -43,12 +38,8 @@ set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
 set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 9
 @ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} * ${EnsembleVerifyObsEnsMeanJobSecondsPerMember} / 60
 @ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
-setenv VerifyObsNodes 1
-setenv VerifyObsPEPerNode 36
 
 setenv VerifyModelJobMinutes 20
-setenv VerifyModelNodes 1
-setenv VerifyModelPEPerNode 36
 
 set DeterministicDABaseMinutes = 20
 set ThreeDEnVarJobSecondsPerMember = 5

--- a/config/mpas/O30kmIE60km/job.csh
+++ b/config/mpas/O30kmIE60km/job.csh
@@ -10,11 +10,6 @@ setenv InitICJobMinutes 1
 setenv InitICNodes 1
 setenv InitICPEPerNode 36
 
-setenv ObstoIODAJobMinutes 10
-setenv ObstoIODANodes 1
-setenv ObstoIODAPEPerNode 1
-setenv ObstoIODAMemory 109
-
 @ CyclingFCJobMinutes = 2 + (7 * $CyclingWindowHR / 6)
 setenv CyclingFCNodes 16
 setenv CyclingFCPEPerNode 32
@@ -43,12 +38,8 @@ set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
 set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 9
 @ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} * ${EnsembleVerifyObsEnsMeanJobSecondsPerMember} / 60
 @ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
-setenv VerifyObsNodes 1
-setenv VerifyObsPEPerNode 36
 
 setenv VerifyModelJobMinutes 20
-setenv VerifyModelNodes 1
-setenv VerifyModelPEPerNode 36
 
 # benchmark: < 20 minutes
 # longer duration with more observations

--- a/config/mpas/OIE120km/job.csh
+++ b/config/mpas/OIE120km/job.csh
@@ -10,11 +10,6 @@ setenv InitICJobMinutes 1
 setenv InitICNodes 1
 setenv InitICPEPerNode 36
 
-setenv ObstoIODAJobMinutes 10
-setenv ObstoIODANodes 1
-setenv ObstoIODAPEPerNode 1
-setenv ObstoIODAMemory 109
-
 @ CyclingFCJobMinutes = 1 + ($CyclingWindowHR / 6)
 setenv CyclingFCNodes 4
 setenv CyclingFCPEPerNode 32
@@ -37,12 +32,8 @@ set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
 set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 9
 @ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} * ${EnsembleVerifyObsEnsMeanJobSecondsPerMember} / 60
 @ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
-setenv VerifyObsNodes 1
-setenv VerifyObsPEPerNode 36
 
 setenv VerifyModelJobMinutes 2
-setenv VerifyModelNodes 1
-setenv VerifyModelPEPerNode 36
 
 ## Variational+EnsOfVariational
 # benchmark: < 3 minutes

--- a/config/mpas/OIE30km/job.csh
+++ b/config/mpas/OIE30km/job.csh
@@ -9,11 +9,6 @@ setenv InitICJobMinutes 1
 setenv InitICNodes 1
 setenv InitICPEPerNode 36
 
-setenv ObstoIODAJobMinutes 10
-setenv ObstoIODANodes 1
-setenv ObstoIODAPEPerNode 1
-setenv ObstoIODAMemory 109
-
 @ CyclingFCJobMinutes = 5 + (5 * $CyclingWindowHR / 6)
 setenv CyclingFCNodes 8
 setenv CyclingFCPEPerNode 32
@@ -33,12 +28,8 @@ set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
 set EnsembleVerifyObsEnsMeanMembersPerJobMinute = 10
 @ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} / ${EnsembleVerifyObsEnsMeanMembersPerJobMinute}
 @ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
-setenv VerifyObsNodes 1
-setenv VerifyObsPEPerNode 36
 
 setenv VerifyModelJobMinutes 2
-setenv VerifyModelNodes 1
-setenv VerifyModelPEPerNode 36
 
 set DeterministicDABaseMinutes = 25
 set ThreeDEnVarMembersPerJobMinute = 12

--- a/config/mpas/OIE60km/job.csh
+++ b/config/mpas/OIE60km/job.csh
@@ -10,11 +10,6 @@ setenv InitICJobMinutes 1
 setenv InitICNodes 1
 setenv InitICPEPerNode 36
 
-setenv ObstoIODAJobMinutes 10
-setenv ObstoIODANodes 1
-setenv ObstoIODAPEPerNode 1
-setenv ObstoIODAMemory 109
-
 @ CyclingFCJobMinutes = 1 + (3 * $CyclingWindowHR / 6)
 setenv CyclingFCNodes 4
 setenv CyclingFCPEPerNode 36
@@ -37,12 +32,8 @@ set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
 set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 9
 @ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} * ${EnsembleVerifyObsEnsMeanJobSecondsPerMember} / 60
 @ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
-setenv VerifyObsNodes 1
-setenv VerifyObsPEPerNode 36
 
 setenv VerifyModelJobMinutes 5
-setenv VerifyModelNodes 1
-setenv VerifyModelPEPerNode 36
 
 ## Variational+EnsOfVariational
 # Timing and memory required for different PE counts

--- a/drive.csh
+++ b/drive.csh
@@ -420,11 +420,13 @@ cat >! suite.rc << EOF
       execution retry delays = ${InitializationRetry}
     # currently ObstoIODA has to be on Cheyenne, because ioda-upgrade.x is built there
     # TODO: build ioda-upgrade.x on casper, remove CP directives below
+    # Note: memory for ObstoIODA may need to be increased when hyperspectral and/or
+    #       geostationary instruments are added
     [[[directives]]]
       -m = ae
       -q = ${CPQueueName}
       -A = ${CPAccountNumber}
-      -l = select=1:ncpus=1:mem=109GB
+      -l = select=1:ncpus=1:mem=10GB
   # variational-related components
   [[InitCyclingDA]]
     env-script = cd ${mainScriptDir}; ./PrepJEDIVariational.csh "1" "0" "DA"

--- a/drive.csh
+++ b/drive.csh
@@ -31,10 +31,6 @@ set finalCyclePoint = 20180514T18
 # OPTIONS: Normal, Bypass, Reanalysis, Reforecast
 set CriticalPathType = Normal
 
-## PreprocessObs: whether to convert RDA archived BUFR observations to IODA
-# OPTIONS: True/False
-set PreprocessObs = False
-
 ## VerifyDeterministicDA: whether to run verification scripts for
 #    obs feedback files from DA.  Does not work for ensemble DA.
 #    Only works when CriticalPathType == Normal.
@@ -136,7 +132,7 @@ cat >! suite.rc << EOF
 {% set finalCyclePoint   = "${finalCyclePoint}" %}
 # cycling components
 {% set CriticalPathType = "${CriticalPathType}" %}
-{% set PreprocessObs = "${PreprocessObs}" %}
+{% set PreprocessObs = ${PreprocessObs} %}
 {% set VerifyDeterministicDA = ${VerifyDeterministicDA} %}
 {% set CompareDA2Benchmark = ${CompareDA2Benchmark} %}
 {% set VerifyExtendedMeanFC = ${VerifyExtendedMeanFC} %}
@@ -171,7 +167,7 @@ cat >! suite.rc << EOF
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingDAFinished" %}
 {% elif CriticalPathType == "Normal" %}
   {% set PrimaryCPGraph = PrimaryCPGraph + "\\n        CyclingFCFinished[-PT${CyclingWindowHR}H]" %}
-  {% if PreprocessObs == "True" %}
+  {% if PreprocessObs %}
     {% set PrimaryCPGraph = PrimaryCPGraph + " => ObstoIODA" %}
   {% endif %}
   {% if (ABEInflation and nEnsDAMembers > 1) %}
@@ -205,7 +201,11 @@ cat >! suite.rc << EOF
   # and to avoid over-utilization of login nodes
   # hint: execute 'ps aux | grep $USER' to check your login node overhead
   # default: 3
+{% if CriticalPathType == "Bypass" %}
+  max active cycle points = 20
+{% else %}
   max active cycle points = 4
+{% endif %}
   initial cycle point = {{initialCyclePoint}}
   final cycle point   = {{finalCyclePoint}}
   [[dependencies]]
@@ -267,7 +267,7 @@ cat >! suite.rc << EOF
 {% elif VerifyEnsMeanBG and nEnsDAMembers == 1 %}
     [[[${cyclingCycles}]]]
       graph = '''
-  {% if PreprocessObs == "True" %}
+  {% if PreprocessObs %}
         ObstoIODA => HofXBG
   {% else %}
         CyclingFCFinished[-PT${CyclingWindowHR}H] => HofXBG
@@ -338,17 +338,18 @@ cat >! suite.rc << EOF
       execution time limit = PT60M
     [[[directives]]]
       -j = oe
-      -S = /bin/csh
-      -q = ${CYQueueName}
-      -A = ${CYAccountNumber}
       -k = eod
-      -l = select=1:ncpus=36:mpiprocs=36
+      -S = /bin/tcsh
+      # default to using one processor
+      -q = ${SingleProcQueueName}
+      -A = ${SingleProcAccountNumber}
+      -l = select=1:ncpus=1
 ## SLURM
 #    [[[job]]]
 #      batch system = slurm
 #      execution time limit = PT60M
 #    [[[directives]]]
-#      --account = ${CYAccountNumber}
+#      --account = ${CPAccountNumber}
 #      --mem = 45G
 #      --ntasks = 1
 #      --cpus-per-task = 36
@@ -358,78 +359,74 @@ cat >! suite.rc << EOF
       execution time limit = PT${CyclingFCJobMinutes}M
     [[[directives]]]
       -m = ae
+      -q = ${CPQueueName}
+      -A = ${CPAccountNumber}
       -l = select=${CyclingFCNodes}:ncpus=${CyclingFCPEPerNode}:mpiprocs=${CyclingFCPEPerNode}
   [[ExtendedFCBase]]
     [[[job]]]
       execution time limit = PT${ExtendedFCJobMinutes}M
     [[[directives]]]
       -m = ae
-      -q = ${VFQueueName}
+      -q = ${NCPQueueName}
+      -A = ${NCPAccountNumber}
       -l = select=${ExtendedFCNodes}:ncpus=${ExtendedFCPEPerNode}:mpiprocs=${ExtendedFCPEPerNode}
   [[HofXBase]]
     [[[job]]]
       execution time limit = PT${HofXJobMinutes}M
     [[[directives]]]
-      -q = ${VFQueueName}
-      -A = ${VFAccountNumber}
+      -q = ${NCPQueueName}
+      -A = ${NCPAccountNumber}
       -l = select=${HofXNodes}:ncpus=${HofXPEPerNode}:mpiprocs=${HofXPEPerNode}:mem=${HofXMemory}GB
   [[VerifyModelBase]]
     [[[job]]]
       execution time limit = PT${VerifyModelJobMinutes}M
     [[[directives]]]
-      -q = ${VFQueueName}
-      -A = ${VFAccountNumber}
-      -l = select=${VerifyModelNodes}:ncpus=${VerifyModelPEPerNode}:mpiprocs=${VerifyModelPEPerNode}
+      -q = ${NCPQueueName}
+      -A = ${NCPAccountNumber}
+      -l = select=1:ncpus=36:mpiprocs=36
   [[VerifyObsBase]]
     [[[job]]]
       execution time limit = PT${VerifyObsJobMinutes}M
+      execution retry delays = ${HofXRetry}
     [[[directives]]]
-      -q = ${VFQueueName}
-      -A = ${VFAccountNumber}
-      -l = select=${VerifyObsNodes}:ncpus=${VerifyObsPEPerNode}:mpiprocs=${VerifyObsPEPerNode}
+      -q = ${NCPQueueName}
+      -A = ${NCPAccountNumber}
+      -l = select=1:ncpus=36:mpiprocs=36
   [[CompareBase]]
     [[[job]]]
       execution time limit = PT5M
     [[[directives]]]
-      -q = ${VFQueueName}
-      -A = ${VFAccountNumber}
+      -q = ${NCPQueueName}
+      -A = ${NCPAccountNumber}
       -l = select=1:ncpus=36:mpiprocs=36
   [[CleanBase]]
     [[[job]]]
       execution time limit = PT5M
-    [[[directives]]]
-      -q = share
-      -A = ${VFAccountNumber}
-      -l = select=1:ncpus=1
 #Cycling components
   # initialization-related components
   [[GetWarmStartIC]]
     script = \$origin/GetWarmStartIC.csh
     [[[job]]]
-      execution time limit = PT5M
+      # give longer for higher resolution and more EDA members
+      # TODO: set time limit based on outer mesh AND (number of members OR
+      #       independent task for each member) under config/mpas/*/job.csh
+      execution time limit = PT10M
       execution retry delays = ${InitializationRetry}
-    [[[directives]]]
-      -q = share
-      -l = select=1:ncpus=1:mpiprocs=1
   # observations-related components
   [[ObstoIODA]]
     script = \$origin/ObstoIODA.csh
     [[[job]]]
-      execution time limit = PT${ObstoIODAJobMinutes}M
+      execution time limit = PT10M
       execution retry delays = ${InitializationRetry}
     [[[directives]]]
-      -q = share
-      -l = select=${ObstoIODANodes}:ncpus=${ObstoIODAPEPerNode}:mpiprocs=${ObstoIODAPEPerNode}:mem=${ObstoIODAMemory}GB
+      -l = select=1:ncpus=1:mem=109GB
   # variational-related components
   [[InitCyclingDA]]
-    env-script = cd ${mainScriptDir}; ./PrepJEDIVariational.csh "1" "0" "DA" "{{PreprocessObs}}"
+    env-script = cd ${mainScriptDir}; ./PrepJEDIVariational.csh "1" "0" "DA"
     script = \$origin/PrepVariational.csh "1"
     [[[job]]]
       execution time limit = PT20M
       execution retry delays = ${VariationalRetry}
-    [[[directives]]]
-      -q = share
-      -l = select=1:ncpus=1
   [[CyclingDA]]
 {% if EDASize > 1 %}
   {% for inst in DAInstances %}
@@ -441,6 +438,8 @@ cat >! suite.rc << EOF
       execution retry delays = ${EnsOfVariationalRetry}
     [[[directives]]]
       -m = ae
+      -q = ${CPQueueName}
+      -A = ${CPAccountNumber}
       -l = select=${EnsOfVariationalNodes}:ncpus=${EnsOfVariationalPEPerNode}:mpiprocs=${EnsOfVariationalPEPerNode}:mem=${EnsOfVariationalMemory}GB
   {% endfor %}
 {% else %}
@@ -453,6 +452,8 @@ cat >! suite.rc << EOF
       execution retry delays = ${VariationalRetry}
     [[[directives]]]
       -m = ae
+      -q = ${CPQueueName}
+      -A = ${CPAccountNumber}
       -l = select=${VariationalNodes}:ncpus=${VariationalPEPerNode}:mpiprocs=${VariationalPEPerNode}:mem=${VariationalMemory}GB
   {% endfor %}
 {% endif %}
@@ -463,15 +464,17 @@ cat >! suite.rc << EOF
       execution retry delays = ${RTPPInflationRetry}
     [[[directives]]]
       -m = ae
+      -q = ${CPQueueName}
+      -A = ${CPAccountNumber}
       -l = select=${CyclingInflationNodes}:ncpus=${CyclingInflationPEPerNode}:mpiprocs=${CyclingInflationPEPerNode}:mem=${CyclingInflationMemory}GB
   [[GenerateABEInflation]]
     script = \$origin/GenerateABEInflation.csh
     [[[job]]]
-      execution time limit = PT10M
+      execution time limit = PT20M
     [[[directives]]]
-      -q = ${CYQueueName}
-      -A = ${CYAccountNumber}
-      -l = select=${VerifyObsNodes}:ncpus=${VerifyObsPEPerNode}:mpiprocs=${VerifyObsPEPerNode}
+      -q = ${CPQueueName}
+      -A = ${CPAccountNumber}
+      -l = select=1:ncpus=36:mpiprocs=36
   [[CyclingDAFinished]]
     [[[job]]]
       batch system = background
@@ -490,15 +493,14 @@ cat >! suite.rc << EOF
     [[[job]]]
       execution time limit = PT5M
       execution retry delays = ${InitializationRetry}
-    [[[directives]]]
-      -q = share
-      -l = select=1:ncpus=1:mpiprocs=1
   [[GenerateColdStartIC]]
     script = \$origin/GenerateColdStartIC.csh
     [[[job]]]
       execution time limit = PT${InitICJobMinutes}M
       execution retry delays = ${InitializationRetry}
     [[[directives]]]
+      -q = ${CPQueueName}
+      -A = ${CPAccountNumber}
       -l = select=${InitICNodes}:ncpus=${InitICPEPerNode}:mpiprocs=${InitICPEPerNode}
   [[ColdStartFC]]
     inherit = CyclingFCBase
@@ -524,7 +526,9 @@ cat >! suite.rc << EOF
       execution time limit = PT5M
     [[[directives]]]
       -m = ae
-      -q = ${VFQueueName}
+      -q = ${NCPQueueName}
+      -A = ${NCPAccountNumber}
+      -l = select=1:ncpus=36:mpiprocs=36
   [[ExtendedMeanFC]]
     inherit = ExtendedFCBase
     script = \$origin/ExtendedMeanFC.csh "1"
@@ -535,7 +539,7 @@ cat >! suite.rc << EOF
 {% for dt in ExtendedFCLengths %}
   [[HofXMeanFC{{dt}}hr]]
     inherit = HofXMeanFC
-    env-script = cd ${mainScriptDir}; ./PrepJEDIHofXMeanFC.csh "1" "{{dt}}" "FC" "{{PreprocessObs}}"
+    env-script = cd ${mainScriptDir}; ./PrepJEDIHofXMeanFC.csh "1" "{{dt}}" "FC"
     script = \$origin/HofXMeanFC.csh "1" "{{dt}}" "FC"
     [[[job]]]
       execution retry delays = ${HofXRetry}
@@ -570,7 +574,7 @@ cat >! suite.rc << EOF
   {% for state in ['BG', 'AN']%}
   [[HofX{{state}}{{mem}}]]
     inherit = HofX{{state}}
-    env-script = cd ${mainScriptDir}; ./PrepJEDIHofX{{state}}.csh "{{mem}}" "0" "{{state}}" "{{PreprocessObs}}"
+    env-script = cd ${mainScriptDir}; ./PrepJEDIHofX{{state}}.csh "{{mem}}" "0" "{{state}}"
     script = \$origin/HofX{{state}}.csh "{{mem}}" "0" "{{state}}"
     [[[job]]]
       execution retry delays = ${HofXRetry}
@@ -601,7 +605,7 @@ cat >! suite.rc << EOF
   {% for dt in ExtendedFCLengths %}
   [[HofXEnsFC{{mem}}-{{dt}}hr]]
     inherit = HofXEnsFC{{mem}}
-    env-script = cd ${mainScriptDir}; ./PrepJEDIHofXEnsFC.csh "{{mem}}" "{{dt}}" "FC" "{{PreprocessObs}}"
+    env-script = cd ${mainScriptDir}; ./PrepJEDIHofXEnsFC.csh "{{mem}}" "{{dt}}" "FC"
     script = \$origin/HofXEnsFC.csh "{{mem}}" "{{dt}}" "FC"
     [[[job]]]
       execution retry delays = ${HofXRetry}
@@ -623,10 +627,12 @@ cat >! suite.rc << EOF
       execution time limit = PT5M
     [[[directives]]]
       -m = ae
-      -q = ${VFQueueName}
+      -q = ${NCPQueueName}
+      -A = ${NCPAccountNumber}
+      -l = select=1:ncpus=36:mpiprocs=36
   [[HofXEnsMeanBG]]
     inherit = HofXBase
-    env-script = cd ${mainScriptDir}; ./PrepJEDIHofXEnsMeanBG.csh "1" "0" "BG" "{{PreprocessObs}}"
+    env-script = cd ${mainScriptDir}; ./PrepJEDIHofXEnsMeanBG.csh "1" "0" "BG"
     script = \$origin/HofXEnsMeanBG.csh "1" "0" "BG"
     [[[directives]]]
       -q = ${EnsMeanBGQueueName}

--- a/drive.csh
+++ b/drive.csh
@@ -418,7 +418,12 @@ cat >! suite.rc << EOF
     [[[job]]]
       execution time limit = PT10M
       execution retry delays = ${InitializationRetry}
+    # currently ObstoIODA has to be on Cheyenne, because ioda-upgrade.x is built there
+    # TODO: build ioda-upgrade.x on casper, remove CP directives below
     [[[directives]]]
+      -m = ae
+      -q = ${CPQueueName}
+      -A = ${CPAccountNumber}
       -l = select=1:ncpus=1:mem=109GB
   # variational-related components
   [[InitCyclingDA]]
@@ -493,6 +498,11 @@ cat >! suite.rc << EOF
     [[[job]]]
       execution time limit = PT5M
       execution retry delays = ${InitializationRetry}
+    # currently UngribColdStartIC has to be on Cheyenne, because ungrib.exe is built there
+    # TODO: build ungrib.exe on casper, remove CP directives below
+    [[[directives]]]
+      -q = ${CPQueueName}
+      -A = ${CPAccountNumber}
   [[GenerateColdStartIC]]
     script = \$origin/GenerateColdStartIC.csh
     [[[job]]]


### PR DESCRIPTION
### Description
Many changes with job accounting.  Single-processor jobs are moved to casper, which avoids an issue in develop with the share queue on Cheyenne.  There are two exceptions, which are submitted using Critical Path settings (see below):
1. `UngribColdStartIC` uses `ungrib.exe`, compiled on Cheyenne.  We need to compile `ungrib.exe` (part of WPS) on Casper.
2. `ObstoIODA` uses `ioda-upgrade.x`, compiled on Cheyenne.  We need to compile `ioda-upgrade.x` (part of mpas-bundle) on Casper.

Account number and queue name are identified for three kinds of jobs: Critical Path (CP), Non-Critical Path (NCP), and single processor (SingleProc).  SingleProc is now used for the default `directives` under the `root` cylc task.  As a result, all multi-processor tasks now have their account and queue name specified explicitly.

Tasks for which the same number of processors and nodes as used for all model meshes (`VerifyObsBase`, `VerifyModelBase`, and `ObstoIODA`) have their process and node counts specified in drive.csh instead of under `config/mpas/*/job.csh`.

Unrelated, but included in this PR: the `PreprocessObs` variable is moved to `config/experiment.csh`, which reduces the number of places that it is referenced.

### Issue closed
Closes #66 

### Tests completed
 - WarmStart
   - [x] OIE120km 3dvar, 2 cycles
   - [x] OIE120km 3denvar, 2 cycles
   - [x] OIE120km eda_3denvar, 2 cycles
   - [x] O30kmIE60km 3denvar, 2 cycles
 - ColdStart
   - [x] OIE120km 3dvar, 2 cycles, PreprocessObs=True

Note: (OIE120km 3dvar, 2 cycles, PreprocessObs=False) fails due to a mismatch in IRVISlandCoeff, which needs to be IGBP for cold-start cycling.  Although `config_landuse_data` in namelist.init_atmosphere is set to `USGS` during `GenerateColdStartIC`, the cold-start output file (`x1.40962.init.2018-04-14_18.00.00.nc`) has `mminlu` set as `MODIFIED_IGBP_MODIS_NOAH`.  Solution TBD in a future PR.