### PR TITLE
Use `lev2d: last` in all `localization`-related `bump` configurations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,6 @@ Closes #(if applicable)
  - [ ] 3dvar_OIE120km_WarmStart
  - [ ] 3denvar_OIE120km_WarmStart
  - [ ] 3dvar_OIE120km_ColdStart
+ - [ ] 3dvar_O30kmIE60km_ColdStart
  - [ ] 3denvar_O30kmIE60km_WarmStart
  - [ ] eda_OIE120km_WarmStart

--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -60,6 +60,7 @@ cost function:
           io_keys: [temperature-temperature,spechum-spechum,uReconstructZonal-uReconstructZonal,uReconstructMeridional-uReconstructMeridional,surface_pressure-surface_pressure,qc-qc,qi-qi,qr-qr,qs-qs,qg-qg]
           #io_values: [dynamic,dynamic,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
           io_values: [dynamic,cloud,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
+          lev2d: last
           verbosity: main
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -56,6 +56,7 @@ cost function:
           datadir: {{bumpLocDir}}
           prefix: {{bumpLocPrefix}}
           strategy: common
+          lev2d: last
           load_nicas_local: true
           verbosity: main
 {{EnsemblePbMembers}}

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -62,7 +62,6 @@ cost function:
             prefix: {{bumpCovPrefix}}
             strategy: specific_univariate
             load_nicas_local: true
-            lev2d: last
             verbosity: main
         - saber block name: StdDev
           input variables: *ctlvars
@@ -83,7 +82,6 @@ cost function:
             vbal_block:     [ true,  true,false, false,false,false,  true,false,false,false]
             vbal_diag_reg:  [ true, false,false, false,false,false, false,false,false,false]
             vbal_diag_auto: [false, false,false, false,false,false, false,false,false,false]
-            lev2d: last
             verbosity: main
         linear variable change:
           linear variable change name: Control2Analysis

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -62,6 +62,7 @@ cost function:
             prefix: {{bumpCovPrefix}}
             strategy: specific_univariate
             load_nicas_local: true
+            lev2d: last
             verbosity: main
         - saber block name: StdDev
           input variables: *ctlvars
@@ -82,6 +83,7 @@ cost function:
             vbal_block:     [ true,  true,false, false,false,false,  true,false,false,false]
             vbal_diag_reg:  [ true, false,false, false,false,false, false,false,false,false]
             vbal_diag_auto: [false, false,false, false,false,false, false,false,false,false]
+            lev2d: last
             verbosity: main
         linear variable change:
           linear variable change name: Control2Analysis
@@ -102,6 +104,7 @@ cost function:
               prefix: {{bumpLocPrefix}}
               strategy: common
               load_nicas_local: true
+              lev2d: last
               verbosity: main
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -45,7 +45,6 @@ cost function:
         prefix: {{bumpCovPrefix}}
         strategy: specific_univariate
         load_nicas_local: true
-        lev2d: last
         verbosity: main
     - saber block name: StdDev
       input variables: *ctlvars
@@ -66,7 +65,6 @@ cost function:
         vbal_block:     [ true,  true,false, false,false,false,  true,false,false,false]
         vbal_diag_reg:  [ true, false,false, false,false,false, false,false,false,false]
         vbal_diag_auto: [false, false,false, false,false,false, false,false,false,false]
-        lev2d: last
         verbosity: main
     linear variable change:
       linear variable change name: Control2Analysis

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -45,6 +45,7 @@ cost function:
         prefix: {{bumpCovPrefix}}
         strategy: specific_univariate
         load_nicas_local: true
+        lev2d: last
         verbosity: main
     - saber block name: StdDev
       input variables: *ctlvars
@@ -65,6 +66,7 @@ cost function:
         vbal_block:     [ true,  true,false, false,false,false,  true,false,false,false]
         vbal_diag_reg:  [ true, false,false, false,false,false, false,false,false,false]
         vbal_diag_auto: [false, false,false, false,false,false, false,false,false,false]
+        lev2d: last
         verbosity: main
     linear variable change:
       linear variable change name: Control2Analysis

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,3 +1,6 @@
 builds:
 # default build directory
   commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_10AUG2022
+
+  # optional single-precision build for resource savings
+  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_10AUG2022_single

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,3 +1,3 @@
 builds:
 # default build directory
-  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_12JUL2022_single
+  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_10AUG2022

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,6 +1,6 @@
 builds:
 # default build directory
-  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_10AUG2022
+  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_10AUG2022_single
 
-  # optional single-precision build for resource savings
-  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_10AUG2022_single
+  # optional double-precision build
+  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_10AUG2022

--- a/scenarios/base/variational.yaml
+++ b/scenarios/base/variational.yaml
@@ -220,13 +220,13 @@ variational:
       #  bumpLocDir: str
       30km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/30km/bumploc/h=1200.0km_v=6.0km_12JUL2022code
+        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/30km/bumploc/h=1200.0km_v=6.0km_10AUG2022code
       60km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/60km/bumploc/h=1200.0km_v=6.0km_12JUL2022code
+        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/60km/bumploc/h=1200.0km_v=6.0km_10AUG2022code
       120km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/120km/bumploc/h=1200.0km_v=6.0km_12JUL2022code
+        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/120km/bumploc/h=1200.0km_v=6.0km_10AUG2022code
 
   # externally-produced background covariance files (var or hybrid)
   covariance:

--- a/scenarios/base/variational.yaml
+++ b/scenarios/base/variational.yaml
@@ -220,13 +220,13 @@ variational:
       #  bumpLocDir: str
       30km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/30km/bumploc/h=1200.0km_v=6.0km_25APR2022code
+        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/30km/bumploc/h=1200.0km_v=6.0km_12JUL2022code
       60km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/60km/bumploc/h=1200.0km_v=6.0km_25APR2022code
+        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/60km/bumploc/h=1200.0km_v=6.0km_12JUL2022code
       120km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/120km/bumploc/h=1200.0km_v=6.0km_25APR2022code
+        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/120km/bumploc/h=1200.0km_v=6.0km_12JUL2022code
 
   # externally-produced background covariance files (var or hybrid)
   covariance:

--- a/scenarios/base/variational.yaml
+++ b/scenarios/base/variational.yaml
@@ -247,13 +247,13 @@ variational:
       bumpCovStdDevFile: None
       bumpCovVBalDir: None
     60km:
-      bumpCovDir: /glade/scratch/bjung/pandac/20220712_build/60km.NICAS_00
-      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20220712_build/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/scratch/bjung/pandac/20220712_build/60km.VBAL_00
+      bumpCovDir: /glade/scratch/bjung/pandac/20220810_develop/60km.NICAS_00
+      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20220810_develop/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/scratch/bjung/pandac/20220810_develop/60km.VBAL_00
     120km:
-      bumpCovDir: /glade/scratch/bjung/pandac/20220712_build/NICAS_00
-      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20220712_build/CMAT_00/mpas.stddev.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/scratch/bjung/pandac/20220712_build/VBAL_00
+      bumpCovDir: /glade/scratch/bjung/pandac/20220810_develop/NICAS_00
+      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20220810_develop/CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/scratch/bjung/pandac/20220810_develop/VBAL_00
 
   # resource requirements
   job:

--- a/scenarios/testinput/3denvar_O30kmIE60km_WarmStart.yaml
+++ b/scenarios/testinput/3denvar_O30kmIE60km_WarmStart.yaml
@@ -24,6 +24,11 @@ variational:
   ensemble:
     forecasts:
       resource: "PANDAC.GEFS"
+  job:
+    30km:
+      60km:
+        3denvar:
+          memory: 45
 job:
   CPQueueName: economy
   NCPQueueName: economy

--- a/scenarios/testinput/3dvar_O30kmIE60km_ColdStart.yaml
+++ b/scenarios/testinput/3dvar_O30kmIE60km_ColdStart.yaml
@@ -27,8 +27,14 @@ externalanalyses:
   resource: "GFS.RDA"
 variational:
   DAType: 3dvar
-  nInnerIterations: [15,]
+  nInnerIterations: [30,]
   biasCorrection: True
+  job:
+    30km:
+      60km:
+        3dvar:
+          memory: 45
+
 job:
   CPQueueName: economy
   NCPQueueName: economy


### PR DESCRIPTION
### Description

Old default build (`12JUL2022`) was not up-to-date, and should not be used from this point forward.  See related discussions:
https://github.com/JCSDA-internal/mpas-jedi/pull/757
https://github.com/JCSDA-internal/mpas-jedi/issues/768

#### Update code and default build
**code**: /glade/work/guerrett/pandac/code/mpas-bundleSources/mpas-bundle_10AUG2022
**build (double-precision)**: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_10AUG2022
**build (single-precision)**: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_10AUG2022_single

**New practice**:  do not modify any of the build/code directories. If we need to switch to a new default build, create a new code directory and archive the old code directory for our records.

#### Bugfixes needed for this build:
- Include `lev2d: last` in all `localization`-related `bump` configurations, including in the yaml's used to generate the localization files outside the workflow
- Updated localization and covariance files, which includes a bugfix in https://github.com/JCSDA-internal/mpas-jedi/pull/757

#### Additionally
- Added `3dvar_O30kmIE60km_ColdStart` to the pull request test list, which should have been part of #123.
- Increased inner iterations to 30 for `3dvar_O30kmIE60km_ColdStart` to avoid NaN in w field errors in subsequent forecast
- Reduced dual-mesh test variational memory to 45GB from 109GB in order to reduce queue times

### Issue closed

Closes #136

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
