### PR TITLE
Use braced sed substitution strings for YAMLS

### DIFF
--- a/PrepJEDI.csh
+++ b/PrepJEDI.csh
@@ -283,23 +283,36 @@ if ($found == 0) then
   exit 1
 endif
 
-# (ii) concatenate all observations to thisYAML
-cat $observationsYAML >> $thisYAML
-
-# (iii) add re-usable YAML anchors
-set obsanchorssed = ObsAnchors
-set thisSEDF = ${obsanchorssed}SEDF.yaml
+# (ii) insert Observations
+set sedstring = Observations
+set thisSEDF = ${sedstring}SEDF.yaml
 cat >! ${thisSEDF} << EOF
-/${obsanchorssed}/c\
+/{{${sedstring}}}/c\
 EOF
 
 # substitute with line breaks
-set SUBYAML=${ConfigDir}/ObsPlugs/${self_AppType}/${obsanchorssed}.yaml
+sed 's@$@\\@' ${observationsYAML} >> ${thisSEDF}
+
+# insert into prevYAML
+set thisYAML = insert${sedstring}.yaml
+sed -f ${thisSEDF} $prevYAML >! $thisYAML
+rm ${thisSEDF}
+set prevYAML = $thisYAML
+
+# (iii) insert re-usable YAML anchors
+set sedstring = ObsAnchors
+set thisSEDF = ${sedstring}SEDF.yaml
+cat >! ${thisSEDF} << EOF
+/{{${sedstring}}}/c\
+EOF
+
+# substitute with line breaks
+set SUBYAML=${ConfigDir}/ObsPlugs/${self_AppType}/${sedstring}.yaml
 sed 's@$@\\@' ${SUBYAML} >> ${thisSEDF}
 echo '_blank: null' >> ${thisSEDF}
 
 # insert into prevYAML
-set thisYAML = insertObsAnchors.yaml
+set thisYAML = insert${sedstring}.yaml
 sed -f ${thisSEDF} $prevYAML >! $thisYAML
 rm ${thisSEDF}
 set prevYAML = $thisYAML

--- a/PrepJEDI.csh
+++ b/PrepJEDI.csh
@@ -306,12 +306,11 @@ set prevYAML = $thisYAML
 
 
 ## Horizontal interpolation type
-sed -i 's@InterpolationType@'${InterpolationType}'@g' $thisYAML
+sed -i 's@{{InterpolationType}}@'${InterpolationType}'@g' $thisYAML
 
 
 ## QC characteristics
-sed -i 's@RADTHINDISTANCE@'${RADTHINDISTANCE}'@g' $thisYAML
-sed -i 's@RADTHINAMOUNT@'${RADTHINAMOUNT}'@g' $thisYAML
+sed -i 's@{{RADTHINDISTANCE}}@'${RADTHINDISTANCE}'@g' $thisYAML
 
 # need to change to mainScriptDir for getObservationsOrNone to work
 cd ${mainScriptDir}
@@ -320,13 +319,13 @@ set AHISuperObGrid = "`$getObservationsOrNone ${observations__resource}.IODASupe
 cd ${self_WorkDir}
 
 if ("$ABISuperObGrid" != None) then
-  sed -i 's@ABISUPEROBGRID@'${ABISuperObGrid}'@g' $thisYAML
+  sed -i 's@{{ABISUPEROBGRID}}@'${ABISuperObGrid}'@g' $thisYAML
 endif
 if ("$AHISuperObGrid" != None) then
-  sed -i 's@AHISUPEROBGRID@'${AHISuperObGrid}'@g' $thisYAML
+  sed -i 's@{{AHISUPEROBGRID}}@'${AHISuperObGrid}'@g' $thisYAML
 endif
 
-sed -i 's@HofXMeshDescriptor@'${HofXMeshDescriptor}'@' $thisYAML
+sed -i 's@{{HofXMeshDescriptor}}@'${HofXMeshDescriptor}'@' $thisYAML
 
 
 ## date-time information
@@ -344,31 +343,31 @@ sed -i 's@{{windowBegin}}@'${halfprevISO8601Date}'@' $thisYAML
 
 ## obs-related file naming
 # crtm tables
-sed -i 's@CRTMTABLES@'${CRTMTABLES}'@g' $thisYAML
+sed -i 's@{{CRTMTABLES}}@'${CRTMTABLES}'@g' $thisYAML
 
 # input and output IODA DB directories
-sed -i 's@InDBDir@'${self_WorkDir}'/'${InDBDir}'@g' $thisYAML
-sed -i 's@OutDBDir@'${self_WorkDir}'/'${OutDBDir}'@g' $thisYAML
+sed -i 's@{{InDBDir}}@'${self_WorkDir}'/'${InDBDir}'@g' $thisYAML
+sed -i 's@{{OutDBDir}}@'${self_WorkDir}'/'${OutDBDir}'@g' $thisYAML
 
 # obs, geo, and diag files with self_AppType suffixes
-sed -i 's@obsPrefix@'${obsPrefix}'_'${self_AppType}'@g' $thisYAML
-sed -i 's@geoPrefix@'${geoPrefix}'_'${self_AppType}'@g' $thisYAML
-sed -i 's@diagPrefix@'${diagPrefix}'_'${self_AppType}'@g' $thisYAML
+sed -i 's@{{obsPrefix}}@'${obsPrefix}'_'${self_AppType}'@g' $thisYAML
+sed -i 's@{{geoPrefix}}@'${geoPrefix}'_'${self_AppType}'@g' $thisYAML
+sed -i 's@{{diagPrefix}}@'${diagPrefix}'_'${self_AppType}'@g' $thisYAML
 
 
 # (3) model-related substitutions
 # ===============================
 
 # bg file
-sed -i 's@bgStatePrefix@'${BGFilePrefix}'@g' $thisYAML
-sed -i 's@bgStateDir@'${self_WorkDir}'/'${bgDir}'@g' $thisYAML
+sed -i 's@{{bgStatePrefix}}@'${BGFilePrefix}'@g' $thisYAML
+sed -i 's@{{bgStateDir}}@'${self_WorkDir}'/'${bgDir}'@g' $thisYAML
 
 # streams+namelist
 set iMesh = 0
 foreach mesh ($MeshList)
   @ iMesh++
-  sed -i 's@'$mesh'StreamsFile@'${self_WorkDir}'/'$StreamsFileList[$iMesh]'@' $thisYAML
-  sed -i 's@'$mesh'NamelistFile@'${self_WorkDir}'/'$NamelistFileList[$iMesh]'@' $thisYAML
+  sed -i 's@{{'$mesh'StreamsFile}}@'${self_WorkDir}'/'$StreamsFileList[$iMesh]'@' $thisYAML
+  sed -i 's@{{'$mesh'NamelistFile}}@'${self_WorkDir}'/'$NamelistFileList[$iMesh]'@' $thisYAML
 end
 
 ## model and analysis variables
@@ -402,7 +401,7 @@ foreach VarGroup (Analysis Model State)
   end
   # remove trailing comma
   set VarSub = `echo "$VarSub" | sed 's/.$//'`
-  sed -i 's@'$VarGroup'Variables@'$VarSub'@' $thisYAML
+  sed -i 's@{{'$VarGroup'Variables}}@'$VarSub'@' $thisYAML
 end
 
 cp $thisYAML $appyaml

--- a/PrepVariational.csh
+++ b/PrepVariational.csh
@@ -67,6 +67,8 @@ rm ${localStaticFieldsPrefix}*.nc*
 # ========================================
 # Member-dependent Observation Directories
 # ========================================
+#TODO: Change behavior to always using member-specific directories
+#      instead of only for EDA.  Will make EDA omb/oma verification easier.
 set member = 1
 while ( $member <= ${nEnsDAMembers} )
   set memDir = `${memberDir} $DAType $member`
@@ -164,8 +166,8 @@ set prevYAML = $thisYAML
 
 # Analysis directory
 # ==================
-sed -i 's@anStatePrefix@'${ANFilePrefix}'@g' $prevYAML
-sed -i 's@anStateDir@'${self_WorkDir}'/'${anDir}'@g' $prevYAML
+sed -i 's@{{anStatePrefix}}@'${ANFilePrefix}'@g' $prevYAML
+sed -i 's@{{anStateDir}}@'${self_WorkDir}'/'${anDir}'@g' $prevYAML
 
 
 # Hybrid Jb weights
@@ -245,7 +247,7 @@ if ( "$DAType" =~ *"envar"* || "$DAType" =~ *"hybrid"* ) then
   #      temperature to be in stream_list.atmosphere.control.
 
   cat >! ${thisSEDF} << EOF
-/${enspbinfsed}/c\
+/{{${enspbinfsed}}}/c\
 ${indentPb}inflation field:\
 ${indentPb}  date: *analysisDate\
 ${indentPb}  filename: ${inflationFields}\
@@ -260,7 +262,7 @@ EOF
   endif
   if ($removeInflation > 0) then
     # delete the line containing $enspbinfsed
-    sed -i '/^'${enspbinfsed}'/d' $prevYAML
+    sed -i '/^{{'${enspbinfsed}'}}/d' $prevYAML
   endif
 endif
 
@@ -322,15 +324,17 @@ while ( $member <= ${nEnsDAMembers} )
 
   # member-specific state I/O and observation file output directory
   set memDir = `${memberDir} $DAType $member`
-  sed -i 's@OOPSMemberDir@'${memDir}'@g' $memberyaml
+  sed -i 's@{{MemberDir}}@'${memDir}'@g' $memberyaml
 
-  # first EDA member and deterministic EnVar do not perturb observations
-  if ($member == 1) then
-    sed -i 's@ObsPerturbations@false@g' $memberyaml
+  # deterministic EnVar does not perturb observations
+  if ($nEnsDAMembers == 1) then
+    sed -i 's@{{ObsPerturbations}}@false@g' $memberyaml
   else
-    sed -i 's@ObsPerturbations@true@g' $memberyaml
+    sed -i 's@{{ObsPerturbations}}@true@g' $memberyaml
   endif
-  sed -i 's@MemberSeed@'$member'@g' $memberyaml
+
+  sed -i 's@{{MemberNumber}}@'$member'@g' $memberyaml
+  sed -i 's@{{TotalMemberCount}}@'${nEnsDAMembers}'@g' $memberyaml
 
   @ member++
 end
@@ -437,6 +441,11 @@ while ( $member <= ${nEnsDAMembers} )
     set FirstCyclingFCDir = ${CyclingFCWorkDir}/${FirstCycleDate}${memDir}/Inner
     cp -v ${FirstCyclingFCDir}/${self_StatePrefix}.${nextFirstFileDate}.nc $tFile
     # modify xtime
+    # TODO: handle errors from python executions, e.g.:
+    # '''
+    #     import netCDF4 as nc
+    # ImportError: No module named netCDF4
+    # '''
     echo "${updateXTIME} $tFile ${thisCycleDate}"
     ${updateXTIME} $tFile ${thisCycleDate}
   endif
@@ -448,7 +457,7 @@ while ( $member <= ${nEnsDAMembers} )
     sed -i 's@TemplateFieldsMember@'${memSuffix}'@' ${StreamsFile_}${memSuffix}
     sed -i 's@analysisPrecision@'${analysisPrecision}'@' ${StreamsFile_}${memSuffix}
   end
-  sed -i 's@StreamsFileMember@'${memSuffix}'@' $yamlFileList[$member]
+  sed -i 's@{{StreamsFileMember}}@'${memSuffix}'@' $yamlFileList[$member]
 
   # Remove existing analysis file, make full copy from bg file
   # ==========================================================

--- a/PrepVariational.csh
+++ b/PrepVariational.csh
@@ -96,10 +96,10 @@ set prevYAML = prevPrep.yaml
 # Outer iterations configuration elements
 # ===========================================
 # performs sed substitution for VariationalIterations
-set iterationssed = VariationalIterations
-set thisSEDF = ${iterationssed}SEDF.yaml
+set sedstring = VariationalIterations
+set thisSEDF = ${sedstring}SEDF.yaml
 cat >! ${thisSEDF} << EOF
-/${iterationssed}/c\
+/${sedstring}/c\
 EOF
 
 set nIterationsIndent = 2
@@ -128,7 +128,7 @@ EOF
 
 end
 
-set thisYAML = insertIterations.yaml
+set thisYAML = insert${sedstring}.yaml
 sed -f ${thisSEDF} $prevYAML >! $thisYAML
 rm ${thisSEDF}
 set prevYAML = $thisYAML
@@ -137,10 +137,10 @@ set prevYAML = $thisYAML
 # Minimization algorithm configuration element
 # ================================================
 # performs sed substitution for VariationalMinimizer
-set algorithmsed = VariationalMinimizer
-set thisSEDF = ${algorithmsed}SEDF.yaml
+set sedstring = VariationalMinimizer
+set thisSEDF = ${sedstring}SEDF.yaml
 cat >! ${thisSEDF} << EOF
-/${algorithmsed}/c\
+/${sedstring}/c\
 EOF
 
 set nAlgorithmIndent = 4
@@ -158,7 +158,7 @@ EOF
 
 endif
 
-set thisYAML = insertAlgorithm.yaml
+set thisYAML = insert${sedstring}.yaml
 sed -f ${thisSEDF} $prevYAML >! $thisYAML
 rm ${thisSEDF}
 set prevYAML = $thisYAML
@@ -230,8 +230,8 @@ if ( "$DAType" =~ *"envar"* || "$DAType" =~ *"hybrid"* ) then
 
   ## inflation
   # performs sed substitution for EnsemblePbInflation
-  set enspbinfsed = EnsemblePbInflation
-  set thisSEDF = ${enspbinfsed}SEDF.yaml
+  set sedstring = EnsemblePbInflation
+  set thisSEDF = ${sedstring}SEDF.yaml
   set removeInflation = 0
   if ( ${ABEInflation} == True ) then
     set inflationFields = ${CyclingABEInflationDir}/BT${ABEIChannel}_ABEIlambda.nc
@@ -241,13 +241,13 @@ if ( "$DAType" =~ *"envar"* || "$DAType" =~ *"hybrid"* ) then
       #TODO: use last valid inflation factors?
       set removeInflation = 1
     else
-      set thisYAML = insertInflation.yaml
+      set thisYAML = insert${sedstring}.yaml
   #NOTE: 'stream name: control' allows for spechum and temperature inflation values to be read
   #      read directly from inflationFields without a variable transform. Also requires spechum and
   #      temperature to be in stream_list.atmosphere.control.
 
   cat >! ${thisSEDF} << EOF
-/{{${enspbinfsed}}}/c\
+/{{${sedstring}}}/c\
 ${indentPb}inflation field:\
 ${indentPb}  date: *analysisDate\
 ${indentPb}  filename: ${inflationFields}\
@@ -261,8 +261,8 @@ EOF
     set removeInflation = 1
   endif
   if ($removeInflation > 0) then
-    # delete the line containing $enspbinfsed
-    sed -i '/^{{'${enspbinfsed}'}}/d' $prevYAML
+    # delete the line containing $sedstring
+    sed -i '/^{{'${sedstring}'}}/d' $prevYAML
   endif
 endif
 

--- a/RTPPInflation.csh
+++ b/RTPPInflation.csh
@@ -129,13 +129,13 @@ set thisYAML = orig.yaml
 cp -v ${ConfigDir}/applicationBase/rtpp.yaml $thisYAML
 
 ## RTPP inflation factor
-sed -i 's@RTPPInflationFactor@'${RTPPInflationFactor}'@g' $thisYAML
+sed -i 's@{{RTPPInflationFactor}}@'${RTPPInflationFactor}'@g' $thisYAML
 
 ## streams
-sed -i 's@EnsembleStreamsFile@'${self_WorkDir}'/'${StreamsFile}'@' $thisYAML
+sed -i 's@{{EnsembleStreamsFile}}@'${self_WorkDir}'/'${StreamsFile}'@' $thisYAML
 
 ## namelist
-sed -i 's@EnsembleNamelistFile@'${self_WorkDir}'/'${NamelistFile}'@' $thisYAML
+sed -i 's@{{EnsembleNamelistFile}}@'${self_WorkDir}'/'${NamelistFile}'@' $thisYAML
 
 ## revise current date
 sed -i 's@{{thisISO8601Date}}@'${thisISO8601Date}'@g' $thisYAML
@@ -145,9 +145,9 @@ set meshFile = ${firstANFile}
 ln -sfv $meshFile ${TemplateFieldsFileOuter}
 
 ## file naming
-sed -i 's@OOPSMemberDir@/mem%{member}%@g' $thisYAML
-sed -i 's@anStatePrefix@'${anPrefix}'@g' $thisYAML
-sed -i 's@anStateDir@'${CyclingDAOutDir}'@g' $thisYAML
+sed -i 's@{{MemberDir}}@/mem%{member}%@g' $thisYAML
+sed -i 's@{{anStatePrefix}}@'${anPrefix}'@g' $thisYAML
+sed -i 's@{{anStateDir}}@'${CyclingDAOutDir}'@g' $thisYAML
 set prevYAML = $thisYAML
 
 ## state and analysis variable configs
@@ -181,7 +181,7 @@ foreach VarGroup (Analysis State)
   end
   # remove trailing comma
   set VarSub = `echo "$VarSub" | sed 's/.$//'`
-  sed -i 's@'$VarGroup'Variables@'$VarSub'@' $prevYAML
+  sed -i 's@{{'$VarGroup'Variables}}@'$VarSub'@' $prevYAML
 end
 
 ## fill in ensemble B config and link/copy analysis ensemble members
@@ -198,7 +198,7 @@ foreach PMatrix (Pb Pa)
 
   set enspsed = Ensemble${PMatrix}Members
 cat >! ${enspsed}SEDF.yaml << EOF
-/${enspsed}/c\
+/{{${enspsed}}}/c\
 EOF
 
   set member = 1

--- a/config/ObsPlugs/hofx/ObsAnchors.yaml
+++ b/config/ObsPlugs/hofx/ObsAnchors.yaml
@@ -5,7 +5,7 @@ _obs error diagonal: &ObsErrorDiagonal
 _clear crtm: &clearCRTMObsOperator
   name: CRTM
   SurfaceWindGeoVars: uv
-  Absorbers: [H2O,O3,CO2]
+  Absorbers: [H2O, O3]
   obs options: &CRTMObsOptions
     EndianType: little_endian
     CoefficientPath: {{CRTMTABLES}}
@@ -13,7 +13,7 @@ _clear crtm: &clearCRTMObsOperator
 _cloudy crtm: &cloudyCRTMObsOperator
   name: CRTM
   SurfaceWindGeoVars: uv
-  Absorbers: [H2O,O3,CO2]
+  Absorbers: [H2O, O3]
   Clouds: [Water, Ice, Rain, Snow, Graupel]
   obs options:
     <<: *CRTMObsOptions

--- a/config/ObsPlugs/hofx/ObsAnchors.yaml
+++ b/config/ObsPlugs/hofx/ObsAnchors.yaml
@@ -8,7 +8,7 @@ _clear crtm: &clearCRTMObsOperator
   Absorbers: [H2O,O3,CO2]
   obs options: &CRTMObsOptions
     EndianType: little_endian
-    CoefficientPath: CRTMTABLES
+    CoefficientPath: {{CRTMTABLES}}
     IRVISlandCoeff: USGS
 _cloudy crtm: &cloudyCRTMObsOperator
   name: CRTM
@@ -18,4 +18,4 @@ _cloudy crtm: &cloudyCRTMObsOperator
   obs options:
     <<: *CRTMObsOptions
 _get values: &GetValues
-  interpolation type: InterpolationType
+  interpolation type: {{InterpolationType}}

--- a/config/ObsPlugs/hofx/abi-clr_g16.yaml
+++ b/config/ObsPlugs/hofx/abi-clr_g16.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: abi-clr_g16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/abi_g16_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_abi-clr_g16.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_abi-clr_g16.h5
     simulated variables: [brightness_temperature]
     channels: &clrabi_channels 7-16
   obs error: *ObsErrorDiagonal
@@ -25,9 +25,9 @@
         name: cloud_area_fraction@MetaData
       maxvalue: 0.05
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_abi-clr_g16.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_abi-clr_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_abi-clr_g16.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_abi-clr_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrabi_channels

--- a/config/ObsPlugs/hofx/abi_g16.yaml
+++ b/config/ObsPlugs/hofx/abi_g16.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: abi_g16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/abi_g16_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_abi_g16.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_abi_g16.h5
     simulated variables: [brightness_temperature]
     channels: &abi_channels 7-16
   obs error: *ObsErrorDiagonal
@@ -62,7 +62,7 @@
         name: ObsErrorModelRamp@ObsFunction
         channels: *abi_channels
         options:
-          <<: *abi_g16_SymmCldFitsABISUPEROBGRID-HofXMeshDescriptor
+          <<: *abi_g16_SymmCldFits{{ABISUPEROBGRID}}-{{HofXMeshDescriptor}}
           channels: *abi_channels
           xvar:
             name: SymmCldImpactIR@ObsFunction
@@ -70,9 +70,9 @@
             options:
               channels: *abi_channels
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_abi_g16.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_abi_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_abi_g16.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_abi_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_channels

--- a/config/ObsPlugs/hofx/ahi-clr_himawari8.yaml
+++ b/config/ObsPlugs/hofx/ahi-clr_himawari8.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: ahi-clr_himawari8
     obsdatain:
-      obsfile: InDBDir/ahi_himawari8_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/ahi_himawari8_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_ahi-clr_himawari8.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_ahi-clr_himawari8.h5
     simulated variables: [brightness_temperature]
     channels: &clrahi_channels 7-16
   obs error: *ObsErrorDiagonal
@@ -25,9 +25,9 @@
         name: cloud_area_fraction@MetaData
       maxvalue: 0.05
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_ahi-clr_himawari8.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_ahi-clr_himawari8.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_ahi-clr_himawari8.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_ahi-clr_himawari8.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrahi_channels

--- a/config/ObsPlugs/hofx/ahi_himawari8.yaml
+++ b/config/ObsPlugs/hofx/ahi_himawari8.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: ahi_himawari8
     obsdatain:
-      obsfile: InDBDir/ahi_himawari8_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/ahi_himawari8_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_ahi_himawari8.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_ahi_himawari8.h5
     simulated variables: [brightness_temperature]
     channels: &ahi_channels 7-16
   obs error: *ObsErrorDiagonal
@@ -54,7 +54,7 @@
         name: ObsErrorModelRamp@ObsFunction
         channels: *ahi_channels
         options:
-          <<: *ahi_himawari8_SymmCldFitsAHISUPEROBGRID-HofXMeshDescriptor
+          <<: *ahi_himawari8_SymmCldFits{{AHISUPEROBGRID}}-{{HofXMeshDescriptor}}
           channels: *ahi_channels
           xvar:
             name: SymmCldImpactIR@ObsFunction
@@ -62,9 +62,9 @@
             options:
               channels: *ahi_channels
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_ahi_himawari8.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_ahi_himawari8.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_ahi_himawari8.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_ahi_himawari8.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *ahi_channels

--- a/config/ObsPlugs/hofx/aircraft.yaml
+++ b/config/ObsPlugs/hofx/aircraft.yaml
@@ -2,10 +2,10 @@
     <<: *ObsSpace
     name: Aircraft
     obsdatain:
-      obsfile: InDBDir/aircraft_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/aircraft_obs_{{thisValidDate}}.h5
       max frame size: 40000
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_aircraft.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_aircraft.h5
       max frame size: 40000
     simulated variables: [air_temperature, eastward_wind, northward_wind, specific_humidity]
   obs error: *ObsErrorDiagonal

--- a/config/ObsPlugs/hofx/amsua-cld_aqua.yaml
+++ b/config/ObsPlugs/hofx/amsua-cld_aqua.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_aqua
     obsdatain:
-      obsfile: InDBDir/amsua_aqua_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_aqua_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua-cld_aqua.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_aqua.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_aqua_channels 1-4,15
   obs error: *ObsErrorDiagonal
@@ -31,9 +31,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua-cld_aqua.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_aqua.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_amsua-cld_aqua.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_aqua.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *amsua-cld_aqua_channels

--- a/config/ObsPlugs/hofx/amsua-cld_metop-a.yaml
+++ b/config/ObsPlugs/hofx/amsua-cld_metop-a.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_metop-a
     obsdatain:
-      obsfile: InDBDir/amsua_metop-a_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_metop-a_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua-cld_metop-a.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_metop-a.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_metop-a_channels 1-4,15
   obs error: *ObsErrorDiagonal
@@ -31,9 +31,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua-cld_metop-a.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_metop-a.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_amsua-cld_metop-a.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_metop-a.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *amsua-cld_metop-a_channels

--- a/config/ObsPlugs/hofx/amsua-cld_metop-b.yaml
+++ b/config/ObsPlugs/hofx/amsua-cld_metop-b.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_metop-b
     obsdatain:
-      obsfile: InDBDir/amsua_metop-b_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_metop-b_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua-cld_metop-b.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_metop-b.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_metop-b_channels 1-4,15
   obs error: *ObsErrorDiagonal
@@ -31,9 +31,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua-cld_metop-b.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_metop-b.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_amsua-cld_metop-b.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_metop-b.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *amsua-cld_metop-b_channels

--- a/config/ObsPlugs/hofx/amsua-cld_n15.yaml
+++ b/config/ObsPlugs/hofx/amsua-cld_n15.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_n15
     obsdatain:
-      obsfile: InDBDir/amsua_n15_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n15_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua-cld_n15.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_n15.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_n15_channels 1-4,15
   obs error: *ObsErrorDiagonal
@@ -31,9 +31,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua-cld_n15.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_n15.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_amsua-cld_n15.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_n15.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *amsua-cld_n15_channels

--- a/config/ObsPlugs/hofx/amsua-cld_n18.yaml
+++ b/config/ObsPlugs/hofx/amsua-cld_n18.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_n18
     obsdatain:
-      obsfile: InDBDir/amsua_n18_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n18_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua-cld_n18.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_n18.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_n18_channels 1-4,15
   obs error: *ObsErrorDiagonal
@@ -31,9 +31,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua-cld_n18.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_n18.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_amsua-cld_n18.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_n18.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *amsua-cld_n18_channels

--- a/config/ObsPlugs/hofx/amsua-cld_n19.yaml
+++ b/config/ObsPlugs/hofx/amsua-cld_n19.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_n19
     obsdatain:
-      obsfile: InDBDir/amsua_n19_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n19_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua-cld_n19.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_n19.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_n19_channels 1-4,15
   obs error: *ObsErrorDiagonal
@@ -31,9 +31,9 @@
 #    minvalue: 170.0
 #    maxvalue: 300.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua-cld_n19.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_n19.nc4
   - filter: YDIAGsaver
-    filename: OutDBDir/diagPrefix_amsua-cld_n19.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_n19.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *amsua-cld_n19_channels

--- a/config/ObsPlugs/hofx/amsua_aqua.yaml
+++ b/config/ObsPlugs/hofx/amsua_aqua.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_aqua
     obsdatain:
-      obsfile: InDBDir/amsua_aqua_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_aqua_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua_aqua.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_aqua.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_aqua_channels 5-14
   obs error: *ObsErrorDiagonal
@@ -27,4 +27,4 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua_aqua.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_aqua.nc4

--- a/config/ObsPlugs/hofx/amsua_metop-a.yaml
+++ b/config/ObsPlugs/hofx/amsua_metop-a.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_metop-a
     obsdatain:
-      obsfile: InDBDir/amsua_metop-a_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_metop-a_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua_metop-a.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_metop-a.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_metop-a_channels 5-14
   obs error: *ObsErrorDiagonal
@@ -27,4 +27,4 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua_metop-a.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_metop-a.nc4

--- a/config/ObsPlugs/hofx/amsua_metop-b.yaml
+++ b/config/ObsPlugs/hofx/amsua_metop-b.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_metop-b
     obsdatain:
-      obsfile: InDBDir/amsua_metop-b_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_metop-b_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua_metop-b.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_metop-b.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_metop-b_channels 5-14
   obs error: *ObsErrorDiagonal
@@ -27,4 +27,4 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua_metop-b.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_metop-b.nc4

--- a/config/ObsPlugs/hofx/amsua_n15.yaml
+++ b/config/ObsPlugs/hofx/amsua_n15.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_n15
     obsdatain:
-      obsfile: InDBDir/amsua_n15_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n15_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua_n15.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_n15.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_n15_channels 5-14
   obs error: *ObsErrorDiagonal
@@ -27,4 +27,4 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua_n15.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_n15.nc4

--- a/config/ObsPlugs/hofx/amsua_n18.yaml
+++ b/config/ObsPlugs/hofx/amsua_n18.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_n18
     obsdatain:
-      obsfile: InDBDir/amsua_n18_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n18_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua_n18.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_n18.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_n18_channels 5-14
   obs error: *ObsErrorDiagonal
@@ -27,4 +27,4 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua_n18.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_n18.nc4

--- a/config/ObsPlugs/hofx/amsua_n19.yaml
+++ b/config/ObsPlugs/hofx/amsua_n19.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_n19
     obsdatain:
-      obsfile: InDBDir/amsua_n19_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n19_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_amsua_n19.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_n19.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_n19_channels 5-14
   obs error: *ObsErrorDiagonal
@@ -27,4 +27,4 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_amsua_n19.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_n19.nc4

--- a/config/ObsPlugs/hofx/gnssroref.yaml
+++ b/config/ObsPlugs/hofx/gnssroref.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: GnssroRef
     obsdatain:
-      obsfile: InDBDir/gnssroref_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/gnssroref_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_gnssroref.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_gnssroref.h5
     simulated variables: [refractivity]
   obs error: *ObsErrorDiagonal
   obs operator:

--- a/config/ObsPlugs/hofx/mhs_metop-a.yaml
+++ b/config/ObsPlugs/hofx/mhs_metop-a.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: mhs_metop-a
     obsdatain:
-      obsfile: InDBDir/mhs_metop-a_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/mhs_metop-a_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_mhs_metop-a.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_mhs_metop-a.h5
     simulated variables: [brightness_temperature]
     channels: &mhs_metop-a_channels 1-5
   obs error: *ObsErrorDiagonal
@@ -27,9 +27,9 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_mhs_metop-a.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_metop-a.nc4
   - filter: YDIAGsaver 
-    filename: OutDBDir/diagPrefix_mhs_metop-a.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_metop-a.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *mhs_metop-a_channels

--- a/config/ObsPlugs/hofx/mhs_metop-b.yaml
+++ b/config/ObsPlugs/hofx/mhs_metop-b.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: mhs_metop-b
     obsdatain:
-      obsfile: InDBDir/mhs_metop-b_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/mhs_metop-b_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_mhs_metop-b.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_mhs_metop-b.h5
     simulated variables: [brightness_temperature]
     channels: &mhs_metop-b_channels 1-5
   obs error: *ObsErrorDiagonal
@@ -27,9 +27,9 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_mhs_metop-b.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_metop-b.nc4
   - filter: YDIAGsaver 
-    filename: OutDBDir/diagPrefix_mhs_metop-b.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_metop-b.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *mhs_metop-b_channels

--- a/config/ObsPlugs/hofx/mhs_n18.yaml
+++ b/config/ObsPlugs/hofx/mhs_n18.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: mhs_n18
     obsdatain:
-      obsfile: InDBDir/mhs_n18_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/mhs_n18_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_mhs_n18.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_mhs_n18.h5
     simulated variables: [brightness_temperature]
     channels: &mhs_n18_channels 1-5
   obs error: *ObsErrorDiagonal
@@ -27,9 +27,9 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_mhs_n18.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_n18.nc4
   - filter: YDIAGsaver 
-    filename: OutDBDir/diagPrefix_mhs_n18.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_n18.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *mhs_n18_channels

--- a/config/ObsPlugs/hofx/mhs_n19.yaml
+++ b/config/ObsPlugs/hofx/mhs_n19.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: mhs_n19
     obsdatain:
-      obsfile: InDBDir/mhs_n19_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/mhs_n19_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_mhs_n19.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_mhs_n19.h5
     simulated variables: [brightness_temperature]
     channels: &mhs_n19_channels 1-5
   obs error: *ObsErrorDiagonal
@@ -27,9 +27,9 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: GOMsaver
-    filename: OutDBDir/geoPrefix_mhs_n19.nc4
+    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_n19.nc4
   - filter: YDIAGsaver 
-    filename: OutDBDir/diagPrefix_mhs_n19.nc4
+    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_n19.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *mhs_n19_channels

--- a/config/ObsPlugs/hofx/satwind.yaml
+++ b/config/ObsPlugs/hofx/satwind.yaml
@@ -2,10 +2,10 @@
     <<: *ObsSpace
     name: Satwind
     obsdatain:
-      obsfile: InDBDir/satwind_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/satwind_obs_{{thisValidDate}}.h5
       max frame size: 80000
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_satwind.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_satwind.h5
       max frame size: 80000
     simulated variables: [eastward_wind, northward_wind]
   obs error: *ObsErrorDiagonal

--- a/config/ObsPlugs/hofx/sfc.yaml
+++ b/config/ObsPlugs/hofx/sfc.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: SfcPCorrected
     obsdatain:
-      obsfile: InDBDir/sfc_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/sfc_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_sfc.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_sfc.h5
     simulated variables: [surface_pressure]
   obs error: *ObsErrorDiagonal
   obs operator:

--- a/config/ObsPlugs/hofx/sondes-2018043006.yaml
+++ b/config/ObsPlugs/hofx/sondes-2018043006.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: Radiosonde
     obsdatain:
-      obsfile: InDBDir/sondes_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/sondes_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_sondes.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_sondes.h5
     simulated variables: [air_temperature, virtual_temperature, eastward_wind, northward_wind]
   obs error: *ObsErrorDiagonal
   obs operator:

--- a/config/ObsPlugs/hofx/sondes.yaml
+++ b/config/ObsPlugs/hofx/sondes.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: Radiosonde
     obsdatain:
-      obsfile: InDBDir/sondes_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/sondes_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDir/obsPrefix_sondes.h5
+      obsfile: {{OutDBDir}}/{{obsPrefix}}_sondes.h5
     simulated variables: [air_temperature, virtual_temperature, eastward_wind, northward_wind, specific_humidity]
   obs error: *ObsErrorDiagonal
   obs operator:

--- a/config/ObsPlugs/variational/ObsAnchors.yaml
+++ b/config/ObsPlugs/variational/ObsAnchors.yaml
@@ -1,21 +1,25 @@
 _obs space: &ObsSpace
-  obs perturbations seed: MemberSeed
+  obs perturbations seed: 1
 _obs error diagonal: &ObsErrorDiagonal
   covariance model: diagonal
+  # Note: the same 'obs perturbations seed' must be used for all members for the 'zero-mean perturbations' option to work
+  zero-mean perturbations: true
+  member: {{MemberNumber}}
+  number of members: {{TotalMemberCount}}
 _clear crtm: &clearCRTMObsOperator
   name: CRTM
   SurfaceWindGeoVars: uv
-  Absorbers: [H2O,O3,CO2]
+  Absorbers: [H2O,O3]
   linear obs operator:
     Absorbers: [H2O]
   obs options: &CRTMObsOptions
     EndianType: little_endian
-    CoefficientPath: CRTMTABLES
+    CoefficientPath: {{CRTMTABLES}}
     IRVISlandCoeff: USGS
 _cloudy crtm: &cloudyCRTMObsOperator
   name: CRTM
   SurfaceWindGeoVars: uv
-  Absorbers: [H2O,O3,CO2]
+  Absorbers: [H2O,O3]
   Clouds: [Water, Ice, Rain, Snow, Graupel]
   linear obs operator:
     Absorbers: [H2O]
@@ -23,4 +27,6 @@ _cloudy crtm: &cloudyCRTMObsOperator
   obs options:
     <<: *CRTMObsOptions
 _get values: &GetValues
-  interpolation type: InterpolationType
+  interpolation type: {{InterpolationType}}
+_multi iteration filter: &multiIterationFilter
+  apply at iterations: 0,1,2,3,4,5

--- a/config/ObsPlugs/variational/ObsAnchors.yaml
+++ b/config/ObsPlugs/variational/ObsAnchors.yaml
@@ -9,7 +9,7 @@ _obs error diagonal: &ObsErrorDiagonal
 _clear crtm: &clearCRTMObsOperator
   name: CRTM
   SurfaceWindGeoVars: uv
-  Absorbers: [H2O,O3]
+  Absorbers: [H2O, O3]
   linear obs operator:
     Absorbers: [H2O]
   obs options: &CRTMObsOptions
@@ -19,7 +19,7 @@ _clear crtm: &clearCRTMObsOperator
 _cloudy crtm: &cloudyCRTMObsOperator
   name: CRTM
   SurfaceWindGeoVars: uv
-  Absorbers: [H2O,O3]
+  Absorbers: [H2O, O3]
   Clouds: [Water, Ice, Rain, Snow, Graupel]
   linear obs operator:
     Absorbers: [H2O]

--- a/config/ObsPlugs/variational/abi-clr_g16.yaml
+++ b/config/ObsPlugs/variational/abi-clr_g16.yaml
@@ -31,7 +31,7 @@
     horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: Background Check
     threshold: 3.0
-    apply at iterations: 0, 1
+    <<: *multiIterationFilter
   - filter: GOMsaver
     filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_abi-clr_g16.nc4
   - filter: YDIAGsaver

--- a/config/ObsPlugs/variational/abi-clr_g16.yaml
+++ b/config/ObsPlugs/variational/abi-clr_g16.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: abi-clr_g16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/abi_g16_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_abi-clr_g16.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_abi-clr_g16.h5
     simulated variables: [brightness_temperature]
     channels: &clrabi_channels 8-10
   obs error: *ObsErrorDiagonal
@@ -28,14 +28,14 @@
 #        name: water_area_fraction@GeoVaLs
 #      minvalue: 1.0
   - filter: Gaussian Thinning
-    horizontal_mesh: RADTHINDISTANCE #km
+    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: Background Check
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_abi-clr_g16.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_abi-clr_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_abi-clr_g16.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{diagPrefix}}_abi-clr_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrabi_channels

--- a/config/ObsPlugs/variational/abi_g16.yaml
+++ b/config/ObsPlugs/variational/abi_g16.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: abi_g16
     obsdatain:
-      obsfile: InDBDir/abi_g16_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/abi_g16_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_abi_g16.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_abi_g16.h5
     simulated variables: [brightness_temperature]
     channels: &abi_g16_channels 8-10
   obs error: *ObsErrorDiagonal
@@ -22,7 +22,7 @@
         name: sensor_zenith_angle@MetaData
       maxvalue: 65.0
   - filter: Gaussian Thinning
-    horizontal_mesh: RADTHINDISTANCE #km
+    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: Perform Action
     apply at iterations: 0, 1, 2, 3, 4, 5
     filter variables:
@@ -75,7 +75,7 @@
         name: ObsErrorModelRamp@ObsFunction
         channels: *abi_g16_channels
         options:
-          <<: *abi_g16_SymmCldFitsABISUPEROBGRID-HofXMeshDescriptor
+          <<: *abi_g16_SymmCldFits{{ABISUPEROBGRID}}-{{HofXMeshDescriptor}}
           channels: *abi_g16_channels
           xvar:
             name: SymmCldImpactIR@ObsFunction
@@ -103,9 +103,9 @@
 #      name: assign error
 #      error parameter: 1000.0
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_abi_g16.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_abi_g16.nc4
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_abi_g16.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{diagPrefix}}_abi_g16.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *abi_g16_channels

--- a/config/ObsPlugs/variational/abi_g16.yaml
+++ b/config/ObsPlugs/variational/abi_g16.yaml
@@ -24,7 +24,7 @@
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: Perform Action
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
     filter variables:
     - name: brightness_temperature
       channels: *abi_g16_channels
@@ -84,10 +84,10 @@
               channels: *abi_g16_channels
   - filter: Background Check
     threshold: 3.0
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
 ## Ignore cloud-affected pixels in 1st iteration
 #  - filter: Domain Check
-#    apply at iterations: 0
+#    <<: *multiIterationFilter
 #    filter variables:
 #    - name: brightness_temperature
 #      channels: *abi_g16_channels

--- a/config/ObsPlugs/variational/ahi-clr_himawari8.yaml
+++ b/config/ObsPlugs/variational/ahi-clr_himawari8.yaml
@@ -28,7 +28,7 @@
     horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: Background Check
     threshold: 3.0
-    apply at iterations: 0, 1
+    <<: *multiIterationFilter
   - filter: GOMsaver
     filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_ahi-clr_himawari8.nc4
   - filter: YDIAGsaver

--- a/config/ObsPlugs/variational/ahi-clr_himawari8.yaml
+++ b/config/ObsPlugs/variational/ahi-clr_himawari8.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: ahi-clr_himawari8
     obsdatain:
-      obsfile: InDBDir/ahi_himawari8_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/ahi_himawari8_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_ahi-clr_himawari8.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_ahi-clr_himawari8.h5
     simulated variables: [brightness_temperature]
     channels: &clrahi_channels 7-16
   obs error: *ObsErrorDiagonal
@@ -25,14 +25,14 @@
         name: cloud_area_fraction@MetaData
       maxvalue: 0.05
   - filter: Gaussian Thinning
-    horizontal_mesh: RADTHINDISTANCE #km
+    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: Background Check
     threshold: 3.0
     apply at iterations: 0, 1
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_ahi-clr_himawari8.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_ahi-clr_himawari8.nc4
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_ahi-clr_himawari8.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{diagPrefix}}_ahi-clr_himawari8.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *clrahi_channels

--- a/config/ObsPlugs/variational/ahi_himawari8.yaml
+++ b/config/ObsPlugs/variational/ahi_himawari8.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: ahi_himawari8
     obsdatain:
-      obsfile: InDBDir/ahi_himawari8_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/ahi_himawari8_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_ahi_himawari8.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_ahi_himawari8.h5
     simulated variables: [brightness_temperature]
     channels: &ahi_himawari8_channels 8-10
   obs error: *ObsErrorDiagonal
@@ -22,7 +22,7 @@
         name: sensor_zenith_angle@MetaData
       maxvalue: 65.0
   - filter: Gaussian Thinning
-    horizontal_mesh: RADTHINDISTANCE #km
+    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: Perform Action
     apply at iterations: 0, 1, 2, 3, 4, 5
     filter variables:
@@ -60,7 +60,7 @@
         name: ObsErrorModelRamp@ObsFunction
         channels: *ahi_himawari8_channels
         options:
-          <<: *ahi_himawari8_SymmCldFitsAHISUPEROBGRID-HofXMeshDescriptor
+          <<: *ahi_himawari8_SymmCldFits{{AHISUPEROBGRID}}-{{HofXMeshDescriptor}}
           channels: *ahi_himawari8_channels
           xvar:
             name: SymmCldImpactIR@ObsFunction
@@ -71,9 +71,9 @@
     threshold: 3.0
     apply at iterations: 0, 1, 2, 3, 4, 5
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_ahi_himawari8.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_ahi_himawari8.nc4
   - filter: YDIAGsaver
-    filename: OutDBDirOOPSMemberDir/diagPrefix_ahi_himawari8.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{diagPrefix}}_ahi_himawari8.nc4
     filter variables:
     - name: brightness_temperature_assuming_clear_sky
       channels: *ahi_himawari8_channels

--- a/config/ObsPlugs/variational/ahi_himawari8.yaml
+++ b/config/ObsPlugs/variational/ahi_himawari8.yaml
@@ -24,7 +24,7 @@
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: Perform Action
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
     filter variables:
     - name: brightness_temperature
       channels: *ahi_himawari8_channels
@@ -69,7 +69,7 @@
               channels: *ahi_himawari8_channels
   - filter: Background Check
     threshold: 3.0
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
   - filter: GOMsaver
     filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_ahi_himawari8.nc4
   - filter: YDIAGsaver

--- a/config/ObsPlugs/variational/aircraft.yaml
+++ b/config/ObsPlugs/variational/aircraft.yaml
@@ -2,10 +2,10 @@
     <<: *ObsSpace
     name: Aircraft
     obsdatain:
-      obsfile: InDBDir/aircraft_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/aircraft_obs_{{thisValidDate}}.h5
       max frame size: 40000
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_aircraft.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_aircraft.h5
       max frame size: 40000
     simulated variables: [air_temperature, eastward_wind, northward_wind, specific_humidity]
   obs error: *ObsErrorDiagonal

--- a/config/ObsPlugs/variational/aircraft.yaml
+++ b/config/ObsPlugs/variational/aircraft.yaml
@@ -18,4 +18,4 @@
     maxvalue: 3
   - filter: Background Check
     threshold: 3.0
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter

--- a/config/ObsPlugs/variational/amsua-cld_aqua.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_aqua.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua-cld_aqua.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_aqua.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_aqua
     obsdatain:
-      obsfile: InDBDir/amsua_aqua_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_aqua_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua-cld_aqua.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_aqua.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_aqua_channels 1-5,15
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua-cld_aqua.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_aqua.nc4

--- a/config/ObsPlugs/variational/amsua-cld_metop-a.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_metop-a.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_metop-a
     obsdatain:
-      obsfile: InDBDir/amsua_metop-a_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_metop-a_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua-cld_metop-a.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_metop-a.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_metop-a_channels 1-5,15
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua-cld_metop-a.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_metop-a.nc4

--- a/config/ObsPlugs/variational/amsua-cld_metop-a.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_metop-a.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua-cld_metop-b.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_metop-b.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_metop-b
     obsdatain:
-      obsfile: InDBDir/amsua_metop-b_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_metop-b_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua-cld_metop-b.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_metop-b.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_metop-b_channels 1-5,15
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua-cld_metop-b.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_metop-b.nc4

--- a/config/ObsPlugs/variational/amsua-cld_metop-b.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_metop-b.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua-cld_n15.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_n15.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_n15
     obsdatain:
-      obsfile: InDBDir/amsua_n15_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n15_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua-cld_n15.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_n15.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_n15_channels 1-5,15
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua-cld_n15.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_n15.nc4

--- a/config/ObsPlugs/variational/amsua-cld_n15.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_n15.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua-cld_n18.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_n18.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_n18
     obsdatain:
-      obsfile: InDBDir/amsua_n18_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n18_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua-cld_n18.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_n18.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_n18_channels 1-5,15
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua-cld_n18.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_n18.nc4

--- a/config/ObsPlugs/variational/amsua-cld_n18.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_n18.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua-cld_n19.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_n19.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua-cld_n19
     obsdatain:
-      obsfile: InDBDir/amsua_n19_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n19_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua-cld_n19.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_n19.h5
     simulated variables: [brightness_temperature]
     channels: &amsua-cld_n19_channels 1-5,15
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua-cld_n19.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_n19.nc4

--- a/config/ObsPlugs/variational/amsua-cld_n19.yaml
+++ b/config/ObsPlugs/variational/amsua-cld_n19.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua_aqua.yaml
+++ b/config/ObsPlugs/variational/amsua_aqua.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_aqua
     obsdatain:
-      obsfile: InDBDir/amsua_aqua_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_aqua_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua_aqua.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_aqua.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_aqua_channels 8,9
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1, 2, 3, 4, 5
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua_aqua.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_aqua.nc4

--- a/config/ObsPlugs/variational/amsua_aqua.yaml
+++ b/config/ObsPlugs/variational/amsua_aqua.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua_metop-a.yaml
+++ b/config/ObsPlugs/variational/amsua_metop-a.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua_metop-a.yaml
+++ b/config/ObsPlugs/variational/amsua_metop-a.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_metop-a
     obsdatain:
-      obsfile: InDBDir/amsua_metop-a_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_metop-a_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua_metop-a.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_metop-a.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_metop-a_channels 5,6,9
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1, 2, 3, 4, 5
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua_metop-a.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-a.nc4

--- a/config/ObsPlugs/variational/amsua_metop-b.yaml
+++ b/config/ObsPlugs/variational/amsua_metop-b.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_metop-b
     obsdatain:
-      obsfile: InDBDir/amsua_metop-b_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_metop-b_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua_metop-b.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_metop-b.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_metop-b_channels 8,9
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1, 2, 3, 4, 5
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua_metop-b.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-b.nc4

--- a/config/ObsPlugs/variational/amsua_metop-b.yaml
+++ b/config/ObsPlugs/variational/amsua_metop-b.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua_n15.yaml
+++ b/config/ObsPlugs/variational/amsua_n15.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_n15
     obsdatain:
-      obsfile: InDBDir/amsua_n15_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n15_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua_n15.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_n15.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_n15_channels 5-9
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1, 2, 3, 4, 5
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua_n15.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n15.nc4

--- a/config/ObsPlugs/variational/amsua_n15.yaml
+++ b/config/ObsPlugs/variational/amsua_n15.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua_n18.yaml
+++ b/config/ObsPlugs/variational/amsua_n18.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_n18
     obsdatain:
-      obsfile: InDBDir/amsua_n18_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n18_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua_n18.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_n18.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_n18_channels 5-9
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1, 2, 3, 4, 5
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua_n18.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n18.nc4

--- a/config/ObsPlugs/variational/amsua_n18.yaml
+++ b/config/ObsPlugs/variational/amsua_n18.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/amsua_n19.yaml
+++ b/config/ObsPlugs/variational/amsua_n19.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: amsua_n19
     obsdatain:
-      obsfile: InDBDir/amsua_n19_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/amsua_n19_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_amsua_n19.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_n19.h5
     simulated variables: [brightness_temperature]
     channels: &amsua_n19_channels 5-7,9
   obs error: *ObsErrorDiagonal
@@ -22,6 +22,6 @@
     threshold: 3
     apply at iterations: 0, 1, 2, 3, 4, 5
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver
-    filename: OutDBDirOOPSMemberDir/geoPrefix_amsua_n19.nc4
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n19.nc4

--- a/config/ObsPlugs/variational/amsua_n19.yaml
+++ b/config/ObsPlugs/variational/amsua_n19.yaml
@@ -20,7 +20,7 @@
     maxvalue: 0
   - filter: Background Check
     threshold: 3
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}} #km
   - filter: GOMsaver

--- a/config/ObsPlugs/variational/gnssroref.yaml
+++ b/config/ObsPlugs/variational/gnssroref.yaml
@@ -30,8 +30,8 @@
       maxvalue: 200
   - filter: Background Check
     threshold: 3.0
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
   - filter: ROobserror
     variable: refractivity
     errmodel: NBAM
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter

--- a/config/ObsPlugs/variational/gnssroref.yaml
+++ b/config/ObsPlugs/variational/gnssroref.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: GnssroRef
     obsdatain:
-      obsfile: InDBDir/gnssroref_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/gnssroref_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_gnssroref.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_gnssroref.h5
     simulated variables: [refractivity]
   obs error: *ObsErrorDiagonal
   obs operator:

--- a/config/ObsPlugs/variational/satwind.yaml
+++ b/config/ObsPlugs/variational/satwind.yaml
@@ -2,10 +2,10 @@
     <<: *ObsSpace
     name: Satwind
     obsdatain:
-      obsfile: InDBDir/satwind_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/satwind_obs_{{thisValidDate}}.h5
       max frame size: 80000
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_satwind.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_satwind.h5
       max frame size: 80000
     simulated variables: [eastward_wind, northward_wind]
   obs error: *ObsErrorDiagonal
@@ -29,4 +29,4 @@
     minvalue: 0.0
     maxvalue: 200.0
 #  - filter: Gaussian Thinning
-#    horizontal_mesh: RADTHINDISTANCE #km
+#    horizontal_mesh: {{RADTHINDISTANCE}} #km

--- a/config/ObsPlugs/variational/satwind.yaml
+++ b/config/ObsPlugs/variational/satwind.yaml
@@ -18,7 +18,7 @@
     maxvalue: 3
   - filter: Background Check
     threshold: 3.0
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
   - filter: Bounds Check
     filter variables:
     - name: eastward_wind

--- a/config/ObsPlugs/variational/sfc.yaml
+++ b/config/ObsPlugs/variational/sfc.yaml
@@ -23,4 +23,4 @@
     threshold: 200.0
   - filter: Background Check
     threshold: 3.0
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter

--- a/config/ObsPlugs/variational/sfc.yaml
+++ b/config/ObsPlugs/variational/sfc.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: SfcPCorrected
     obsdatain:
-      obsfile: InDBDir/sfc_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/sfc_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_sfc.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_sfc.h5
     simulated variables: [surface_pressure]
   obs error: *ObsErrorDiagonal
   obs operator:

