### PR TITLE
Utilize surface stream for SST and XICE updating

### DIFF
--- a/GenerateColdStartIC.csh
+++ b/GenerateColdStartIC.csh
@@ -4,6 +4,7 @@ date
 
 # Setup environment
 # =================
+source config/forecast.csh
 source config/model.csh
 source config/filestructure.csh
 source config/modeldata.csh
@@ -39,7 +40,7 @@ end
 rm ${StreamsFileInit}
 cp -v ${initModelConfigDir}/${StreamsFileInit} .
 sed -i 's@nCells@'${MPASnCellsOuter}'@' ${StreamsFileInit}
-sed -i 's@forecastPrecision@'${forecastPrecision}'@' ${StreamsFileInit}
+sed -i 's@forecastPrecision@'${forecast__precision}'@' ${StreamsFileInit}
 
 ## copy/modify dynamic namelist
 rm ${NamelistFileInit}

--- a/PrepJEDI.csh
+++ b/PrepJEDI.csh
@@ -45,6 +45,7 @@ endif
 # =================
 source config/environment.csh
 source config/filestructure.csh
+source config/forecast.csh
 source config/model.csh
 source config/observations.csh
 source config/tools.csh
@@ -147,7 +148,7 @@ foreach StreamsFile_ ($StreamsFileList)
   sed -i 's@nCells@'$MPASnCellsList[$iMesh]'@' ${StreamsFile_}
   sed -i 's@TemplateFieldsPrefix@'${self_WorkDir}'/'${TemplateFieldsPrefix}'@' ${StreamsFile_}
   sed -i 's@StaticFieldsPrefix@'${self_WorkDir}'/'${localStaticFieldsPrefix}'@' ${StreamsFile_}
-  sed -i 's@forecastPrecision@'${forecastPrecision}'@' ${StreamsFile_}
+  sed -i 's@forecastPrecision@'${forecast__precision}'@' ${StreamsFile_}
 end
 
 ## copy/modify dynamic namelist file

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ the default values for all settings.  Those `base` configurations are as follows
 
 `scenarios/base/hofx.yaml`: settings specific to the hofx application
 
+`scenarios/base/forecast.yaml`: settings specific to the forecast application
+
 `scenarios/base/job.yaml`: account and queue selection
 
 

--- a/RTPPInflation.csh
+++ b/RTPPInflation.csh
@@ -5,6 +5,7 @@ date
 # Setup environment
 # =================
 source config/variational.csh
+source config/forecast.csh
 source config/model.csh
 source config/filestructure.csh
 source config/tools.csh
@@ -91,7 +92,7 @@ cp -v $self_ModelConfigDir/${StreamsFile} .
 sed -i 's@nCells@'${MPASnCellsEnsemble}'@' ${StreamsFile}
 sed -i 's@TemplateFieldsPrefix@'${self_WorkDir}'/'${TemplateFieldsPrefix}'@' ${StreamsFile}
 sed -i 's@StaticFieldsPrefix@'${self_WorkDir}'/'${localStaticFieldsPrefix}'@' ${StreamsFile}
-sed -i 's@forecastPrecision@'${forecastPrecision}'@' ${StreamsFile}
+sed -i 's@forecastPrecision@'${forecast__precision}'@' ${StreamsFile}
 
 # determine analysis output precision
 ncdump -h ${firstANFile} | grep uReconstruct | grep double

--- a/config/forecast.csh
+++ b/config/forecast.csh
@@ -1,0 +1,18 @@
+#!/bin/csh -f
+
+# only load forecast if it is not already loaded
+# note: set must be used instead of setenv, because some of the setLocal commands apply to
+# lists, which use set instead of setenv
+if ( $?config_forecast ) exit 0
+set config_forecast = 1
+
+source config/scenario.csh
+
+# setLocal is a helper function that picks out a configuration node
+# under the "forecast" key of scenarioConfig
+setenv baseConfig scenarios/base/forecast.yaml
+setenv setLocal "source $setConfig $baseConfig $scenarioConfig forecast"
+setenv setNestedForecast "source $setNestedConfig $baseConfig $scenarioConfig forecast"
+
+$setLocal updateSea
+$setNestedForecast precision

--- a/config/model.csh
+++ b/config/model.csh
@@ -14,6 +14,5 @@ setenv setLocal "source $setConfig $baseConfig $scenarioConfig model"
 setenv setNestedModel "source $setNestedConfig $baseConfig $scenarioConfig model"
 
 $setNestedModel AnalysisSource
-
 $setLocal MPASGridDescriptor
-$setLocal forecastPrecision single
+$setLocal GraphInfoDir

--- a/config/modeldata.csh
+++ b/config/modeldata.csh
@@ -5,6 +5,7 @@ set config_modeldata = 1
 
 source config/workflow.csh
 source config/model.csh
+source config/forecast.csh
 source config/variational.csh
 source config/filestructure.csh
 set wd = `pwd`
@@ -125,17 +126,13 @@ endif
 
 # MPAS-Model
 # ----------
-## directory containing x1.${MPASnCells}.graph.info* files
-setenv GraphInfoDir /glade/work/duda/static_moved_to_campaign
-
 ## sea/ocean surface files
 setenv seaMaxMembers ${nGEFSMembers}
 setenv deterministicSeaAnaDir ${GFSAnaDirOuter}
-setenv updateSea 1
 if ( "$DAType" =~ *"eda"* ) then
   # using member-specific sst/xice data from GEFS
   # 60km and 120km
-  setenv SeaAnaDir ${ModelData}/GEFS/surface/000hr/${forecastPrecision}
+  setenv SeaAnaDir ${ModelData}/GEFS/surface/000hr/${forecast__precision}
   setenv seaMemFmt "${gefsMemFmt}"
 else
   # deterministic

--- a/config/mpas/forecast/streams.atmosphere
+++ b/config/mpas/forecast/streams.atmosphere
@@ -47,10 +47,10 @@
 
 <stream name="surface"
         type="input"
-        precision="forecastPrecision"
-        filename_template="x1.nCells.sfc_update.nc"
+        precision="{{surfacePrecision}}"
+        filename_template="{{surfaceUpdateFile}}"
         filename_interval="none"
-        input_interval="none" >
+        input_interval="{{surfaceInputInterval}}" >
 	<file name="stream_list.atmosphere.surface"/>
 </stream>
 

--- a/config/mpas/variables.csh
+++ b/config/mpas/variables.csh
@@ -4,7 +4,6 @@
 ## workflow-relevant state variables
 ####################################
 setenv MPASJEDIDiagVariables cldfrac
-setenv MPASSeaVariables sst,xice
 set MPASHydroIncrementVariables = (qc qi qg qr qs)
 set MPASHydroStateVariables = (${MPASHydroIncrementVariables} cldfrac)
 

--- a/drive.csh
+++ b/drive.csh
@@ -90,6 +90,7 @@ cat >! suite.rc << EOF
 # initialization type
 {% set InitializationType = "${InitializationType}" %}
 {% set observationsResource = "${observations__resource}" %}
+{% set modelAnalysisSource = "${model__AnalysisSource}" %}
 
 # eda
 {% set EDASize = ${EDASize} %} #integer
@@ -173,17 +174,20 @@ cat >! suite.rc << EOF
 
 ## Mini-workflow that prepares observations for IODA ingest
 {% if observationsResource == "PANDACArchive" %}
+  # assume that IODA observation files are already available for PANDACArchive case
   {% set PrepareObservations = "ObsReady" %}
 {% else %}
   {% set PrepareObservations = "GetObs => ObsToIODA => ObsReady" %}
 {% endif %}
 
 ## Mini-workflow that prepares a cold-start initial condition file from a GFS analysis
-{% if InitializationType == "WarmStart" %}
-  # assume that cold-start IC files are already available for WarmStart case
+{% if "PANDACArchive" in modelAnalysisSource %}
+  # assume that external analysis files are already available for GFSfromPANDACArchive case
   {% set PrepareExternalAnalysis = "ExternalAnalysisReady" %}
-{% else %}
+{% elif modelAnalysisSource in ["GFSfromRDAOnline", "GFSfromNCEPFTPOnline"] %}
   {% set PrepareExternalAnalysis = "GetGFSanalysis => UngribColdStartIC => GenerateColdStartIC => ExternalAnalysisReady" %}
+{% else %}
+  {{ raise('modelAnalysisSource is not valid') }}
 {% endif %}
 # Use GFS analysis for sea surface updating
 {% set PrepareSeaSurfaceUpdate = PrepareExternalAnalysis %}

--- a/scenarios/base/forecast.yaml
+++ b/scenarios/base/forecast.yaml
@@ -1,0 +1,10 @@
+forecast:
+## updateSea
+# whether to update surface fields before a forecast (e.g., sst, xice)
+# OPTIONS: True/False
+  updateSea: True
+
+## forecastPrecision
+# floating-point precision of forecast output
+# OPTIONS: single, double
+  precision: single

--- a/scenarios/base/model.yaml
+++ b/scenarios/base/model.yaml
@@ -18,10 +18,10 @@ model:
 #   + TODO: "O30kmIE60km" dual-resolution 4denvar
   MPASGridDescriptor: None
 
-## forecastPrecision
-# floating-point precision of forecast output; options: [single, double]
-  forecastPrecision: single
-
 ## Analysis source
 # OPTIONS: GFSfromPANDACArchive, GFSfromRDAOnline, GFSfromNCEPFTPOnline
   AnalysisSource: GFSfromPANDACArchive
+
+## GraphInfoDir
+# directory containing x1.{{nCells}}.graph.info* files
+  GraphInfoDir: /glade/work/duda/static_moved_to_campaign


### PR DESCRIPTION
### Description
The sea-surface updating is carried out via the surface stream during the forecast execution instead of using the `ncks` command before the forecast.  The `updateSea` and forecast `precision` are moved to the new `forecast.yaml` base scenario configuration.  Other forecast-specific settings can be moved there eventually.

The `GraphInfoDir` setting is moved from `modeldata.csh` to the `model.yaml`  base scenario configuration.

### Issue closed

Closes #90

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart