### PR TITLE
Update to `12JUL2022`  bundle build

### DIFF
--- a/config/builds.csh
+++ b/config/builds.csh
@@ -10,21 +10,15 @@ source config/scenario.csh builds
 ## build directory structures
 #############################
 
-# Note: at this time, all executables should be built in the same environment, one that is
-# consistent with config/environmentForJedi.csh
+# mpas-bundle applications
+# ========================
+# + at this time, all mpas-bundle executables should be built in the same environment, one that is
+#   consistent with config/environmentJEDI.csh
+# + it is preferred to build mpas-bundle with a single-precision MPAS-Model, such that
+#   set(MPAS_DOUBLE_PRECISION "OFF") is used in mpas-bundle/CMakeLists.txt
 
-# default build directory
+# default mpas-bundle build directory
 $setLocal commonBuild
-
-# Ungrib
-setenv ungribEXE ungrib.exe
-setenv WPSBuildDir /glade/work/guerrett/pandac/data/GEFS
-
-# Obs2IODA-v2
-setenv obs2iodaEXEC obs2ioda-v2.x
-setenv obs2iodaBuildDir /glade/p/mmm/parc/ivette/pandac/fork_obs2ioda/obs2ioda/obs2ioda-v2/src
-setenv iodaupgradeEXEC ioda-upgrade.x
-setenv iodaupgradeBuildDir ${commonBuild}/bin
 
 # MPAS-JEDI
 # ---------
@@ -50,20 +44,51 @@ setenv InitEXE mpas_init_${MPASCore}
 setenv InitBuildDir ${commonBuild}/bin
 setenv ForecastTopBuildDir ${commonBuild}
 
-# Use a static single-precision build of MPAS-A to conserve resources
-setenv ForecastBuildDir /glade/p/mmm/parc/liuz/pandac_common/20220309_mpas_bundle/code/MPAS-gnumpt-single
-setenv ForecastEXE ${MPASCore}_model
-
-# TODO: enable single-precision MPAS-A build in mpas-bundle, then use bundle-built executables
-# Note to developers: it is easier to use the ForecastBuildDir and ForecastEXE settings below when
-# modifying MPAS-Model source code.  The added expense is minimal for short-range cycling tests.
-# This also requires modifying the mpiexec executable in forecast.csh.
-#setenv ForecastBuildDir ${ForecastTopBuildDir}/bin
-#setenv ForecastEXE mpas_${MPASCore}
-
+# use forecast executable built in the bundle
+setenv ForecastBuildDir ${ForecastTopBuildDir}/bin
+setenv ForecastEXE mpas_${MPASCore}
 
 setenv MPASLookupDir ${ForecastTopBuildDir}/MPAS/core_${MPASCore}
 set MPASLookupFileGlobs = (.TBL .DBL DATA COMPATABILITY VERSION)
+
+# Alternatively, use a stand-alone single-precision build of MPAS-A with GNU-MPT
+#setenv ForecastBuildDir /glade/p/mmm/parc/liuz/pandac_common/20220309_mpas_bundle/code/MPAS-gnumpt-single
+#setenv ForecastEXE ${MPASCore}_model
+
+# Note: this also requires modifying the following modifications to forecast.csh:
+#@@ -28,7 +28,7 @@ source config/tools.csh
+# source config/model.csh
+# source config/modeldata.csh
+# source config/builds.csh
+#-source config/environmentJEDI.csh
+#+source config/environmentMPT.csh
+# source config/applications/forecast.csh
+# set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
+# set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
+#@@ -203,8 +203,8 @@ else
+#   rm ./${ForecastEXE}
+#   ln -sfv ${ForecastBuildDir}/${ForecastEXE} ./
+#   # mpiexec is for Open MPI, mpiexec_mpt is for MPT
+#-  mpiexec ./${ForecastEXE}
+#-  #mpiexec_mpt ./${ForecastEXE}
+#+  #mpiexec ./${ForecastEXE}
+#+  mpiexec_mpt ./${ForecastEXE}
+
+
+# Non-bundle applications
+# =======================
+
+# Ungrib
+# ------
+setenv ungribEXE ungrib.exe
+setenv WPSBuildDir /glade/work/guerrett/pandac/data/GEFS
+
+# Obs2IODA-v2
+# -----------
+setenv obs2iodaEXEC obs2ioda-v2.x
+setenv obs2iodaBuildDir /glade/p/mmm/parc/ivette/pandac/fork_obs2ioda/obs2ioda/obs2ioda-v2/src
+setenv iodaupgradeEXEC ioda-upgrade.x
+setenv iodaupgradeBuildDir ${commonBuild}/bin
 
 # Mean state calculator
 # ---------------------

--- a/config/builds.csh
+++ b/config/builds.csh
@@ -55,7 +55,7 @@ set MPASLookupFileGlobs = (.TBL .DBL DATA COMPATABILITY VERSION)
 #setenv ForecastBuildDir /glade/p/mmm/parc/liuz/pandac_common/20220309_mpas_bundle/code/MPAS-gnumpt-single
 #setenv ForecastEXE ${MPASCore}_model
 
-# Note: this also requires modifying the following modifications to forecast.csh:
+# Note: this also requires modifying forecast.csh:
 #@@ -28,7 +28,7 @@ source config/tools.csh
 # source config/model.csh
 # source config/modeldata.csh

--- a/config/jedi/ObsPlugs/hofx/base/gnssroref.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssroref.yaml
@@ -1,6 +1,6 @@
 - obs space:
     <<: *ObsSpace
-    name: GnssroRef
+    name: GnssroRefNCEP
     obsdatain:
       obsfile: {{InDBDir}}/gnssroref_obs_{{thisValidDate}}.h5
     obsdataout:
@@ -8,7 +8,7 @@
     simulated variables: [refractivity]
   obs error: *ObsErrorDiagonal
   obs operator:
-    name: GnssroRef
+    name: GnssroRefNCEP
     obs options:
       use_compress: 0
   get values:

--- a/config/jedi/ObsPlugs/hofx/filters/gnssroref.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/gnssroref.yaml
@@ -15,4 +15,4 @@
       maxvalue: 200.0
   - filter: ROobserror
     variable: refractivity
-    errmodel: NBAM
+    errmodel: NCEP

--- a/config/jedi/ObsPlugs/variational/base/gnssroref.yaml
+++ b/config/jedi/ObsPlugs/variational/base/gnssroref.yaml
@@ -1,6 +1,6 @@
 - obs space:
     <<: *ObsSpace
-    name: GnssroRef
+    name: GnssroRefNCEP
     obsdatain:
       obsfile: {{InDBDir}}/gnssroref_obs_{{thisValidDate}}.h5
     obsdataout:
@@ -8,7 +8,7 @@
     simulated variables: [refractivity]
   obs error: *ObsErrorDiagonal
   obs operator:
-    name: GnssroRef
+    name: GnssroRefNCEP
     obs options:
       use_compress: 0
   get values:

--- a/config/jedi/ObsPlugs/variational/filters/gnssroref.yaml
+++ b/config/jedi/ObsPlugs/variational/filters/gnssroref.yaml
@@ -15,7 +15,7 @@
       maxvalue: 200.0
   - filter: ROobserror
     variable: refractivity
-    errmodel: NBAM
+    errmodel: NCEP
     <<: *multiIterationFilter
   - filter: Background Check
     threshold: 3.0

--- a/forecast.csh
+++ b/forecast.csh
@@ -28,7 +28,7 @@ source config/tools.csh
 source config/model.csh
 source config/modeldata.csh
 source config/builds.csh
-source config/environmentMPT.csh
+source config/environmentJEDI.csh
 source config/applications/forecast.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
@@ -203,8 +203,8 @@ else
   rm ./${ForecastEXE}
   ln -sfv ${ForecastBuildDir}/${ForecastEXE} ./
   # mpiexec is for Open MPI, mpiexec_mpt is for MPT
-  #mpiexec ./${ForecastEXE}
-  mpiexec_mpt ./${ForecastEXE}
+  mpiexec ./${ForecastEXE}
+  #mpiexec_mpt ./${ForecastEXE}
 
 
   # Check status

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,3 +1,3 @@
 builds:
 # default build directory
-  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_16MAY2022
+  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_12JUL2022

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,3 +1,3 @@
 builds:
 # default build directory
-  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_12JUL2022
+  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_12JUL2022_single

--- a/scenarios/base/variational.yaml
+++ b/scenarios/base/variational.yaml
@@ -152,13 +152,13 @@ variational:
       bumpCovStdDevFile: None
       bumpCovVBalDir: None
     60km:
-      bumpCovDir: /glade/scratch/bjung/pandac/20220425_develop/60km.NICAS_00
-      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20220425_develop/60km.CMAT_00/mpas.stddev.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/scratch/bjung/pandac/20220425_develop/60km.VBAL_00
+      bumpCovDir: /glade/scratch/bjung/pandac/20220712_build/60km.NICAS_00
+      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20220712_build/60km.CMAT_00/mpas.stddev.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/scratch/bjung/pandac/20220712_build/60km.VBAL_00
     120km:
-      bumpCovDir: /glade/scratch/bjung/pandac/20220425_develop/NICAS_00
-      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20220425_develop/CMAT_00/mpas.stddev.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/scratch/bjung/pandac/20220425_develop/VBAL_00
+      bumpCovDir: /glade/scratch/bjung/pandac/20220712_build/NICAS_00
+      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20220712_build/CMAT_00/mpas.stddev.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/scratch/bjung/pandac/20220712_build/VBAL_00
 
   # resource requirements
   job:


### PR DESCRIPTION
### Description
Update to `12JUL2022`  bundle build, using single-precision in all bundle-built executables.  The forecast executable from the bundle is also used instead of a standalone GNU MPT build of MPAS-Atmosphere.

Required changes to naming in `gnssroref.yaml` files and updated covariance files from @byoung-joo.

### Issue closed

Closes #124

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart