### PR TITLE
Always use valid date for data retrieval

### DIFF
--- a/GetGDASanalysis.csh
+++ b/GetGDASanalysis.csh
@@ -8,12 +8,15 @@ date
 source config/model.csh
 source config/experiment.csh
 source config/builds.csh
-set yyyymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
-set yy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
+set ccyymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
-set thisCycleDate = ${yyyymmdd}${hh}
+set thisCycleDate = ${ccyymmdd}${hh}
 set thisValidDate = ${thisCycleDate}
+
 source ./getCycleVars.csh
+
+set ccyymmdd = `echo ${thisValidDate} | cut -c 1-8`
+set hh = `echo ${thisValidDate} | cut -c 9-10`
 
 # static work directory
 set Campaign = /glade/campaign/mmm/parc/ivette/pandac
@@ -28,7 +31,7 @@ set fhour = 000
 
 echo "Getting GDAS atm and sfc analyses from the NCEP FTP"
 # url for GDAS data
-set gdas_ftp = https://www.ftp.ncep.noaa.gov/data/nccf/com/gfs/prod/gdas.${yyyymmdd}/${hh}/atmos
+set gdas_ftp = https://www.ftp.ncep.noaa.gov/data/nccf/com/gfs/prod/gdas.${ccyymmdd}/${hh}/atmos
 set gdasAnaInfix = (atm sfc sfluxgrb)
 
 foreach anaInfix ($gdasAnaInfix)

--- a/GetGFSAnalysisFromFTP.csh
+++ b/GetGFSAnalysisFromFTP.csh
@@ -22,18 +22,21 @@ source config/builds.csh
 source config/experiment.csh
 #source config/externalanalyses.csh
 source config/tools.csh
-set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
+set ccyymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
-set thisCycleDate = ${yymmdd}${hh}
+set thisCycleDate = ${ccyymmdd}${hh}
 set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
+
+source ./getCycleVars.csh
+
+set ccyymmdd = `echo ${thisValidDate} | cut -c 1-8`
+set hh = `echo ${thisValidDate} | cut -c 9-10`
 
 set res = 0p25
 set fhour = 000
 # url for GFS data
-set gfs_ftp = https://www.ftp.ncep.noaa.gov/data/nccf/com/gfs/prod/gfs.${yymmdd}/${hh}/atmos
+set gfs_ftp = https://www.ftp.ncep.noaa.gov/data/nccf/com/gfs/prod/gfs.${ccyymmdd}/${hh}/atmos
 set gribFile = gfs.t${hh}z.pgrb2.${res}.f${fhour}
-
-source ./getCycleVars.csh
 
 # static work directory
 set WorkDir = ${ExternalAnalysisDir}

--- a/GetGFSAnalysisFromRDA.csh
+++ b/GetGFSAnalysisFromRDA.csh
@@ -21,17 +21,19 @@ date
 source config/builds.csh
 source config/experiment.csh
 source config/tools.csh
-set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
-set yy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
+set ccyymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
-set thisCycleDate = ${yymmdd}${hh}
+set thisCycleDate = ${ccyymmdd}${hh}
 set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
+
+source ./getCycleVars.csh
+
+set ccyymmdd = `echo ${thisValidDate} | cut -c 1-8`
+set ccyy = `echo ${thisValidDate} | cut -c 1-4`
 
 set res = 0p25
 set fhour = 000
-set gribFile = ${yy}/${yymmdd}/gfs.${res}.${yymmdd}${hh}.f${fhour}.grib2
-
-source ./getCycleVars.csh
+set gribFile = ${ccyy}/${ccyymmdd}/gfs.${res}.${thisValidDate}.f${fhour}.grib2
 
 # static work directory
 set WorkDir = ${ExternalAnalysisDir}

--- a/GetObs.csh
+++ b/GetObs.csh
@@ -24,13 +24,16 @@ source config/observations.csh
 source config/experiment.csh
 source config/builds.csh
 source config/tools.csh
-set yyyymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
-set ccyy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
-set mmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 5-8`
+set ccyymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
-set thisCycleDate = ${yyyymmdd}${hh}
+set thisCycleDate = ${ccyymmdd}${hh}
 set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
+
 source ./getCycleVars.csh
+
+set ccyymmdd = `echo ${thisValidDate} | cut -c 1-8`
+set ccyy = `echo ${thisValidDate} | cut -c 1-4`
+set hh = `echo ${thisValidDate} | cut -c 9-10`
 
 # templated work directory
 set WorkDir = ${ObsDir}
@@ -49,7 +52,7 @@ foreach inst ( ${convertToIODAObservations} )
     echo "Getting ${inst} from RDA"
     # for satwnd observations
     if ( ${inst} == satwnd ) then
-       setenv THIS_FILE gdas.${inst}.t${hh}z.${ccyy}${mmdd}.bufr
+       setenv THIS_FILE gdas.${inst}.t${hh}z.${ccyymmdd}.bufr
        if ( ! -e ${THIS_FILE}) then
           echo "Source file: ${satwndBUFRDirectory}/bufr/${ccyy}/${THIS_FILE}"
           cp -p ${satwndBUFRDirectory}/bufr/${ccyy}/${THIS_FILE} .
@@ -63,13 +66,13 @@ foreach inst ( ${convertToIODAObservations} )
        endif
     # for prepbufr observations
     else if ( ${inst} == prepbufr ) then
-       setenv THIS_FILE prepbufr.gdas.${ccyy}${mmdd}${hh}.nr
+       setenv THIS_FILE prepbufr.gdas.${thisValidDate}.nr
        if ( ! -e ${THIS_FILE}) then
           if ( -e ${PrepBUFRDirectory}/prepnr/${ccyy}/${THIS_FILE} ) then
              echo "Source file: ${PrepBUFRDirectory}/prepnr/${ccyy}/${THIS_FILE}"
              cp -p ${PrepBUFRDirectory}/prepnr/${ccyy}/${THIS_FILE} .
           else
-             setenv THIS_FILE prepbufr.gdas.${ccyy}${mmdd}.t${hh}z.nr.48h
+             setenv THIS_FILE prepbufr.gdas.${ccyymmdd}.t${hh}z.nr.48h
              echo "Source file: ${PrepBUFRDirectory}/prep48h/${ccyy}/${THIS_FILE}"
              cp -p ${PrepBUFRDirectory}/prep48h/${ccyy}/${THIS_FILE} .
           endif
@@ -85,21 +88,21 @@ foreach inst ( ${convertToIODAObservations} )
     # for all other observations
     else
        # set the specific file to be extracted from the tar file
-       setenv THIS_FILE gdas.${inst}.t${hh}z.${ccyy}${mmdd}.bufr
+       setenv THIS_FILE gdas.${inst}.t${hh}z.${ccyymmdd}.bufr
        if ( ${inst} == 'cris' && ${ccyy} >= '2021' ) then
           # cris file name became crisf4 since 2021
-          setenv THIS_FILE gdas.${inst}f4.t${hh}z.${ccyy}${mmdd}.bufr
+          setenv THIS_FILE gdas.${inst}f4.t${hh}z.${ccyymmdd}.bufr
        endif
-       set THIS_TAR_FILE = ${defaultBUFRDirectory}/${inst}/${ccyy}/${inst}.${ccyy}${mmdd}.tar.gz
+       set THIS_TAR_FILE = ${defaultBUFRDirectory}/${inst}/${ccyy}/${inst}.${ccyymmdd}.tar.gz
        if ( ${inst} == 'cris' && ${ccyy} >= '2021' ) then
           # cris file name became crisf4 since 2021
-          set THIS_TAR_FILE = ${defaultBUFRDirectory}/${inst}/${ccyy}/${inst}f4.${ccyy}${mmdd}.tar.gz
+          set THIS_TAR_FILE = ${defaultBUFRDirectory}/${inst}/${ccyy}/${inst}f4.${ccyymmdd}.tar.gz
        endif
        # if the observation file does not exist, untar it
        # whether in the sub-directory or current directory
        if ( ! -e ${THIS_FILE}) then
           # some tar files contain sub-directory
-          set THIS_TAR_DIR = ${ccyy}${mmdd}.${inst}
+          set THIS_TAR_DIR = ${ccyymmdd}.${inst}
           tar -x -f ${THIS_TAR_FILE} ${THIS_TAR_DIR}/${THIS_FILE}
           if ( $status == 0 ) then
              echo "Source file: tar -x -f ${THIS_TAR_FILE} ${THIS_TAR_DIR}/${THIS_FILE}"
@@ -120,7 +123,7 @@ foreach inst ( ${convertToIODAObservations} )
           if ( ${got_file} == false && ${inst} == airsev ) then
              # try again with another dir name
              # typo in the archived directory name
-             set THIS_TAR_DIR = ${ccyy}${mmdd}.airssev
+             set THIS_TAR_DIR = ${ccyymmdd}.airssev
              tar -x -f ${THIS_TAR_FILE} ${THIS_TAR_DIR}/${THIS_FILE}
              if ( $status == 0 ) then
                 set SUB_DIR = true
@@ -141,7 +144,7 @@ foreach inst ( ${convertToIODAObservations} )
   else if ( "${observations__resource}" == "NCEPFTPOnline" ) then
     echo "Getting ${inst} from the NCEP FTP"
     # url for GDAS data
-    set gdas_ftp = https://ftpprd.ncep.noaa.gov/data/nccf/com/obsproc/prod/gdas.${yyyymmdd}
+    set gdas_ftp = https://ftpprd.ncep.noaa.gov/data/nccf/com/obsproc/prod/gdas.${ccyymmdd}
     # set name for the observation type
     if ( ${inst} == prepbufr ) then
       set THIS_FILE = gdas.t${hh}z.${inst}.nr

--- a/ObsToIODA.csh
+++ b/ObsToIODA.csh
@@ -22,12 +22,14 @@ source config/observations.csh
 source config/experiment.csh
 source config/builds.csh
 source config/tools.csh
-set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
-set ccyy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
+set ccyymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
-set thisCycleDate = ${yymmdd}${hh}
+set thisCycleDate = ${ccyymmdd}${hh}
 set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
+
 source ./getCycleVars.csh
+
+set ccyy = `echo ${thisValidDate} | cut -c 1-4`
 
 # templated work directory
 set WorkDir = ${ObsDir}


### PR DESCRIPTION
### Description
Fixes a bug introduced in #145 that would have impacted extended forecast verification when observations and external analyses are retrieved online in the workflow, such as in real-time applications.  The date strings for file retrieval now use the valid date instead of the cycle date.  This would not have impacted the 2018 historical period applications or background forecast verification (0-hr time offset between valid and cycle dates).

### Issue closed

Closes #149 

### Tests completed
Only ColdStart tests and RealTime application are impacted
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart