### PR TITLE
Update variational resources, fix bugs in 3dvar_O30kmIE60km_ColdStart

### DIFF
--- a/scenarios/3dvar_O30kmIE60km_ColdStart.yaml
+++ b/scenarios/3dvar_O30kmIE60km_ColdStart.yaml
@@ -1,6 +1,6 @@
 workflow:
   firstCyclePoint: 20220217T18
-  initialCyclePoint: 20220218T00
+  initialCyclePoint: 20220217T18
   finalCyclePoint: 20220228T00
   VerifyEnsMeanBG: False
 observations:
@@ -9,6 +9,14 @@ model:
   outerMesh: 30km
   innerMesh: 60km
   ensembleMesh: 60km
+  # Need x1.655362.static.nc to include var2d, con, oa{1,2,3,4}, and ol{1,2,3,4} fields
+  # alternatively could use /glade/work/liuz/pandac/prepare_mpas/mpas_static_30km/x1.655362.static.nc,
+  # but no such file exists for 60km mesh.  This might skew comparisons to 30km GFS analyses produced
+  # offline using /glade/work/liuz/pandac/prepare_mpas/mpas_static_30km/x1.655362.static.nc.  The
+  # ultimate action item then is to look deeper into the x1.*.static.nc file generation process,
+  # and determine if it is viable to bring into the workflow.  Ideally those files should be
+  # generated using the same MPAS-A code version as is used in the initic and forecast applications.
+  GraphInfoDir: /glade/work/duda/static_moved_to_campaign
 firstbackground:
   resource: "ForecastFromAnalysis"
 externalanalyses:
@@ -16,3 +24,4 @@ externalanalyses:
 variational:
   DAType: 3dvar
   biasCorrection: True
+  nInnerIterations: [60,60]

--- a/scenarios/base/variational.yaml
+++ b/scenarios/base/variational.yaml
@@ -257,8 +257,7 @@ variational:
 
   # resource requirements
   job:
-    # TODO: determine job settings for 3dhybrid; for now use 3denvar settings for non-3dvar DAType's
-    # TODO: update with latest resource requirements following GetValues refactoring
+    ## FORMAT
     #{{outerMesh}}:
     #  {{innerMesh}}:
     #    {{DAType}}: # i.e., 3dvar, 3denvar, 3dhybrid, 4denvar, etc...
@@ -268,76 +267,82 @@ variational:
     #      nodes: int
     #      PEPerNode: int
     #      memory: int
+    ## All resource requests below are based on
+    # + single-precision bundle build
+    # + sondes, aircraft, sfc, gnssro, satwind, 6 clear amsua
+    # These are starting points.  When more memory is needed (e.g., more observations, more EnVar
+    # memmbers) than is available in default resource requests below, use more nodes and keep
+    # the product of (nodes x PEPerNode) constant. If (nodes x PEPerNode) is modifed, new
+    # localization or covariance files may be needed.
     30km:
-      30km: #120 inner total
+      # Assuming 120 total inner iterations
+      30km:
         3denvar:
+          nodes: 64
+          PEPerNode: 8
+          memory: 45
           baseSeconds: 1500
           secondsPerEnVarMember: 5
+        3dvar:
           nodes: 64
           PEPerNode: 8
           memory: 45
-        3dvar:
           baseSeconds: 1500
-          nodes: 64
-          PEPerNode: 8
-          memory: 45
-      60km: #120 inner total
-        3denvar:
-          # single-precision bundle build
-          nodes: 6
-          PEPerNode: 32
-          memory: 109
-          baseSeconds: 200
-          secondsPerEnVarMember: 10
-        3dhybrid:
-          # single-precision bundle build
-          nodes: 6
-          PEPerNode: 32
-          memory: 109
-          baseSeconds: 250
-          secondsPerEnVarMember: 10
-        3dvar:
-          baseSeconds: 1200
-          nodes: 6
-          PEPerNode: 32
-          memory: 109
-    60km: #60 inner total
       60km:
         3denvar:
+          nodes: 6
+          PEPerNode: 32
+          memory: 45
+          baseSeconds: 400
+          secondsPerEnVarMember: 9
+        3dhybrid:
+          nodes: 6
+          PEPerNode: 32
+          memory: 45
+          baseSeconds: 500
+          secondsPerEnVarMember: 9
+        3dvar:
+          nodes: 6
+          PEPerNode: 32
+          memory: 45
+          baseSeconds: 500
+    60km:
+      # Assuming 60 total inner iterations
+      60km:
+        3denvar:
+          nodes: 4
+          PEPerNode: 36
+          memory: 45
+          baseSeconds: 200
+          secondsPerEnVarMember: 6
           # double-precision bundle build
           ##nodes: 6
           ##PEPerNode: 32
           ##memory: 45
           ##baseSeconds: 200
           ##secondsPerEnVarMember: 6
-          # single-precision bundle build
-          nodes: 4
-          PEPerNode: 36
-          memory: 45
-          baseSeconds: 200
-          secondsPerEnVarMember: 6
         3dhybrid:
-          # single-precision bundle build (approximated from 3denvar)
           nodes: 4
           PEPerNode: 36
           memory: 45
           baseSeconds: 250
           secondsPerEnVarMember: 6
         3dvar:
-          baseSeconds: 500
           nodes: 6
           PEPerNode: 32
-          memory: 109
-    120km: #60 inner total
+          memory: 45
+          baseSeconds: 250
+    120km:
+      # Assuming 60 total inner iterations
       120km:
         3denvar:
-          baseSeconds: 360
+          nodes: 4
+          PEPerNode: 32
+          memory: 45
+          baseSeconds: 200
           secondsPerEnVarMember: 5
-          nodes: 4
-          PEPerNode: 32
-          memory: 45
         3dvar:
-          baseSeconds: 360
           nodes: 4
           PEPerNode: 32
           memory: 45
+          baseSeconds: 200

--- a/scenarios/eda_OIE60km_WarmStart.yaml
+++ b/scenarios/eda_OIE60km_WarmStart.yaml
@@ -20,22 +20,6 @@ variational:
   DAType: 3denvar
   SelfExclusion: True
   maxIODAPoolSize: 3
-  job:
-    60km:
-      60km:
-        #NOTE: increase memory and time when instruments are added beyond conv + clear-amsua
-        3denvar:
-          nodes: 6
-          PEPerNode: 32
-          memory: 45
-          baseSeconds: 200
-          secondsPerEnVarMember: 6
-          #if single-precision mpas-jedi
-          #nodes: 4
-          #PEPerNode: 36
-          #memory: 45
-          #baseSeconds: 200
-          #secondsPerEnVarMember: 6
 hofx:
   maxIODAPoolSize: 3
 rtpp:


### PR DESCRIPTION
### Description

There have been many improvements in mpas-jedi recently that have reduced wall-time and memory usage. This PR adjusts memory and wall times for `variational`, with special attention on `30km.60km` settings.

Also fix some bugs in the `3dvar_O30kmIE60km_ColdStart` scenario so that forecasts are successful and it is comparable to other `30km.60km` scenarios.

The job resource settings for `eda_OIE60km_WarmStart` are now identical to the defaults.  So the special settings in the scenario YAML are removed.

### Issue closed

Closes #137

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart