### PR TITLE
Fix bug for AMSUA NOAA-15 PrepQC filter

### DIFF
--- a/config/jedi/ObsPlugs/variational/filters/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/variational/filters/amsua_n15.yaml
@@ -1,5 +1,6 @@
   obs filters:
   - filter: PreQC
+    maxvalue: 0
 #  Useflag check #amsua-n15
   - filter: Bounds Check
     filter variables:
@@ -16,7 +17,6 @@
     minvalue: 1.0e-12
     action:
       name: reject
-    maxvalue: 0
   - filter: GOMsaver
     filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n15.nc4
   - filter: Background Check


### PR DESCRIPTION
### Description
This PR fixes a bug found in the YAML for AMSUA NOAA 15 observations for the PrepQC filter. These observations are now assimilated after this fix, for example see lines from the 3dvar_OIE120km_WarmStart test jedi.log file:
```
Test     : CostJo   : Nonlinear Jo(amsua_n15) = 2.2456520079424557e+04, nobs = 38871, Jo/n = 5.7771912426808048e-01, err = 2.8053722255793490e-01
```

### Issue closed
Closes https://github.com/NCAR/MPAS-Workflow/issues/132

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
