### PR TITLE
Remove obsolete diagnostics

### DIFF
--- a/config/mpas/forecast/stream_list.atmosphere.diagnostics
+++ b/config/mpas/forecast/stream_list.atmosphere.diagnostics
@@ -94,10 +94,3 @@ cldfrac_low_UPP
 cldfrac_mid_UPP
 cldfrac_high_UPP
 cldfrac_tot_UPP
-cldfrac_low_UM
-cldfrac_mid_UM
-cldfrac_high_UM
-cldfrac_tot_UM_max
-cldfrac_tot_UM_rand
-cldht_top_UM
-cldht_base_UM


### PR DESCRIPTION
### Description
Diagnostics no longer available in JCSDA-internal:MPAS-Model are removed.

### Issue closed
None

### Tests completed
Not needed