### PR TITLE
Prepare external analyses past final cycle point

### DIFF
--- a/ExternalAnalysisToMPAS.csh
+++ b/ExternalAnalysisToMPAS.csh
@@ -6,6 +6,16 @@
 # ArgMesh: str, mesh name, one of allMeshesJinja
 set ArgMesh = "$1"
 
+# ArgDT: int, valid time offset beyond CYLC_TASK_CYCLE_POINT in hours
+set ArgDT = "$2"
+
+set test = `echo $ArgDT | grep '^[0-9]*$'`
+set isNotInt = ($status)
+if ( $isNotInt ) then
+  echo "ERROR in $0 : ArgDT must be an integer, not $ArgDT"
+  exit 1
+endif
+
 date
 
 # Setup environment
@@ -16,10 +26,11 @@ source config/builds.csh
 source config/environmentJEDI.csh
 source config/applications/initic.csh
 source config/externalanalyses.csh
+source config/tools.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}
-set thisValidDate = ${thisCycleDate}
+set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
 source ./getCycleVars.csh
 
 # static work directory

--- a/GetGFSAnalysisFromFTP.csh
+++ b/GetGFSAnalysisFromFTP.csh
@@ -1,6 +1,19 @@
 #!/bin/csh -f
 # Get GFS analysis (0-h forecast) for cold start initial conditions
 
+# Process arguments
+# =================
+## args
+# ArgDT: int, valid time offset beyond CYLC_TASK_CYCLE_POINT in hours
+set ArgDT = "$1"
+
+set test = `echo $ArgDT | grep '^[0-9]*$'`
+set isNotInt = ($status)
+if ( $isNotInt ) then
+  echo "ERROR in $0 : ArgDT must be an integer, not $ArgDT"
+  exit 1
+endif
+
 date
 
 # Setup environment
@@ -8,11 +21,11 @@ date
 source config/builds.csh
 source config/experiment.csh
 #source config/externalanalyses.csh
+source config/tools.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
-set yy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}
-set thisValidDate = ${thisCycleDate}
+set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
 
 set res = 0p25
 set fhour = 000

--- a/GetGFSAnalysisFromRDA.csh
+++ b/GetGFSAnalysisFromRDA.csh
@@ -1,17 +1,31 @@
 #!/bin/csh -f
 # Get GFS analysis (0-h forecast) for cold start initial conditions
 
+# Process arguments
+# =================
+## args
+# ArgDT: int, valid time offset beyond CYLC_TASK_CYCLE_POINT in hours
+set ArgDT = "$1"
+
+set test = `echo $ArgDT | grep '^[0-9]*$'`
+set isNotInt = ($status)
+if ( $isNotInt ) then
+  echo "ERROR in $0 : ArgDT must be an integer, not $ArgDT"
+  exit 1
+endif
+
 date
 
 # Setup environment
 # =================
 source config/builds.csh
 source config/experiment.csh
+source config/tools.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set yy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}
-set thisValidDate = ${thisCycleDate}
+set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
 
 set res = 0p25
 set fhour = 000

--- a/GetObs.csh
+++ b/GetObs.csh
@@ -2,6 +2,19 @@
 # Get observations for a cold start experiment
 # from the NCEP FTP BUFR/PrepBUFR files or CISL RDA archived NCEP BUFR files
 
+# Process arguments
+# =================
+## args
+# ArgDT: int, valid time offset beyond CYLC_TASK_CYCLE_POINT in hours
+set ArgDT = "$1"
+
+set test = `echo $ArgDT | grep '^[0-9]*$'`
+set isNotInt = ($status)
+if ( $isNotInt ) then
+  echo "ERROR in $0 : ArgDT must be an integer, not $ArgDT"
+  exit 1
+endif
+
 date
 
 # Setup environment
@@ -10,12 +23,13 @@ source config/workflow.csh
 source config/observations.csh
 source config/experiment.csh
 source config/builds.csh
+source config/tools.csh
 set yyyymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
-set ccyy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c1-4`
-set mmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c5-8`
+set ccyy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
+set mmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 5-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yyyymmdd}${hh}
-set thisValidDate = ${thisCycleDate}
+set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
 source ./getCycleVars.csh
 
 # templated work directory

--- a/LinkExternalAnalysis.csh
+++ b/LinkExternalAnalysis.csh
@@ -7,6 +7,16 @@
 # ArgMesh: str, mesh name, one of allMeshesJinja
 set ArgMesh = "$1"
 
+# ArgDT: int, valid time offset beyond CYLC_TASK_CYCLE_POINT in hours
+set ArgDT = "$2"
+
+set test = `echo $ArgDT | grep '^[0-9]*$'`
+set isNotInt = ($status)
+if ( $isNotInt ) then
+  echo "ERROR in $0 : ArgDT must be an integer, not $ArgDT"
+  exit 1
+endif
+
 date
 
 # Setup environment
@@ -15,11 +25,11 @@ source config/builds.csh
 source config/experiment.csh
 source config/externalanalyses.csh
 source config/model.csh
+source config/tools.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
-set yy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}
-set thisValidDate = ${thisCycleDate}
+set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
 source ./getCycleVars.csh
 
 if ("$ArgMesh" == "$outerMesh") then

--- a/ObsToIODA.csh
+++ b/ObsToIODA.csh
@@ -1,6 +1,19 @@
 #!/bin/csh -f
 #Convert CISL RDA archived NCEP BUFR files to IODA-v2 format based on Jamie Bresch (NCAR/MMM) script rda_obs2ioda.csh
 
+# Process arguments
+# =================
+## args
+# ArgDT: int, valid time offset beyond CYLC_TASK_CYCLE_POINT in hours
+set ArgDT = "$1"
+
+set test = `echo $ArgDT | grep '^[0-9]*$'`
+set isNotInt = ($status)
+if ( $isNotInt ) then
+  echo "ERROR in $0 : ArgDT must be an integer, not $ArgDT"
+  exit 1
+endif
+
 date
 
 # Setup environment
@@ -8,12 +21,12 @@ date
 source config/observations.csh
 source config/experiment.csh
 source config/builds.csh
+source config/tools.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
-set ccyy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c1-4`
-set mmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c5-8`
+set ccyy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}
-set thisValidDate = ${thisCycleDate}
+set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
 source ./getCycleVars.csh
 
 # templated work directory

--- a/UngribExternalAnalysis.csh
+++ b/UngribExternalAnalysis.csh
@@ -1,5 +1,18 @@
 #!/bin/csh -f
 
+# Process arguments
+# =================
+## args
+# ArgDT: int, valid time offset beyond CYLC_TASK_CYCLE_POINT in hours
+set ArgDT = "$1"
+
+set test = `echo $ArgDT | grep '^[0-9]*$'`
+set isNotInt = ($status)
+if ( $isNotInt ) then
+  echo "ERROR in $0 : ArgDT must be an integer, not $ArgDT"
+  exit 1
+endif
+
 date
 
 # Setup environment
@@ -9,11 +22,11 @@ source config/experiment.csh
 source config/builds.csh
 source config/applications/initic.csh
 source config/externalanalyses.csh
+source config/tools.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
-set yy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}
-set thisValidDate = ${thisCycleDate}
+set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
 source ./getCycleVars.csh
 
 # static work directory

--- a/drive.csh
+++ b/drive.csh
@@ -217,10 +217,11 @@ cat >! suite.rc << EOF
 ## Mini-workflow that prepares observations for IODA ingest
 {% if observationsResource == "PANDACArchive" %}
   # assume that IODA observation files are already available for PANDACArchive case
-  {% set PrepareObservations = "ObsReady" %}
+  {% set PrepareObservationsTasks = ["ObsReady"] %}
 {% else %}
-  {% set PrepareObservations = "GetObs => ObsToIODA => ObsReady" %}
+  {% set PrepareObservationsTasks = ["GetObs", "ObsToIODA", "ObsReady"] %}
 {% endif %}
+{% set PrepareObservations = " => ".join(PrepareObservationsTasks) %}
 
 # Use external analysis for sea surface updating
 {% set PrepareSeaSurfaceUpdate = PrepareExternalAnalysisOuter %}

--- a/drive.csh
+++ b/drive.csh
@@ -215,8 +215,8 @@ cat >! suite.rc << EOF
 {% set maxActiveCyclePoints = ${maxActiveCyclePoints} %}
 
 ## Mini-workflow that prepares observations for IODA ingest
-{% if observationsResource == "PANDACArchive" %}
-  # assume that IODA observation files are already available for PANDACArchive case
+{% if observationsResource in ["PANDACArchive", "GenerateObs"] %}
+  # assume that IODA observation files are already available for pre-generated cases
   {% set PrepareObservationsTasks = ["ObsReady"] %}
 {% else %}
   {% set PrepareObservationsTasks = ["GetObs", "ObsToIODA", "ObsReady"] %}

--- a/include/criticalpath.rc
+++ b/include/criticalpath.rc
@@ -35,9 +35,6 @@
 
 {% elif CriticalPathType == "Bypass" %}
   {% set CleanDataAssim = 'Null' %}
-    [[[{{AnalysisTimes}}]]]
-      graph = DataAssimFinished
-
     [[[{{ForecastTimes}}]]]
       graph = ForecastFinished
 
@@ -60,4 +57,18 @@
 
 {% else %}
     {{ raise('CriticalPathType is not valid') }}
+{% endif %}
+
+# optional extended forecasts for verification
+{% if VerifyExtendedMeanFC %}
+    [[[{{ExtendedMeanFCTimes}}]]]
+      graph = '''
+        DataAssimFinished => MeanAnalysis => ExtendedMeanFC => ExtendedForecastFinished
+      '''
+{% endif %}
+{% if VerifyExtendedEnsFC and nMembers > 1 %}
+    [[[{{ExtendedEnsFCTimes}}]]]
+      graph = '''
+        DataAssimFinished => ExtendedEnsFC:succeed-all => ExtendedForecastFinished
+      '''
 {% endif %}

--- a/include/tasks.rc
+++ b/include/tasks.rc
@@ -114,7 +114,6 @@ conda activate npl
   [[ObsToIODA]]
     inherit = ObsToIODA-0hr
   [[ObsReady]]
-    inherit = ObsReady-0hr
 
 
 ## Data assimilation and supporting tasks (critical path)
@@ -290,7 +289,6 @@ conda activate npl
     inherit = ExternalAnalysisToMPAS-{{mesh}}-0hr
 {% endfor %}
   [[ExternalAnalysisReady]]
-    inherit = ExternalAnalysisReady-0hr
 
   [[GetGDASanalysis]]
     inherit = BATCH

--- a/include/tasks.rc
+++ b/include/tasks.rc
@@ -35,7 +35,9 @@ conda activate npl
       -q = {{CPQueueName}}
       -A = {{CPAccountNumber}}
       -l = select={{CyclingFCNodes}}:ncpus={{CyclingFCPEPerNode}}:mpiprocs={{CyclingFCPEPerNode}}
+  [[ExtendedForecast]]
   [[ExtendedFCBase]]
+    inherit = ExtendedForecast
     [[[job]]]
       execution time limit = PT{{ExtendedFCSeconds}}S
     [[[directives]]]
@@ -299,6 +301,7 @@ conda activate npl
 
 ## Verification: extended forecast from mean analysis (including single-member deterministic)
   [[ExtendedForecastFinished]]
+    inherit = ExtendedForecast
   [[MeanAnalysis]]
     inherit = BATCH
     script = $origin/MeanAnalysis.csh

--- a/include/tasks.rc
+++ b/include/tasks.rc
@@ -83,15 +83,17 @@ conda activate npl
   [[Null]]
 
 ## Observations
-  [[GetObs]]
-    inherit = BATCH
-    script = $origin/GetObs.csh
+  [[Observations]]
+{% for dt in ExtendedFCLengths %}
+  [[GetObs-{{dt}}hr]]
+    inherit = Observations, BATCH
+    script = $origin/GetObs.csh "{{dt}}"
     [[[job]]]
       execution time limit = PT10M
       execution retry delays = {{GetObsRetry}}
-  [[ObsToIODA]]
-    inherit = BATCH
-    script = $origin/ObsToIODA.csh
+  [[ObsToIODA-{{dt}}hr]]
+    inherit = Observations, BATCH
+    script = $origin/ObsToIODA.csh "{{dt}}"
     [[[job]]]
       execution time limit = PT10M
       execution retry delays = {{InitializationRetry}}
@@ -104,7 +106,15 @@ conda activate npl
       -q = {{CPQueueName}}
       -A = {{CPAccountNumber}}
       -l = select=1:ncpus=1:mem=10GB
+  [[ObsReady-{{dt}}hr]]
+    inherit = Observations
+{% endfor %}
+  [[GetObs]]
+    inherit = GetObs-0hr
+  [[ObsToIODA]]
+    inherit = ObsToIODA-0hr
   [[ObsReady]]
+    inherit = ObsReady-0hr
 
 
 ## Data assimilation and supporting tasks (critical path)
@@ -219,22 +229,25 @@ conda activate npl
       #       independent task for each member)
       execution time limit = PT10M
       execution retry delays = {{InitializationRetry}}
-  [[GetGFSAnalysisFromRDA]]
-    inherit = BATCH
-    script = $origin/GetGFSAnalysisFromRDA.csh
-    [[[job]]]
-      execution time limit = PT20M
-      execution retry delays = {{GFSAnalysisRetry}}
-  [[GetGFSAnalysisFromFTP]]
-    inherit = BATCH
-    script = $origin/GetGFSAnalysisFromFTP.csh
-    [[[job]]]
-      execution time limit = PT20M
-      execution retry delays = {{GFSAnalysisRetry}}
 
-  [[UngribExternalAnalysis]]
-    inherit = BATCH
-    script = $origin/UngribExternalAnalysis.csh
+  # external analyses
+  [[ExternalAnalyses]]
+{% for dt in ExtendedFCLengths %}
+  [[GetGFSAnalysisFromRDA-{{dt}}hr]]
+    inherit = ExternalAnalyses, BATCH
+    script = $origin/GetGFSAnalysisFromRDA.csh "{{dt}}"
+    [[[job]]]
+      execution time limit = PT20M
+      execution retry delays = {{GFSAnalysisRetry}}
+  [[GetGFSAnalysisFromFTP-{{dt}}hr]]
+    inherit = ExternalAnalyses, BATCH
+    script = $origin/GetGFSAnalysisFromFTP.csh "{{dt}}"
+    [[[job]]]
+      execution time limit = PT20M
+      execution retry delays = {{GFSAnalysisRetry}}
+  [[UngribExternalAnalysis-{{dt}}hr]]
+    inherit = ExternalAnalyses, BATCH
+    script = $origin/UngribExternalAnalysis.csh "{{dt}}"
     [[[job]]]
       execution time limit = PT5M
       execution retry delays = {{InitializationRetry}}
@@ -243,17 +256,15 @@ conda activate npl
     [[[directives]]]
       -q = {{CPQueueName}}
       -A = {{CPAccountNumber}}
-
-{% for mesh in allMeshes %}
-  [[LinkExternalAnalysis-{{mesh}}]]
-    inherit = BATCH
-    script = $origin/LinkExternalAnalysis.csh "{{mesh}}"
+  {% for mesh in allMeshes %}
+  [[LinkExternalAnalysis-{{mesh}}-{{dt}}hr]]
+    inherit = ExternalAnalyses, BATCH
+    script = $origin/LinkExternalAnalysis.csh "{{mesh}}" "{{dt}}"
     [[[job]]]
       execution time limit = PT30S
-
-  [[ExternalAnalysisToMPAS-{{mesh}}]]
-    inherit = BATCH
-    script = $origin/ExternalAnalysisToMPAS.csh "{{mesh}}"
+  [[ExternalAnalysisToMPAS-{{mesh}}-{{dt}}hr]]
+    inherit = ExternalAnalyses, BATCH
+    script = $origin/ExternalAnalysisToMPAS.csh "{{mesh}}" "{{dt}}"
     [[[job]]]
       execution time limit = PT{{InitICSeconds}}S
       execution retry delays = {{InitializationRetry}}
@@ -261,9 +272,26 @@ conda activate npl
       -q = {{CPQueueName}}
       -A = {{CPAccountNumber}}
       -l = select={{InitICNodes}}:ncpus={{InitICPEPerNode}}:mpiprocs={{InitICPEPerNode}}
+  {% endfor %}
+  [[ExternalAnalysisReady-{{dt}}hr]]
+    inherit = ExternalAnalyses
 {% endfor %}
 
+  [[GetGFSAnalysisFromRDA]]
+    inherit = GetGFSAnalysisFromRDA-0hr
+  [[GetGFSAnalysisFromFTP]]
+    inherit = GetGFSAnalysisFromFTP-0hr
+  [[UngribExternalAnalysis]]
+    inherit = UngribExternalAnalysis-0hr
+{% for mesh in allMeshes %}
+  [[LinkExternalAnalysis-{{mesh}}]]
+    inherit = LinkExternalAnalysis-{{mesh}}-0hr
+  [[ExternalAnalysisToMPAS-{{mesh}}]]
+    inherit = ExternalAnalysisToMPAS-{{mesh}}-0hr
+{% endfor %}
   [[ExternalAnalysisReady]]
+    inherit = ExternalAnalysisReady-0hr
+
   [[GetGDASanalysis]]
     inherit = BATCH
     script = $origin/GetGDASanalysis.csh

--- a/include/tasks.rc
+++ b/include/tasks.rc
@@ -300,6 +300,7 @@ conda activate npl
       execution retry delays = {{GFSAnalysisRetry}}
 
 ## Verification: extended forecast from mean analysis (including single-member deterministic)
+  [[ExtendedForecastFinished]]
   [[MeanAnalysis]]
     inherit = BATCH
     script = $origin/MeanAnalysis.csh
@@ -373,8 +374,6 @@ conda activate npl
 
 
 ## Verification: various kinds of ensembles
-  [[ExtendedEnsFC]]
-    inherit = ExtendedFCBase, BATCH
 {% for state in ['BG', 'AN']%}
   [[HofX{{state}}]]
     inherit = HofXBase, BATCH
@@ -415,8 +414,10 @@ conda activate npl
   {% endfor %}
 {% endfor %}
 
-{% for mem in EnsVerifyMembers %}
   # ensemble of extended forecasts from ensemble of analyses
+  [[ExtendedEnsFC]]
+    inherit = ExtendedFCBase, BATCH
+{% for mem in EnsVerifyMembers %}
   [[ExtendedFC{{mem}}]]
     inherit = ExtendedEnsFC
     script = $origin/ExtendedEnsFC.csh "{{mem}}" "{{ExtendedFCOutIntervalHR}}" "{{ExtendedFCLengthHR}}" "False" "{{outerMesh}}"

--- a/include/tasks.rc
+++ b/include/tasks.rc
@@ -116,6 +116,7 @@ conda activate npl
   [[ObsToIODA]]
     inherit = ObsToIODA-0hr
   [[ObsReady]]
+    inherit = Observations
 
 
 ## Data assimilation and supporting tasks (critical path)
@@ -291,19 +292,21 @@ conda activate npl
     inherit = ExternalAnalysisToMPAS-{{mesh}}-0hr
 {% endfor %}
   [[ExternalAnalysisReady]]
+    inherit = ExternalAnalyses
 
   [[GetGDASanalysis]]
-    inherit = BATCH
+    inherit = ExternalAnalyses, BATCH
     script = $origin/GetGDASanalysis.csh
     [[[job]]]
       execution time limit = PT45M
       execution retry delays = {{GFSAnalysisRetry}}
 
+
 ## Verification: extended forecast from mean analysis (including single-member deterministic)
   [[ExtendedForecastFinished]]
     inherit = ExtendedForecast
   [[MeanAnalysis]]
-    inherit = BATCH
+    inherit = ExtendedForecast, BATCH
     script = $origin/MeanAnalysis.csh
     [[[job]]]
       execution time limit = PT5M

--- a/include/tasks.rc
+++ b/include/tasks.rc
@@ -4,17 +4,7 @@
     [[[environment]]]
       origin = {{mainScriptDir}}
 
-## Default settings for background and batch-submitted tasks. Currently
-## these are the only two task classifications used.  All new tasks
-## should inherit directly or indirectly from one of these two.
-  [[BACKGROUND]]
-    # These should be very small overhead and few in number; typically these
-    # only act as placeholders in the suite to facilitate transitions between
-    # complex combinations of BATCH tasks
-    [[[job]]]
-      batch system = background
-      execution time limit = PT30S
-
+## Default settings for batch-submitted tasks
   [[BATCH]]
     # load conda + activate npl
     init-script = '''
@@ -38,7 +28,6 @@ conda activate npl
 
 ## Base
   [[ForecastBase]]
-    inherit = BATCH
     [[[job]]]
       execution time limit = PT{{CyclingFCSeconds}}S
     [[[directives]]]
@@ -47,7 +36,6 @@ conda activate npl
       -A = {{CPAccountNumber}}
       -l = select={{CyclingFCNodes}}:ncpus={{CyclingFCPEPerNode}}:mpiprocs={{CyclingFCPEPerNode}}
   [[ExtendedFCBase]]
-    inherit = BATCH
     [[[job]]]
       execution time limit = PT{{ExtendedFCSeconds}}S
     [[[directives]]]
@@ -56,7 +44,6 @@ conda activate npl
       -A = {{NCPAccountNumber}}
       -l = select={{ExtendedFCNodes}}:ncpus={{ExtendedFCPEPerNode}}:mpiprocs={{ExtendedFCPEPerNode}}
   [[HofXBase]]
-    inherit = BATCH
     [[[job]]]
       execution time limit = PT{{HofXSeconds}}S
       execution retry delays = {{HofXRetry}}
@@ -65,7 +52,6 @@ conda activate npl
       -A = {{NCPAccountNumber}}
       -l = select={{HofXNodes}}:ncpus={{HofXPEPerNode}}:mpiprocs={{HofXPEPerNode}}:mem={{HofXMemory}}GB
   [[VerifyModelBase]]
-    inherit = BATCH
     [[[job]]]
       execution time limit = PT{{VerifyModelSeconds}}S
       execution retry delays = {{VerifyModelRetry}}
@@ -74,7 +60,6 @@ conda activate npl
       -A = {{NCPAccountNumber}}
       -l = select=1:ncpus=36:mpiprocs=36
   [[VerifyObsBase]]
-    inherit = BATCH
     [[[job]]]
       execution time limit = PT{{VerifyObsSeconds}}S
       execution retry delays = {{VerifyObsRetry}}
@@ -83,7 +68,6 @@ conda activate npl
       -A = {{NCPAccountNumber}}
       -l = select=1:ncpus=36:mpiprocs=36
   [[CompareBase]]
-    inherit = BATCH
     [[[job]]]
       execution time limit = PT5M
     [[[directives]]]
@@ -91,14 +75,12 @@ conda activate npl
       -A = {{NCPAccountNumber}}
       -l = select=1:ncpus=36:mpiprocs=36
   [[CleanBase]]
-    inherit = BATCH
     [[[job]]]
       execution time limit = PT5M
       execution retry delays = {{CleanRetry}}
 
 ## Null parent or child
   [[Null]]
-    inherit = BACKGROUND
 
 ## Observations
   [[GetObs]]
@@ -123,18 +105,13 @@ conda activate npl
       -A = {{CPAccountNumber}}
       -l = select=1:ncpus=1:mem=10GB
   [[ObsReady]]
-    inherit = BACKGROUND
 
 
 ## Data assimilation and supporting tasks (critical path)
   # Pre => (Ens)DataAssim => Post => Finished => Clean
   [[PreDataAssim]]
-    [[[job]]]
-      batch system = background
   [[DataAssimPost]]
-    inherit = BACKGROUND
   [[DataAssimFinished]]
-    inherit = BACKGROUND
 
   # directory/file preparation
   [[InitDataAssim]]
@@ -177,7 +154,7 @@ conda activate npl
       -l = select={{VariationalNodes}}:ncpus={{VariationalPEPerNode}}:mpiprocs={{VariationalPEPerNode}}:mem={{VariationalMemory}}GB
   {% endfor %}
   [[CleanVariational]]
-    inherit = CleanBase
+    inherit = CleanBase, BATCH
     script = $origin/CleanVariational.csh
 
   # inflation (pre and post)
@@ -208,15 +185,15 @@ conda activate npl
       -A = {{CPAccountNumber}}
       -l = select={{RTPPNodes}}:ncpus={{RTPPPEPerNode}}:mpiprocs={{RTPPPEPerNode}}:mem={{RTPPMemory}}GB
   [[CleanRTPP]]
-    inherit = CleanBase
+    inherit = CleanBase, BATCH
     script = $origin/CleanRTPP.csh
 
   # verification
   [[VerifyObsDA]]
-    inherit = VerifyObsBase
+    inherit = VerifyObsBase, BATCH
     script = $origin/VerifyObsDA.csh "1" "0" "DA" "0" "variational"
   [[CompareObsDA]]
-    inherit = CompareBase
+    inherit = CompareBase, BATCH
     script = $origin/CompareObsDA.csh "1" "0" "DA" "variational"
 
 ## Forecast (critical path)
@@ -224,13 +201,12 @@ conda activate npl
     inherit = ForecastBase
 {% for mem in allMembers %}
   [[ForecastMember{{mem}}]]
-    inherit = Forecast
+    inherit = Forecast, BATCH
     script = $origin/Forecast.csh "{{mem}}" "{{FCOutIntervalHR}}" "{{FCLengthHR}}" "{{forecastIAU}}" "{{outerMesh}}"
     [[[job]]]
       execution retry delays = {{CyclingFCRetry}}
 {% endfor %}
   [[ForecastFinished]]
-    inherit = BACKGROUND
 
 
 ## Forecasts and analyses generated outside MPAS-Workflow
@@ -288,7 +264,6 @@ conda activate npl
 {% endfor %}
 
   [[ExternalAnalysisReady]]
-    inherit = BACKGROUND
   [[GetGDASanalysis]]
     inherit = BATCH
     script = $origin/GetGDASanalysis.csh
@@ -308,29 +283,21 @@ conda activate npl
       -A = {{NCPAccountNumber}}
       -l = select=1:ncpus=36:mpiprocs=36
   [[ExtendedMeanFC]]
-    inherit = ExtendedFCBase
+    inherit = ExtendedFCBase, BATCH
     script = $origin/ExtendedMeanFC.csh "1" "{{ExtendedFCOutIntervalHR}}" "{{ExtendedFCLengthHR}}" "False" "{{outerMesh}}"
-  [[HofXMeanFC]]
-    inherit = HofXBase
-  [[VerifyModelMeanFC]]
-    inherit = VerifyModelBase
-  [[VerifyObsMeanFC]]
-    inherit = VerifyModelBase
-  [[CleanHofXMeanFC]]
-    inherit = CleanBase
 {% for dt in ExtendedFCLengths %}
   [[HofXMeanFC{{dt}}hr]]
-    inherit = HofXMeanFC
+    inherit = HofXBase, BATCH
     env-script = cd {{mainScriptDir}}; ./PrepJEDIHofXMeanFC.csh "1" "{{dt}}" "FC" "hofx"
     script = $origin/HofXMeanFC.csh "1" "{{dt}}" "FC"
   [[VerifyObsMeanFC{{dt}}hr]]
-    inherit = VerifyObsMeanFC
+    inherit = VerifyObsBase, BATCH
     script = $origin/VerifyObsMeanFC.csh "1" "{{dt}}" "FC" "0" "hofx"
   [[VerifyModelMeanFC{{dt}}hr]]
-    inherit = VerifyModelMeanFC
+    inherit = VerifyModelBase, BATCH
     script = $origin/VerifyModelMeanFC.csh "1" "{{dt}}" "FC" "0"
   [[CleanHofXMeanFC{{dt}}hr]]
-    inherit = CleanHofXMeanFC
+    inherit = CleanBase, BATCH
     script = $origin/CleanHofXMeanFC.csh "1" "{{dt}}" "FC"
 {% endfor %}
 
@@ -347,7 +314,7 @@ conda activate npl
       -A = {{NCPAccountNumber}}
       -l = select=1:ncpus=36:mpiprocs=36
   [[HofXEnsMeanBG]]
-    inherit = HofXBase
+    inherit = HofXBase, BATCH
     env-script = cd {{mainScriptDir}}; ./PrepJEDIHofXEnsMeanBG.csh "1" "0" "BG" "hofx"
     script = $origin/HofXEnsMeanBG.csh "1" "0" "BG"
     [[[directives]]]
@@ -363,36 +330,36 @@ conda activate npl
   {% set obsSeconds = VerifyObsSeconds %}
 {% endif %}
   [[VerifyModelEnsMeanBG]]
-    inherit = VerifyModelBase
+    inherit = VerifyModelBase, BATCH
     script = $origin/VerifyModelEnsMeanBG.csh "1" "0" "BG" "{{nEnsSpreadMem}}"
     [[[job]]]
       execution time limit = PT{{modelSeconds}}S
   [[VerifyObsEnsMeanBG]]
-    inherit = VerifyObsBase
+    inherit = VerifyObsBase, BATCH
     script = $origin/VerifyObsEnsMeanBG.csh "1" "0" "BG" "{{nEnsSpreadMem}}" "hofx"
     [[[job]]]
       execution time limit = PT{{obsSeconds}}S
   [[CleanHofXEnsMeanBG]]
-    inherit = CleanBase
+    inherit = CleanBase, BATCH
     script = $origin/CleanHofXEnsMeanBG.csh "1" "0" "BG"
 
 
 ## Verification: various kinds of ensembles
   [[ExtendedEnsFC]]
-    inherit = ExtendedFCBase
+    inherit = ExtendedFCBase, BATCH
 {% for state in ['BG', 'AN']%}
   [[HofX{{state}}]]
-    inherit = HofXBase
+    inherit = HofXBase, BATCH
   [[VerifyModel{{state}}]]
-    inherit = VerifyModelBase
+    inherit = VerifyModelBase, BATCH
   [[CompareModel{{state}}]]
-    inherit = CompareBase
+    inherit = CompareBase, BATCH
   [[VerifyObs{{state}}]]
-    inherit = VerifyObsBase
+    inherit = VerifyObsBase, BATCH
   [[CompareObs{{state}}]]
-    inherit = CompareBase
+    inherit = CompareBase, BATCH
   [[CleanHofX{{state}}]]
-    inherit = CleanBase
+    inherit = CleanBase, BATCH
 {% endfor %}
 
 {% for mem in EnsVerifyMembers %}
@@ -420,14 +387,6 @@ conda activate npl
   {% endfor %}
 {% endfor %}
 
-  [[HofXEnsFC]]
-    inherit = HofXBase
-  [[VerifyModelEnsFC]]
-    inherit = VerifyModelBase
-  [[VerifyObsEnsFC]]
-    inherit = VerifyObsBase
-  [[CleanHofXEnsFC]]
-    inherit = CleanBase
 {% for mem in EnsVerifyMembers %}
   # ensemble of extended forecasts from ensemble of analyses
   [[ExtendedFC{{mem}}]]
@@ -435,17 +394,17 @@ conda activate npl
     script = $origin/ExtendedEnsFC.csh "{{mem}}" "{{ExtendedFCOutIntervalHR}}" "{{ExtendedFCLengthHR}}" "False" "{{outerMesh}}"
   {% for dt in ExtendedFCLengths %}
   [[HofXEnsFC{{mem}}-{{dt}}hr]]
-    inherit = HofXEnsFC
+    inherit = HofXBase, BATCH
     env-script = cd {{mainScriptDir}}; ./PrepJEDIHofXEnsFC.csh "{{mem}}" "{{dt}}" "FC" "hofx"
     script = $origin/HofXEnsFC.csh "{{mem}}" "{{dt}}" "FC"
   [[VerifyModelEnsFC{{mem}}-{{dt}}hr]]
-    inherit = VerifyModelEnsFC
+    inherit = VerifyModelBase, BATCH
     script = $origin/VerifyModelEnsFC.csh "{{mem}}" "{{dt}}" "FC" "0"
   [[VerifyObsEnsFC{{mem}}-{{dt}}hr]]
-    inherit = VerifyObsEnsFC
+    inherit = VerifyObsBase, BATCH
     script = $origin/VerifyObsEnsFC.csh "{{mem}}" "{{dt}}" "FC" "0" "hofx"
   [[CleanHofXEnsFC{{mem}}-{{dt}}hr]]
-    inherit = CleanHofXEnsFC
+    inherit = CleanBase, BATCH
     script = $origin/CleanHofXEnsFC.csh "{{mem}}" "{{dt}}" "FC"
   {% endfor %}
 {% endfor %}

--- a/include/verifymodel.rc
+++ b/include/verifymodel.rc
@@ -39,18 +39,15 @@
   # ... for extended forecast from deterministic analysis or mean of ensemble of analyses
   # note: assumes that obs and verifying analyses are available at extended forecast times
 {% if VerifyExtendedMeanFC %}
-  {% for TIME in ExtendedMeanFCTimesList %}
-    [[[{{TIME}}/PT{{ExtendedFCOutIntervalHR}}H]]]
+  {% for dt in ExtendedFCLengths %}
+    {% set ds = "-"+(dt|string)+"hr" %}
+    {% set prep = (ds+" => ").join(PrepareExternalAnalysisTasksOuter)+ds %}
+    [[[{{ExtendedMeanFCTimes}}]]]
       graph = '''
