### PR TITLE
Include gnu version in module load

### DIFF
--- a/config/environmentJEDI.csh
+++ b/config/environmentJEDI.csh
@@ -7,7 +7,7 @@ setenv config_environmentJEDI 1
 # {compiler}-{mpi-implementation} combination that selects the JEDI module used to build
 # the executables described in config/builds.csh
 # OPTIONS: gnu-openmpi, intel-impi
-setenv BuildCompiler 'gnu-openmpi'
+setenv BuildCompiler 'gnu-openmpi/10.1.0'
 
 source /etc/profile.d/modules.csh
 setenv OPT /glade/work/jedipara/cheyenne/opt/modules


### PR DESCRIPTION
### Description
Eliminates a possible source of errors by ensuring we use the correct gnu-openmpi module on Cheyenne.  Nobody reported this is causing errors, but we need to follow common practices between the bundle build and the workflow.

### Issue closed

Closes #129 

### Tests completed

- [x] 3dvar_OIE120km_WarmStart