### PR TITLE
Remove default override of max active cycle points

### DIFF
--- a/drive.csh
+++ b/drive.csh
@@ -242,11 +242,7 @@ cat >! suite.rc << EOF
   # and to avoid over-utilization of login nodes
   # hint: execute 'ps aux | grep $USER' to check your login node overhead
   # default: 3
-{% if CriticalPathType != "Normal" %}
-  max active cycle points = 20
-{% else %}
   max active cycle points = {{maxActiveCyclePoints}}
-{% endif %}
 
   [[dependencies]]
 


### PR DESCRIPTION
### Description
In the `develop` branch, the configured `workflow.maxActiveCyclePoints` is overridden when `CriticalPath` != `Normal`.  That behavior is removed in this PR.  The default value for `workflow.maxActiveCyclePoints` is `4`.  After this PR, users can override that default value for their own verification workflows.

### Issue closed

None

### Tests completed
Not applicable.