-        {{PrepareExternalAnalysisOuter}}
-      '''
-    {% for dt in ExtendedFCLengths %}
-    [[[{{TIME}}]]]
-      graph = '''
+        {{prep}}
         ExtendedForecastFinished => VerifyModelMeanFC{{dt}}hr
-        ExternalAnalysisReady[PT{{dt}}H] => VerifyModelMeanFC{{dt}}hr
+        ExternalAnalysisReady-{{dt}}hr => VerifyModelMeanFC{{dt}}hr
       '''
-    {% endfor %}
   {% endfor %}
 {% endif %}
 
@@ -58,19 +55,16 @@
   # ... for extended forecast from ensemble of analyses
   # note: assumes that obs and verifying analyses are available at extended forecast times
 {% if VerifyExtendedEnsFC and nMembers > 1 %}
-  {% for TIME in ExtendedEnsFCTimesList %}
-    [[[{{TIME}}/PT{{ExtendedFCOutIntervalHR}}H]]]
+  {% for dt in ExtendedFCLengths %}
+    {% set ds = "-"+(dt|string)+"hr" %}
+    {% set prep = (ds+" => ").join(PrepareExternalAnalysisTasksOuter)+ds %}
+    [[[{{ExtendedEnsFCTimes}}]]]
       graph = '''
-        {{PrepareExternalAnalysisOuter}}
-      '''
-    {% for dt in ExtendedFCLengths %}
-    [[[{{TIME}}]]]
-      graph = '''
-      {% for mem in EnsVerifyMembers %}
+        {{prep}}
+    {% for mem in EnsVerifyMembers %}
         ExtendedForecastFinished => VerifyModelEnsFC{{mem}}-{{dt}}hr
-        ExternalAnalysisReady[PT{{dt}}H] => VerifyModelEnsFC{{mem}}-{{dt}}hr
-      {% endfor %}
-      '''
+        ExternalAnalysisReady-{{dt}}hr => VerifyModelEnsFC{{mem}}-{{dt}}hr
     {% endfor %}
+      '''
   {% endfor %}
 {% endif %}

--- a/include/verifymodel.rc
+++ b/include/verifymodel.rc
@@ -41,7 +41,11 @@
 {% if VerifyExtendedMeanFC %}
   {% for dt in ExtendedFCLengths %}
     {% set ds = "-"+(dt|string)+"hr" %}
-    {% set prep = (ds+" => ").join(PrepareExternalAnalysisTasksOuter)+ds %}
+    {% if dt == 0 %}
+      {% set prep = (ds+":succeed-all => ").join(PrepareExternalAnalysisTasksOuter)+ds %}
+    {% else %}
+      {% set prep = (ds+" => ").join(PrepareExternalAnalysisTasksOuter)+ds %}
+    {% endif %}
     [[[{{ExtendedMeanFCTimes}}]]]
       graph = '''
         {{prep}}
@@ -57,7 +61,11 @@
 {% if VerifyExtendedEnsFC and nMembers > 1 %}
   {% for dt in ExtendedFCLengths %}
     {% set ds = "-"+(dt|string)+"hr" %}
-    {% set prep = (ds+" => ").join(PrepareExternalAnalysisTasksOuter)+ds %}
+    {% if dt == 0 %}
+      {% set prep = (ds+":succeed-all => ").join(PrepareExternalAnalysisTasksOuter)+ds %}
+    {% else %}
+      {% set prep = (ds+" => ").join(PrepareExternalAnalysisTasksOuter)+ds %}
+    {% endif %}
     [[[{{ExtendedEnsFCTimes}}]]]
       graph = '''
         {{prep}}

--- a/include/verifymodel.rc
+++ b/include/verifymodel.rc
@@ -39,20 +39,38 @@
   # ... for extended forecast from deterministic analysis or mean of ensemble of analyses
   # note: assumes that obs and verifying analyses are available at extended forecast times
 {% if VerifyExtendedMeanFC %}
-    [[[{{ExtendedMeanFCTimes}}]]]
+  {% for TIME in ExtendedMeanFCTimesList %}
+    [[[{{TIME}}/PT{{ExtendedFCOutIntervalHR}}H]]]
       graph = '''
-        DataAssimFinished => MeanAnalysis => ExtendedMeanFC
-        ExtendedMeanFC => VerifyModelMeanFC
+        {{PrepareExternalAnalysisOuter}}
       '''
+    {% for dt in ExtendedFCLengths %}
+    [[[{{TIME}}]]]
+      graph = '''
+        ExtendedForecastFinished => VerifyModelMeanFC{{dt}}hr
+        ExternalAnalysisReady[PT{{dt}}H] => VerifyModelMeanFC{{dt}}hr
+      '''
+    {% endfor %}
+  {% endfor %}
 {% endif %}
 
 
   # ... for extended forecast from ensemble of analyses
   # note: assumes that obs and verifying analyses are available at extended forecast times
-{% if VerifyExtendedEnsFC %}
-    [[[{{ExtendedEnsFCTimes}}]]]
+{% if VerifyExtendedEnsFC and nMembers > 1 %}
+  {% for TIME in ExtendedEnsFCTimesList %}
+    [[[{{TIME}}/PT{{ExtendedFCOutIntervalHR}}H]]]
       graph = '''
-        DataAssimFinished => ExtendedEnsFC
-        ExtendedEnsFC:succeed-all => VerifyModelEnsFC
+        {{PrepareExternalAnalysisOuter}}
       '''
+    {% for dt in ExtendedFCLengths %}
+    [[[{{TIME}}]]]
+      graph = '''
+      {% for mem in EnsVerifyMembers %}
+        ExtendedForecastFinished => VerifyModelEnsFC{{mem}}-{{dt}}hr
+        ExternalAnalysisReady[PT{{dt}}H] => VerifyModelEnsFC{{mem}}-{{dt}}hr
+      {% endfor %}
+      '''
+    {% endfor %}
+  {% endfor %}
 {% endif %}

--- a/include/verifyobs.rc
+++ b/include/verifyobs.rc
@@ -61,7 +61,11 @@
 {% if VerifyExtendedMeanFC %}
   {% for dt in ExtendedFCLengths %}
     {% set ds = "-"+(dt|string)+"hr" %}
-    {% set prep = (ds+" => ").join(PrepareObservationsTasks)+ds %}
+    {% if dt == 0 %}
+      {% set prep = (ds+":succeed-all => ").join(PrepareObservationsTasks)+ds %}
+    {% else %}
+      {% set prep = (ds+" => ").join(PrepareObservationsTasks)+ds %}
+    {% endif %}
     [[[{{ExtendedMeanFCTimes}}]]]
       graph = '''
         {{prep}}
@@ -79,7 +83,11 @@
 {% if VerifyExtendedEnsFC and nMembers > 1 %}
   {% for dt in ExtendedFCLengths %}
     {% set ds = "-"+(dt|string)+"hr" %}
-    {% set prep = (ds+" => ").join(PrepareObservationsTasks)+ds %}
+    {% if dt == 0 %}
+      {% set prep = (ds+":succeed-all => ").join(PrepareObservationsTasks)+ds %}
+    {% else %}
+      {% set prep = (ds+" => ").join(PrepareObservationsTasks)+ds %}
+    {% endif %}
     [[[{{ExtendedEnsFCTimes}}]]]
       graph = '''
         {{prep}}

--- a/include/verifyobs.rc
+++ b/include/verifyobs.rc
@@ -59,24 +59,42 @@
   # ... for extended forecast from deterministic analysis or mean of ensemble of analyses
   # note: assumes that obs and verifying analyses are available at extended forecast times
 {% if VerifyExtendedMeanFC %}
-    [[[{{ExtendedMeanFCTimes}}]]]
+  {% for TIME in ExtendedMeanFCTimesList %}
+    [[[{{TIME}}/PT{{ExtendedFCOutIntervalHR}}H]]]
       graph = '''
-        DataAssimFinished => MeanAnalysis => ExtendedMeanFC
-        ExtendedMeanFC => HofXMeanFC
-        HofXMeanFC:succeed-all => VerifyObsMeanFC
-        VerifyObsMeanFC:succeed-all => CleanHofXMeanFC
+        {{PrepareObservations}}
       '''
+    {% for dt in ExtendedFCLengths %}
+    [[[{{TIME}}]]]
+      graph = '''
+        ExtendedForecastFinished => HofXMeanFC{{dt}}hr
+        ObsReady[PT{{dt}}H] => HofXMeanFC{{dt}}hr
+        HofXMeanFC{{dt}}hr => VerifyObsMeanFC{{dt}}hr
+        VerifyObsMeanFC{{dt}}hr => CleanHofXMeanFC{{dt}}hr
+      '''
+    {% endfor %}
+  {% endfor %}
 {% endif %}
 
 
   # ... for extended forecast from ensemble of analyses
   # note: assumes that obs and verifying analyses are available at extended forecast times
-{% if VerifyExtendedEnsFC %}
-    [[[{{ExtendedEnsFCTimes}}]]]
+{% if VerifyExtendedEnsFC and nMembers > 1 %}
+  {% for TIME in ExtendedEnsFCTimesList %}
+    [[[{{TIME}}/PT{{ExtendedFCOutIntervalHR}}H]]]
       graph = '''
-        DataAssimFinished => ExtendedEnsFC
-        ExtendedEnsFC:succeed-all => HofXEnsFC
-        HofXEnsFC:succeed-all => VerifyObsEnsFC
-        VerifyObsEnsFC:succeed-all => CleanHofXEnsFC
+        {{PrepareObservations}}
       '''
+    {% for dt in ExtendedFCLengths %}
+    [[[{{TIME}}]]]
+      graph = '''
+      {% for mem in EnsVerifyMembers %}
+        ExtendedForecastFinished => HofXEnsFC{{mem}}-{{dt}}hr
+        ObsReady[PT{{dt}}H] => HofXEnsFC{{mem}}-{{dt}}hr
+        HofXEnsFC{{mem}}-{{dt}}hr => VerifyObsEnsFC{{mem}}-{{dt}}hr
+        VerifyObsEnsFC{{mem}}-{{dt}}hr => CleanHofXEnsFC{{mem}}-{{dt}}hr
+      {% endfor %}
+      '''
+    {% endfor %}
+  {% endfor %}
 {% endif %}

--- a/include/verifyobs.rc
+++ b/include/verifyobs.rc
@@ -59,20 +59,17 @@
   # ... for extended forecast from deterministic analysis or mean of ensemble of analyses
   # note: assumes that obs and verifying analyses are available at extended forecast times
 {% if VerifyExtendedMeanFC %}
-  {% for TIME in ExtendedMeanFCTimesList %}
-    [[[{{TIME}}/PT{{ExtendedFCOutIntervalHR}}H]]]
+  {% for dt in ExtendedFCLengths %}
+    {% set ds = "-"+(dt|string)+"hr" %}
+    {% set prep = (ds+" => ").join(PrepareObservationsTasks)+ds %}
+    [[[{{ExtendedMeanFCTimes}}]]]
       graph = '''
-        {{PrepareObservations}}
-      '''
-    {% for dt in ExtendedFCLengths %}
-    [[[{{TIME}}]]]
-      graph = '''
+        {{prep}}
         ExtendedForecastFinished => HofXMeanFC{{dt}}hr
-        ObsReady[PT{{dt}}H] => HofXMeanFC{{dt}}hr
+        ObsReady-{{dt}}hr => HofXMeanFC{{dt}}hr
         HofXMeanFC{{dt}}hr => VerifyObsMeanFC{{dt}}hr
         VerifyObsMeanFC{{dt}}hr => CleanHofXMeanFC{{dt}}hr
       '''
-    {% endfor %}
   {% endfor %}
 {% endif %}
 
@@ -80,21 +77,18 @@
   # ... for extended forecast from ensemble of analyses
   # note: assumes that obs and verifying analyses are available at extended forecast times
 {% if VerifyExtendedEnsFC and nMembers > 1 %}
-  {% for TIME in ExtendedEnsFCTimesList %}
-    [[[{{TIME}}/PT{{ExtendedFCOutIntervalHR}}H]]]
+  {% for dt in ExtendedFCLengths %}
+    {% set ds = "-"+(dt|string)+"hr" %}
+    {% set prep = (ds+" => ").join(PrepareObservationsTasks)+ds %}
+    [[[{{ExtendedEnsFCTimes}}]]]
       graph = '''
-        {{PrepareObservations}}
-      '''
-    {% for dt in ExtendedFCLengths %}
-    [[[{{TIME}}]]]
-      graph = '''
-      {% for mem in EnsVerifyMembers %}
+        {{prep}}
+    {% for mem in EnsVerifyMembers %}
         ExtendedForecastFinished => HofXEnsFC{{mem}}-{{dt}}hr
-        ObsReady[PT{{dt}}H] => HofXEnsFC{{mem}}-{{dt}}hr
+        ObsReady-{{dt}}hr => HofXEnsFC{{mem}}-{{dt}}hr
         HofXEnsFC{{mem}}-{{dt}}hr => VerifyObsEnsFC{{mem}}-{{dt}}hr
         VerifyObsEnsFC{{mem}}-{{dt}}hr => CleanHofXEnsFC{{mem}}-{{dt}}hr
-      {% endfor %}
-      '''
     {% endfor %}
+      '''
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
### Description

`PrepareExternalAnalyses*` and `PrepareObservations` tasks are modified to include forecast duration offsets between `thisCycleDate` and `thisValidDate`, such that later cycle data can be processed in an earlier cycle.  This allows for extended forecast verification beyond the cylc `final cycle point`.  In this bugfix branch there are redundancies between cycles when preparing observations and external analyses.  For example, the external analysis used to verify the 24 hour forecast from 2018051400 is identical to the one used to verify the 0 hour forecast from 2018051500.  Removing those redundancies will require some smart inter-cycle triggering that checks whether the required data is already present, which can wait for a follow-on PR.  The extended forecast functionality is primarily used for the 2018 test period, such that the redundant tasks are duplicating link creation and not any computationally expensive procedures.

In addition to that bugfix, some flexibility is added for running extended forecasts separately from the obs-space and model-space verification, as requested in #143.  When `VerifyExtendedMeanFC` is `True`, and both `VerifyAgainstObservations` and `VerifyAgainstExternalAnalyses` are `False`, only the extended forecast will be run and not the verification.  The opposite is not true however.  That is to say, setting `VerifyExtendedMeanFC` to `False` (irrespective of the values for `VerifyAgainstObservations` and `VerifyAgainstExternalAnalyses`) will turn off both the extended forecast and the corresponding verification.  So #143 is not completely addressed.

### Issue closed

Closes #144 

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart