### PR TITLE
Add 15x15 ABI and AHI to GenerateObs files

### DIFF
--- a/scenarios/base/observations.yaml
+++ b/scenarios/base/observations.yaml
@@ -194,13 +194,27 @@ observations:
       amsua-cld_n15: amsua_n15
       amsua-cld_n18: amsua_n18
       amsua-cld_n19: amsua_n19
+      abi-clr_g16: abi_g16
+      ahi-clr_himawari8: ahi_himawari8
 
     IODADirectory:
       variational:
         common: /glade/p/mmm/parc/guerrett/pandac/fixed_input/GenerateObs/Observations
+        abi_g16: /glade/work/guerrett/pandac/obs/ABIASR/ioda-v2/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+        abi-clr_g16: /glade/work/guerrett/pandac/obs/ABIASR/ioda-v2/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
+        ahi_himawari8: /glade/work/guerrett/pandac/obs/AHIASR/ioda-v2/IODANC_SUPEROB15X15_no-bias-correct
+        ahi-clr_himawari8: /glade/work/guerrett/pandac/obs/AHIASR/ioda-v2/IODANC_SUPEROB15X15_no-bias-correct
 
       hofx:
         common: /glade/p/mmm/parc/guerrett/pandac/fixed_input/GenerateObs/Observations
+        abi_g16: /glade/work/guerrett/pandac/obs/ABIASR/ioda-v2/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+        abi-clr_g16: /glade/work/guerrett/pandac/obs/ABIASR/ioda-v2/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
+        ahi_himawari8: /glade/work/guerrett/pandac/obs/AHIASR/ioda-v2/IODANC_SUPEROB15X15_no-bias-correct
+        ahi-clr_himawari8: /glade/work/guerrett/pandac/obs/AHIASR/ioda-v2/IODANC_SUPEROB15X15_no-bias-correct
+
+    IODASuperObGrid:
+      abi_g16: 15X15
+      ahi_himawari8: 15X15
 
 
 ## CRTM


### PR DESCRIPTION
### Description
Useful if anybody wants to use the `GenerateObs` files for verification.  These are "raw" converted files generated by MPAS-Workflow for the 2018 time period, including 2018051500 to 2018052418.  For now, the ABI and AHI files are those converted from WRFDA.  In time they will be replaced with files converted using @ibanos90's new functionality.  Then the changes in this PR can be reverted.

You can use these files by setting `observations.resource` to `GenerateObs` in the scenario YAML.

### Issue closed
None

### Tests completed
Not applicable