### PR TITLE
Fix bug in forecast.csh

### DIFF
--- a/forecast.csh
+++ b/forecast.csh
@@ -187,7 +187,7 @@ else
   if ( ${InitializationType} == "WarmStart" ) then
     rm ${localStaticFieldsFile}
     mv ${localStaticFieldsFile}${OrigFileSuffix} ${localStaticFieldsFile}
-  endid
+  endif
 endif
 
 if ( "$deleteZerothForecast" == "True" ) then


### PR DESCRIPTION
### Description
Replace `endid` with `endif`

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