--- a/config/ObsPlugs/variational/sondes-2018043006.yaml
+++ b/config/ObsPlugs/variational/sondes-2018043006.yaml
@@ -16,4 +16,4 @@
     maxvalue: 3
   - filter: Background Check
     threshold: 3.0
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter

--- a/config/ObsPlugs/variational/sondes-2018043006.yaml
+++ b/config/ObsPlugs/variational/sondes-2018043006.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: Radiosonde
     obsdatain:
-      obsfile: InDBDir/sondes_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/sondes_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_sondes.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_sondes.h5
     simulated variables: [air_temperature, virtual_temperature, eastward_wind, northward_wind]
   obs error: *ObsErrorDiagonal
   obs operator:

--- a/config/ObsPlugs/variational/sondes.yaml
+++ b/config/ObsPlugs/variational/sondes.yaml
@@ -2,9 +2,9 @@
     <<: *ObsSpace
     name: Radiosonde
     obsdatain:
-      obsfile: InDBDir/sondes_obs_{{thisValidDate}}.h5
+      obsfile: {{InDBDir}}/sondes_obs_{{thisValidDate}}.h5
     obsdataout:
-      obsfile: OutDBDirOOPSMemberDir/obsPrefix_sondes.h5
+      obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_sondes.h5
     simulated variables: [air_temperature, virtual_temperature, eastward_wind, northward_wind, specific_humidity]
   obs error: *ObsErrorDiagonal
   obs operator:

--- a/config/ObsPlugs/variational/sondes.yaml
+++ b/config/ObsPlugs/variational/sondes.yaml
@@ -16,7 +16,7 @@
     maxvalue: 3
   - filter: Background Check
     threshold: 3.0
-    apply at iterations: 0, 1, 2, 3, 4, 5
+    <<: *multiIterationFilter
 # avoids large ObsError values polluting plots of ObsError
   - filter: Bounds Check
     filter variables:

--- a/config/applicationBase/3denvar-specific_multivariate.yaml
+++ b/config/applicationBase/3denvar-specific_multivariate.yaml
@@ -17,7 +17,7 @@ _member: &memberConfig
   date: &analysisDate {{thisISO8601Date}}
   state variables: &incvars [{{AnalysisVariables}}]
   stream name: ensemble
-ObsAnchors
+{{ObsAnchors}}
 output:
   filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
   stream name: analysis
@@ -64,3 +64,4 @@ cost function:
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:
+{{Observations}}

--- a/config/applicationBase/3denvar-specific_multivariate.yaml
+++ b/config/applicationBase/3denvar-specific_multivariate.yaml
@@ -1,11 +1,11 @@
 _iteration: &iterationConfig
   geometry:
-    nml_file: InnerNamelistFile
-    streams_file: InnerStreamsFileStreamsFileMember
+    nml_file: {{InnerNamelistFile}}
+    streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: ObsPerturbations
+  obs perturbations: {{ObsPerturbations}}
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
 #    tlm taylor test: true
@@ -15,17 +15,17 @@ _iteration: &iterationConfig
 #    online adj test: true
 _member: &memberConfig
   date: &analysisDate {{thisISO8601Date}}
-  state variables: &incvars [AnalysisVariables]
+  state variables: &incvars [{{AnalysisVariables}}]
   stream name: ensemble
 ObsAnchors
 output:
-  filename: anStateDirOOPSMemberDir/anStatePrefix.$Y-$M-$D_$h.$m.$s.nc
+  filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
   stream name: analysis
 variational:
   minimizer:
-VariationalMinimizer
+{{VariationalMinimizer}}
   iterations:
-VariationalIterations
+{{VariationalIterations}}
 final:
   diagnostics:
     departures: depan
@@ -35,14 +35,14 @@ cost function:
   window length: {{windowLength}}
   jb evaluation: false
   geometry:
-    nml_file: OuterNamelistFile
-    streams_file: OuterStreamsFileStreamsFileMember
+    nml_file: {{OuterNamelistFile}}
+    streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
     interpolation type: unstructured
   analysis variables: *incvars
   background:
-    state variables: [StateVariables]
-    filename: bgStateDirOOPSMemberDir/bgStatePrefix.{{thisMPASFileDate}}.nc
+    state variables: [{{StateVariables}}]
+    filename: {{bgStateDir}}{{MemberDir}}/{{bgStatePrefix}}.{{thisMPASFileDate}}.nc
     date: *analysisDate
   background error:
     covariance model: ensemble
