### PR TITLE
Use atlas/ecmwf-0.29.0

### DIFF
--- a/config/environmentJEDI.csh
+++ b/config/environmentJEDI.csh
@@ -16,6 +16,7 @@ module use $OPT/modulefiles/core
 module load jedi/${BuildCompiler}
 module load json
 module load json-schema-validator
+module load atlas/ecmwf-0.29.0 # temp. patch until JEDI stack recovers
 limit stacksize unlimited
 setenv OOPS_TRACE 0
 setenv OOPS_DEBUG 0


### PR DESCRIPTION
### Description
Ensures the correct ATLAS module is loaded

### Issue closed

None

### Tests completed
None, this is consistent with mpas-bundle build instructions.