### PR TITLE
Fix channel selection for NCDIAG AMSUA variational

### DIFF
--- a/config/ObsPlugs/variational/filters/amsua_aqua.yaml
+++ b/config/ObsPlugs/variational/filters/amsua_aqua.yaml
@@ -6,3 +6,19 @@
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter
+#  Useflag check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightness_temperature
+      channels: *amsua_aqua_channels
+    test variables:
+    - name: ChannelUseflagCheckRad@ObsFunction
+      channels: *amsua_aqua_channels
+      options:
+        channels: *amsua_aqua_channels
+        use_flag: [ -1, -1, -1, -1, -1,
+                    -1, -1,  1,  1, -1,
+                    -1, -1, -1, -1, -1 ]
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/config/ObsPlugs/variational/filters/amsua_metop-a.yaml
+++ b/config/ObsPlugs/variational/filters/amsua_metop-a.yaml
@@ -6,3 +6,19 @@
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter
+#  Useflag check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightness_temperature
+      channels: *amsua_metop-a_channels
+    test variables:
+    - name: ChannelUseflagCheckRad@ObsFunction
+      channels: *amsua_metop-a_channels
+      options:
+        channels: *amsua_metop-a_channels
+        use_flag: [ -1, -1, -1, -1,  1,
+                     1, -1, -1,  1, -1,
+                    -1, -1, -1, -1, -1 ]
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/config/ObsPlugs/variational/filters/amsua_metop-b.yaml
+++ b/config/ObsPlugs/variational/filters/amsua_metop-b.yaml
@@ -6,3 +6,19 @@
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter
+#  Useflag check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightness_temperature
+      channels: *amsua_metop-b_channels
+    test variables:
+    - name: ChannelUseflagCheckRad@ObsFunction
+      channels: *amsua_metop-b_channels
+      options:
+        channels: *amsua_metop-b_channels
+        use_flag: [ -1, -1, -1, -1, -1,
+                    -1, -1,  1,  1, -1,
+                    -1, -1, -1, -1, -1 ]
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/config/ObsPlugs/variational/filters/amsua_metop-c.yaml
+++ b/config/ObsPlugs/variational/filters/amsua_metop-c.yaml
@@ -6,3 +6,19 @@
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter
+#  Useflag check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightness_temperature
+      channels: *amsua_metop-c_channels
+    test variables:
+    - name: ChannelUseflagCheckRad@ObsFunction
+      channels: *amsua_metop-c_channels
+      options:
+        channels: *amsua_metop-c_channels
+        use_flag: [ -1, -1, -1, -1,  1,
+                     1,  1,  1,  1, -1,
+                    -1, -1, -1, -1, -1 ]
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/config/ObsPlugs/variational/filters/amsua_n15.yaml
+++ b/config/ObsPlugs/variational/filters/amsua_n15.yaml
@@ -6,3 +6,19 @@
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter
+#  Useflag check #amsua-n15
+  - filter: Bounds Check
+    filter variables:
+    - name: brightness_temperature
+      channels: *amsua_n15_channels
+    test variables:
+    - name: ChannelUseflagCheckRad@ObsFunction
+      channels: *amsua_n15_channels
+      options:
+        channels: *amsua_n15_channels
+        use_flag: [-1, -1, -1, -1,  1,
+                    1,  1,  1,  1, -1,
+                   -1, -1, -1, -1, -1 ]
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/config/ObsPlugs/variational/filters/amsua_n18.yaml
+++ b/config/ObsPlugs/variational/filters/amsua_n18.yaml
@@ -6,3 +6,19 @@
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter
+#  Useflag check #amsua-n18
+  - filter: Bounds Check
+    filter variables:
+    - name: brightness_temperature
+      channels: *amsua_n18_channels
+    test variables:
+    - name: ChannelUseflagCheckRad@ObsFunction
+      channels: *amsua_n18_channels
+      options:
+        channels: *amsua_n18_channels
+        use_flag: [-1, -1, -1, -1,  1,
+                    1,  1,  1,  1, -1,
+                   -1, -1, -1, -1, -1 ]
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/config/ObsPlugs/variational/filters/amsua_n19.yaml
+++ b/config/ObsPlugs/variational/filters/amsua_n19.yaml
@@ -6,3 +6,19 @@
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter
+#  Useflag check #amsua-n19
+  - filter: Bounds Check
+    filter variables:
+    - name: brightness_temperature
+      channels: *amsua_n19_channels
+    test variables:
+    - name: ChannelUseflagCheckRad@ObsFunction
+      channels: *amsua_n19_channels
+      options:
+        channels: *amsua_n19_channels
+        use_flag: [-1, -1, -1, -1,  1,
+                    1,  1, -1,  1, -1,
+                   -1, -1, -1, -1, -1 ]
+    minvalue: 1.0e-12
+    action:
+      name: reject


### PR DESCRIPTION
### Description
This PR fixes a bug in the channel selection for NCDIAG AMSUA variational. In order to account for the limited channel set for AMSUA instruments used in `PANDACArchive` experiments, the `Useflag check` was added to the base filters. This allows to use the same base yaml files for experiments using `PANDACArchive` or `*Online` data. The channel selection in the check follows the used before the last PR #92.

### Issue closed
Closes #95

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
