### PR TITLE
Update workflow for new diagnostics

### DIFF
--- a/config/mpas/O30kmIE120km/job.csh
+++ b/config/mpas/O30kmIE120km/job.csh
@@ -32,11 +32,11 @@ setenv HofXPEPerNode 36
 setenv HofXMemory 109
 
 # ~8-12 min. for VerifyObsDA, ~5 min. for VerifyObsBG
-set DeterministicVerifyObsJobMinutes = 15
+set DeterministicVerifyObsJobMinutes = 10
 set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
 
 # 3 min. premium per 20 members for VerifyObsEnsMean
-set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 9
+set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 120
 @ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} * ${EnsembleVerifyObsEnsMeanJobSecondsPerMember} / 60
 @ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
 

--- a/config/mpas/O30kmIE60km/job.csh
+++ b/config/mpas/O30kmIE60km/job.csh
@@ -15,7 +15,7 @@ setenv InitICPEPerNode 36
 setenv CyclingFCNodes 16
 setenv CyclingFCPEPerNode 32
 
-@ ExtendedFCJobMinutes = 1 + ($ExtendedFCWindowHR / 4)
+@ ExtendedFCJobMinutes = 1 + (6 * $ExtendedFCWindowHR / 6)
 setenv ExtendedFCNodes ${CyclingFCNodes}
 setenv ExtendedFCPEPerNode ${CyclingFCPEPerNode}
 
@@ -32,11 +32,11 @@ setenv HofXPEPerNode 36
 setenv HofXMemory 109
 
 # ~8-12 min. for VerifyObsDA, ~5 min. for VerifyObsBG
-set DeterministicVerifyObsJobMinutes = 15
+set DeterministicVerifyObsJobMinutes = 10
 set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
 
 # 3 min. premium per 20 members for VerifyObsEnsMean
-set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 9
+set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 120
 @ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} * ${EnsembleVerifyObsEnsMeanJobSecondsPerMember} / 60
 @ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
 
@@ -44,7 +44,7 @@ setenv VerifyModelJobMinutes 20
 
 # benchmark: < 20 minutes
 # longer duration with more observations
-set DeterministicDABaseMinutes = 20
+set DeterministicDABaseMinutes = 40
 
 # wall-time increase per member in ensemble B
 # TODO: run tests w/ > 20 members

--- a/config/mpas/OIE120km/job.csh
+++ b/config/mpas/OIE120km/job.csh
@@ -26,11 +26,11 @@ setenv HofXPEPerNode 36
 setenv HofXMemory 109
 
 # ~8-12 min. for VerifyObsDA, ~5 min. for VerifyObsBG; 08OCT2021
-set DeterministicVerifyObsJobMinutes = 15
+set DeterministicVerifyObsJobMinutes = 10
 set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
 
 # ~180 sec. premium per 20 members for VerifyObsEnsMean; 08OCT2021
-set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 9
+set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 120
 @ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} * ${EnsembleVerifyObsEnsMeanJobSecondsPerMember} / 60
 @ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
 

--- a/config/mpas/OIE30km/job.csh
+++ b/config/mpas/OIE30km/job.csh
@@ -23,9 +23,10 @@ setenv HofXNodes 32
 setenv HofXPEPerNode 16
 setenv HofXMemory 109
 
-set DeterministicVerifyObsJobMinutes = 5
+set DeterministicVerifyObsJobMinutes = 10
 set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
-set EnsembleVerifyObsEnsMeanMembersPerJobMinute = 10
+
+set EnsembleVerifyObsEnsMeanMembersPerJobMinute = 120
 @ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} / ${EnsembleVerifyObsEnsMeanMembersPerJobMinute}
 @ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
 

--- a/config/mpas/OIE60km/job.csh
+++ b/config/mpas/OIE60km/job.csh
@@ -26,11 +26,11 @@ setenv HofXPEPerNode 36
 setenv HofXMemory 109
 
 # ~?-? min. for VerifyObsDA, ~? min. for VerifyObsBG
-set DeterministicVerifyObsJobMinutes = 15
+set DeterministicVerifyObsJobMinutes = 10
 set VerifyObsJobMinutes = ${DeterministicVerifyObsJobMinutes}
 
 # ? min. premium per 20 members for VerifyObsEnsMean
-set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 9
+set EnsembleVerifyObsEnsMeanJobSecondsPerMember = 120
 @ VerifyObsEnsMeanJobMinutes = ${nEnsDAMembers} * ${EnsembleVerifyObsEnsMeanJobSecondsPerMember} / 60
 @ VerifyObsEnsMeanJobMinutes = ${VerifyObsEnsMeanJobMinutes} + ${DeterministicVerifyObsJobMinutes}
 
@@ -47,7 +47,8 @@ setenv VerifyModelJobMinutes 8
 # 384pe: 8-8.5 min., 234 GB memory
 # benchmark: < 9 minutes
 # longer duration with more observations
-set DeterministicDABaseMinutes = 13
+#set DeterministicDABaseMinutes = 13
+set DeterministicDABaseMinutes = 40
 
 # Variational
 setenv VariationalMemory 45
@@ -110,9 +111,10 @@ setenv VariationalPEPerNode 32
 # 80-members: 819-890 sec., 218-221 GB memory, ~132-145 sec. for Localization::multiply
 # 110 sec. premium per 20 members
 
-# note: more memory needed for all-sky experiments due to hydrometeor increment variables,
+# note1: more memory needed for all-sky experiments due to hydrometeor increment variables,
 # ~290GB for 20-member 3DEnVar.  Either increase memory or change Nodes and PE.
-#setenv VariationalMemory 109
+# note2: more memory needed for 80-member EDA, >52GB per node with 32 PE per node
+setenv VariationalMemory 109
 
 set ThreeDEnVarJobSecondsPerMember = 7
 
@@ -166,7 +168,10 @@ setenv EnsOfVariationalNodes $EnsOfVariationalNodes
 # inflation, e.g., RTPP
 setenv CyclingInflationJobMinutes 25
 setenv CyclingInflationMemory 109
-setenv CyclingInflationNodes ${HofXNodes}
-setenv CyclingInflationPEPerNode ${HofXPEPerNode}
+#setenv CyclingInflationNodes ${HofXNodes}
+#setenv CyclingInflationPEPerNode ${HofXPEPerNode}
+# note: need more memory for more members, XXGB per member
+setenv CyclingInflationNodes 3
+setenv CyclingInflationPEPerNode 12
 
 

--- a/verifymodel.csh
+++ b/verifymodel.csh
@@ -73,12 +73,15 @@ ln -sf ${bgFileOther} ../restart.$thisMPASFileDate.nc
 
 ln -fs ${pyModelDir}/*.py ./
 
-set mainScript = writediagstats_modelspace
+set mainScript = DiagnoseModelStatistics
+
 ln -fs ${pyModelDir}/${mainScript}.py ./
+set NUMPROC=`cat $PBS_NODEFILE | wc -l`
+
 set success = 1
 while ( $success != 0 )
   mv log.$mainScript log.${mainScript}_LAST
-  setenv baseCommand "python ${mainScript}.py ${thisValidDate} -r $GFSAnaDirVerify/$InitFilePrefixOuter"
+  setenv baseCommand "python ${mainScript}.py ${thisValidDate} -n ${NUMPROC} -r $GFSAnaDirVerify/$InitFilePrefixOuter"
   echo "${baseCommand}" | tee ./myCommand
   ${baseCommand} >& log.$mainScript
   set success = $?


### PR DESCRIPTION
### Description
Timings and model-space diagnostic execution signature are updated corresponding to https://github.com/JCSDA-internal/mpas-jedi/pull/704.

The primary change is that `DiagnoseModelStatistics.py` replaces `writediagstats_modelspace.py`.  The ensemble obs-space verification has a higher wall-time per member than before, while the single-member obs-space verification has lower wall-time.  That is caused by the new code spending more time in the IODA file reading step for more than one member, while the actual binning is parallelized, reducing masking and computation wall-time.

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