@@ -61,6 +61,6 @@ cost function:
           #io_values: [dynamic,dynamic,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
           io_values: [dynamic,cloud,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
           verbosity: main
-EnsemblePbMembers
-EnsemblePbInflation
+{{EnsemblePbMembers}}
+{{EnsemblePbInflation}}
   observations:

--- a/config/applicationBase/3denvar.yaml
+++ b/config/applicationBase/3denvar.yaml
@@ -1,11 +1,11 @@
 _iteration: &iterationConfig
   geometry:
-    nml_file: InnerNamelistFile
-    streams_file: InnerStreamsFileStreamsFileMember
+    nml_file: {{InnerNamelistFile}}
+    streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: ObsPerturbations
+  obs perturbations: {{ObsPerturbations}}
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
 #    tlm taylor test: true
@@ -15,17 +15,17 @@ _iteration: &iterationConfig
 #    online adj test: true
 _member: &memberConfig
   date: &analysisDate {{thisISO8601Date}}
-  state variables: &incvars [AnalysisVariables]
+  state variables: &incvars [{{AnalysisVariables}}]
   stream name: ensemble
 ObsAnchors
 output:
-  filename: anStateDirOOPSMemberDir/anStatePrefix.$Y-$M-$D_$h.$m.$s.nc
+  filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
   stream name: analysis
 variational:
   minimizer:
-VariationalMinimizer
+{{VariationalMinimizer}}
   iterations:
-VariationalIterations
+{{VariationalIterations}}
 final:
   diagnostics:
     departures: depan
@@ -35,14 +35,14 @@ cost function:
   window length: {{windowLength}}
   jb evaluation: false
   geometry:
-    nml_file: OuterNamelistFile
-    streams_file: OuterStreamsFileStreamsFileMember
+    nml_file: {{OuterNamelistFile}}
+    streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
     interpolation type: unstructured
   analysis variables: *incvars
   background:
-    state variables: [StateVariables]
-    filename: bgStateDirOOPSMemberDir/bgStatePrefix.{{thisMPASFileDate}}.nc
+    state variables: [{{StateVariables}}]
+    filename: {{bgStateDir}}{{MemberDir}}/{{bgStatePrefix}}.{{thisMPASFileDate}}.nc
     date: *analysisDate
   background error:
     covariance model: ensemble
@@ -58,6 +58,6 @@ cost function:
           strategy: common
           load_nicas_local: true
           verbosity: main
-EnsemblePbMembers
-EnsemblePbInflation
+{{EnsemblePbMembers}}
+{{EnsemblePbInflation}}
   observations:

--- a/config/applicationBase/3denvar.yaml
+++ b/config/applicationBase/3denvar.yaml
@@ -17,7 +17,7 @@ _member: &memberConfig
   date: &analysisDate {{thisISO8601Date}}
   state variables: &incvars [{{AnalysisVariables}}]
   stream name: ensemble
-ObsAnchors
+{{ObsAnchors}}
 output:
   filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
   stream name: analysis
@@ -61,3 +61,4 @@ cost function:
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:
+{{Observations}}

--- a/config/applicationBase/3dhybrid.yaml
+++ b/config/applicationBase/3dhybrid.yaml
@@ -1,7 +1,7 @@
 _iteration: &iterationConfig
   geometry:
-    nml_file: InnerNamelistFile
-    streams_file: InnerStreamsFileStreamsFileMember
+    nml_file: {{InnerNamelistFile}}
+    streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
@@ -17,7 +17,7 @@ _member: &memberConfig
   date: &analysisDate {{thisISO8601Date}}
   state variables: &incvars [{{AnalysisVariables}}]
   stream name: ensemble
-ObsAnchors
+{{ObsAnchors}}
 output:
   filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
   stream name: analysis
@@ -35,8 +35,8 @@ cost function:
   window length: {{windowLength}}
   jb evaluation: false
   geometry:
-    nml_file: OuterNamelistFile
-    streams_file: OuterStreamsFileStreamsFileMember
+    nml_file: {{OuterNamelistFile}}
+    streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
     interpolation type: unstructured
   analysis variables: *incvars
@@ -106,3 +106,4 @@ cost function:
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:
+{{Observations}}

--- a/config/applicationBase/3dhybrid.yaml
+++ b/config/applicationBase/3dhybrid.yaml
@@ -5,7 +5,7 @@ _iteration: &iterationConfig
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: ObsPerturbations
+  obs perturbations: {{ObsPerturbations}}
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
 #    tlm taylor test: true
@@ -15,17 +15,17 @@ _iteration: &iterationConfig
 #    online adj test: true
 _member: &memberConfig
   date: &analysisDate {{thisISO8601Date}}
-  state variables: &incvars [AnalysisVariables]
+  state variables: &incvars [{{AnalysisVariables}}]
   stream name: ensemble
 ObsAnchors
 output:
-  filename: anStateDirOOPSMemberDir/anStatePrefix.$Y-$M-$D_$h.$m.$s.nc
+  filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
   stream name: analysis
 variational:
   minimizer:
-VariationalMinimizer
+{{VariationalMinimizer}}
   iterations:
-VariationalIterations
+{{VariationalIterations}}
 final:
   diagnostics:
     departures: depan
@@ -41,8 +41,8 @@ cost function:
     interpolation type: unstructured
   analysis variables: *incvars
   background:
-    state variables: [StateVariables]
-    filename: bgStateDirOOPSMemberDir/bgStatePrefix.{{thisMPASFileDate}}.nc
+    state variables: [{{StateVariables}}]
+    filename: {{bgStateDir}}{{MemberDir}}/{{bgStatePrefix}}.{{thisMPASFileDate}}.nc
     date: *analysisDate
   background error:
     covariance model: hybrid
@@ -103,6 +103,6 @@ cost function:
               strategy: common
               load_nicas_local: true
               verbosity: main
-EnsemblePbMembers
-EnsemblePbInflation
+{{EnsemblePbMembers}}
+{{EnsemblePbInflation}}
   observations:

--- a/config/applicationBase/3dvar.yaml
+++ b/config/applicationBase/3dvar.yaml
@@ -6,7 +6,7 @@ _iteration: &iterationConfig
     interpolation type: unstructured
   gradient norm reduction: 1e-3
   obs perturbations: {{ObsPerturbations}}
-ObsAnchors
+{{ObsAnchors}}
 output:
   filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
   stream name: analysis
@@ -71,3 +71,4 @@ cost function:
       input variables: *ctlvars
       output variables: *incvars
   observations:
+{{Observations}}

--- a/config/applicationBase/3dvar.yaml
+++ b/config/applicationBase/3dvar.yaml
@@ -1,20 +1,20 @@
 _iteration: &iterationConfig
   geometry:
-    nml_file: InnerNamelistFile
-    streams_file: InnerStreamsFile
+    nml_file: {{InnerNamelistFile}}
+    streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: ObsPerturbations
+  obs perturbations: {{ObsPerturbations}}
 ObsAnchors
 output:
-  filename: anStateDirOOPSMemberDir/anStatePrefix.$Y-$M-$D_$h.$m.$s.nc
+  filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
   stream name: analysis
 variational:
   minimizer:
-VariationalMinimizer
+{{VariationalMinimizer}}
   iterations:
-VariationalIterations
+{{VariationalIterations}}
 final:
   diagnostics:
     departures: depan
@@ -23,14 +23,14 @@ cost function:
   window begin: {{windowBegin}}
   window length: {{windowLength}}
   geometry:
-    nml_file: OuterNamelistFile
-    streams_file: OuterStreamsFile
+    nml_file: {{OuterNamelistFile}}
+    streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
     interpolation type: unstructured
-  analysis variables: &incvars [AnalysisVariables]
+  analysis variables: &incvars [{{AnalysisVariables}}]
   background:
-    state variables: [StateVariables]
-    filename: bgStateDirOOPSMemberDir/bgStatePrefix.{{thisMPASFileDate}}.nc
+    state variables: [{{StateVariables}}]
+    filename: {{bgStateDir}}{{MemberDir}}/{{bgStatePrefix}}.{{thisMPASFileDate}}.nc
     date: &analysisDate {{thisISO8601Date}}
   background error:
     covariance model: SABER

--- a/config/applicationBase/hofx.yaml
+++ b/config/applicationBase/hofx.yaml
@@ -2,11 +2,11 @@ ObsAnchors
 window begin: {{windowBegin}}
 window length: {{windowLength}}
 geometry:
-  nml_file: HofXNamelistFile
-  streams_file: HofXStreamsFile
+  nml_file: {{HofXNamelistFile}}
+  streams_file: {{HofXStreamsFile}}
   deallocate non-da fields: true
 state:
-  state variables: [ModelVariables]
-  filename: bgStateDir/bgStatePrefix.{{thisMPASFileDate}}.nc
+  state variables: [{{StateVariables}}]
+  filename: {{bgStateDir}}/{{bgStatePrefix}}.{{thisMPASFileDate}}.nc
   date: {{thisISO8601Date}}
 observations:

--- a/config/applicationBase/hofx.yaml
+++ b/config/applicationBase/hofx.yaml
@@ -1,4 +1,4 @@
-ObsAnchors
+{{ObsAnchors}}
 window begin: {{windowBegin}}
 window length: {{windowLength}}
 geometry:
@@ -10,3 +10,4 @@ state:
   filename: {{bgStateDir}}/{{bgStatePrefix}}.{{thisMPASFileDate}}.nc
   date: {{thisISO8601Date}}
 observations:
+{{Observations}}

--- a/config/applicationBase/rtpp.yaml
+++ b/config/applicationBase/rtpp.yaml
@@ -1,19 +1,19 @@
 _state read: &stateReadConfig
   date: {{thisISO8601Date}}
-  state variables: [StateVariables]
+  state variables: [{{StateVariables}}]
   stream name: background
 output:
-  filename: anStateDirOOPSMemberDir/anStatePrefix.$Y-$M-$D_$h.$m.$s.nc
+  filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
   stream name: analysis
 geometry:
-  nml_file: EnsembleNamelistFile
-  streams_file: EnsembleStreamsFile
+  nml_file: {{EnsembleNamelistFile}}
+  streams_file: {{EnsembleStreamsFile}}
   deallocate non-da fields: true
-analysis variables: [AnalysisVariables]
+analysis variables: [{{AnalysisVariables}}]
 background:
   members:
-EnsemblePbMembers
+{{EnsemblePbMembers}}
 analysis:
   members:
-EnsemblePaMembers
-factor: RTPPInflationFactor
+{{EnsemblePaMembers}}
+factor: {{RTPPInflationFactor}}

--- a/config/job.csh
+++ b/config/job.csh
@@ -25,5 +25,6 @@ $setLocal EnsOfVariationalRetry
 $setLocal CyclingFCRetry
 $setLocal RTPPInflationRetry
 $setLocal HofXRetry
+$setLocal CleanRetry
 #$setLocal VerifyObsRetry
 #$setLocal VerifyModelRetry

--- a/drive.csh
+++ b/drive.csh
@@ -339,6 +339,7 @@ cat >! suite.rc << EOF
   [[CleanBase]]
     [[[job]]]
       execution time limit = PT5M
+      execution retry delays = ${CleanRetry}
 #Cycling components
   # initialization-related components
   [[GetWarmStartIC]]

--- a/scenarios/base/job.yaml
+++ b/scenarios/base/job.yaml
@@ -34,5 +34,6 @@ job:
   CyclingFCRetry: '2*PT30S'
   RTPPInflationRetry: '2*PT30S'
   HofXRetry: '2*PT30S'
+  CleanRetry: '2*PT15S'
   VerifyObsRetry: '1*PT30S'
   VerifyModelRetry: '1*PT30S'

--- a/tools/substituteEnsembleBMembers.py
+++ b/tools/substituteEnsembleBMembers.py
@@ -100,7 +100,7 @@ def substituteEnsembleB():
       filedata = f.read()
 
     # replace for substitutionString
-    filedata = filedata.replace(substitutionString+'\n', replacementString)
+    filedata = filedata.replace('{{'+substitutionString+'}}\n', replacementString)
 
     # replace yamlFile with new version
     f = open(yamlFile, 'w')

--- a/tools/substituteEnsembleBTemplate.py
+++ b/tools/substituteEnsembleBTemplate.py
@@ -148,7 +148,7 @@ members from template:
       filedata = f.read()
 
     # replace for substitutionString
-    filedata = filedata.replace(substitutionString+'\n', replacementString)
+    filedata = filedata.replace('{{'+substitutionString+'}}\n', replacementString)
 
     # replace yamlFile with new version
     f = open(yamlFile, 'w')


### PR DESCRIPTION
### Description
This branch modifies all YAML substitution strings to be surrounded by double braces, i.e., `{{substitutionString}}` instead of `substitutionString`.  This modification makes it clearer to users and developers which variables are provided by the workflow and which ones are static.

A later PR will do the same for namelist and streams files.

Two additional unrelated changes in `PrepVariational.csh` cause (1) observation perturbations to be enabled for all EDA members, including the first member and (2)observation perturbations to be re-centered around zero. I.e., in commit ab2a490d9126c05ed83909f30c0447f9b532179d, 

![image](https://user-images.githubusercontent.com/20328709/158232021-ea8fde8a-29e7-444d-bde9-2a57b8a0abd8.png)


### Issue closed

None

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
