### PR TITLE
Update env-setup scripts for more general usage

### DIFF
--- a/env-setup/cheyenne.csh
+++ b/env-setup/cheyenne.csh
@@ -1,6 +1,20 @@
+#!/bin/tcsh -f
+
+# Use deactivate to remove NPL from environment if it is activated
+which deactivate >& /dev/null
+if ($? == 0) then
+  deactivate
+endif
+
 source /etc/profile.d/modules.csh
+module purge
+module load ncarenv/1.3
+module load gnu/10.1.0
+module load ncarcompilers/0.5.0
+module load netcdf/4.8.1
 module load conda/latest
 conda activate npl
+setenv PYTHONDONTWRITEBYTECODE 1 # avoid __pycache__ creation
 
 # "conda init" modifies ~/.tcshrc in order to enable conda in batch jobs.  If conda is loaded in
 # a csh/tcsh script that is part of a batch job, the following line is needed.
@@ -13,6 +27,7 @@ conda activate npl
 # are migrated to "~/.tcshrc", users should have their expected environment restored.
 
 module load cylc
+module load graphviz
 module load git
 git lfs install
 module list

--- a/env-setup/cheyenne.sh
+++ b/env-setup/cheyenne.sh
@@ -1,6 +1,20 @@
+#!/bin/bash -f
+
+# Use deactivate to remove NPL from environment if it is activated
+type deactivate >& /dev/null
+if [ $? -eq 0 ]; then
+  deactivate
+fi
+
 source /etc/profile.d/modules.sh
+module purge
+module load ncarenv/1.3
+module load gnu/10.1.0
+module load ncarcompilers/0.5.0
+module load netcdf/4.8.1
 module load conda/latest
 conda activate npl
+export PYTHONDONTWRITEBYTECODE=1 # avoid __pycache__ creation
 
 # "conda init" modifies ~/.bashrc in order to enable conda in batch jobs.  If conda is loaded in
 # a bash script that is part of a batch job, the following line is needed.
@@ -11,6 +25,7 @@ conda activate npl
 # because that flag prevents sourcing ~/.bashrc.
 
 module load cylc
+module load graphviz
 module load git
 git lfs install
 module list


### PR DESCRIPTION
### Description
The current `env-setup` scripts are not sensitive to individual users' `.tcshrc`, `.bashrc`, or other similar login settings files.  This PR introduces measures in `env-setup` to ensure that users load the modules expected by the workflow.  Additional modules are up to the user after that.

### Issue closed

None

### Tests completed
Used for setting up environment for real experiments
