### PR TITLE
Add scenario to download GDAS analyses in real-time and other small modifications

### DIFF
--- a/GetGFSAnalysisFromRDA.csh
+++ b/GetGFSAnalysisFromRDA.csh
@@ -26,6 +26,7 @@ set yy = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-4`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}
 set thisValidDate = `$advanceCYMDH ${thisCycleDate} ${ArgDT}`
+set prevValidDate = `$advanceCYMDH ${thisCycleDate} -6`
 
 set res = 0p25
 set fhour = 000
@@ -48,8 +49,23 @@ rm -rf GRIBFILE.*
 echo "Getting GFS analysis from RDA"
 # RDA GFS forecasts directory
 set GFSgribdirRDA = /gpfs/fs1/collections/rda/data/ds084.1
+
+if ( ! -e ${GFSgribdirRDA}/${gribFile} ) then
+   set preVyymmdd = `echo ${prevValidDate} | cut -c 1-8`
+   set preVyy = `echo ${prevValidDate} | cut -c 1-4`
+   set preVhh = `echo ${prevValidDate} | cut -c 9-10`
+   set nexTfhour = 006
+   set gribFile = ${preVyy}/${preVyymmdd}/gfs.${res}.${preVyymmdd}${preVhh}.f${nexTfhour}.grib2
+endif
+
 # link ungribbed GFS
 ./${linkWPS} ${GFSgribdirRDA}/${gribFile}
+
+# check if the gribFile was linked
+if ( ! -e "GRIBFILE.AAA") then
+   echo "GRIBFILE.AAA is not in folder -- exiting"
+   exit 1
+endif
 
 date
 

--- a/config/model.csh
+++ b/config/model.csh
@@ -37,9 +37,6 @@ setenv MeshesDescriptor ${MeshesDescriptor}E${ensembleMesh}
 $setLocal ${outerMesh}.TimeStep
 $setLocal ${outerMesh}.DiffusionLengthScale
 
-# Get GDAS analyses
-$setLocal GetGDASAnalysis
-
 $setLocal GraphInfoDir
 
 $setNestedModel precision

--- a/drive.csh
+++ b/drive.csh
@@ -241,7 +241,7 @@ cat >! suite.rc << EOF
   # and to avoid over-utilization of login nodes
   # hint: execute 'ps aux | grep $USER' to check your login node overhead
   # default: 3
-{% if CriticalPathType != "Normal" %}
+{% if CriticalPathType not in ["Normal", "GetGDASanalysis"] %}
   max active cycle points = 20
 {% else %}
   max active cycle points = {{maxActiveCyclePoints}}

--- a/drive.csh
+++ b/drive.csh
@@ -106,7 +106,6 @@ cat >! suite.rc << EOF
 
 # observation information
 {% set observationsResource = "${observations__resource}" %}
-{% set GetGDASAnalysis = ${GetGDASAnalysis} %} #bool
 
 # members
 {% set nMembers = ${nMembers} %} #integer
@@ -260,6 +259,10 @@ cat >! suite.rc << EOF
     [[[{{GenerateTimes}}]]]
       graph = {{PrepareObservations}}
 
+{% elif CriticalPathType == "GetGDASanalysis" %}
+## (iii) Download GDAS Analysis from NCEP FTP
+    [[[{{GenerateTimes}}]]]
+      graph = GetGDASanalysis
 {% else %}
 
 ## (iii.a) Critical path

--- a/include/criticalpath.rc
+++ b/include/criticalpath.rc
@@ -19,9 +19,6 @@
 %include include/da.rc
         # depends on previous Forecast
         ForecastFinished[-PT{{FC2DAOffsetHR}}H] => PreDataAssim
-  {% if GetGDASAnalysis %}
-        GetGDASanalysis
-  {% endif %}
       '''
 
 # TODO: add IAU graph

--- a/run.csh
+++ b/run.csh
@@ -29,7 +29,8 @@ set ValidRunConfigs = ( \
   GenerateGFSAnalyses \
   IASI120km3denvar \
   IASI30kmIE60km3denvar \
-  ABIAHI120km3denvar.yaml \
+  ABIAHI120km3denvar \
+  GetGDASanalysis \
 )
 set ArgRunConfig = $1
 

--- a/runs/GetGDASanalysis.yaml
+++ b/runs/GetGDASanalysis.yaml
@@ -1,0 +1,2 @@
+run:
+  scenarios: [GetGDASanalysis]

--- a/scenarios/GetGDASanalysis.yaml
+++ b/scenarios/GetGDASanalysis.yaml
@@ -1,10 +1,10 @@
 workflow:
   # test a recent date
   firstCyclePoint: 20220819T00
-  initialCyclePoint: 20220819T06
+  initialCyclePoint: 20220829T06
   finalCyclePoint: 20250524T18
   CriticalPathType: GetGDASanalysis
-  maxActiveCyclePoints: 60
+  maxActiveCyclePoints: 1
 experiment:
   ExperimentName: 'DownloadGDASAnalysis'
   ExperimentUserPrefix: ''

--- a/scenarios/GetGDASanalysis.yaml
+++ b/scenarios/GetGDASanalysis.yaml
@@ -1,8 +1,8 @@
 workflow:
   # test a recent date
   firstCyclePoint: 20220819T00
-  initialCyclePoint: 20220829T06
-  finalCyclePoint: 20250524T18
+  initialCyclePoint: 20220915T12
+  finalCyclePoint: 20250912T12
   CriticalPathType: GetGDASanalysis
   maxActiveCyclePoints: 1
 experiment:

--- a/scenarios/GetGDASanalysis.yaml
+++ b/scenarios/GetGDASanalysis.yaml
@@ -1,0 +1,27 @@
+workflow:
+  # test a recent date
+  firstCyclePoint: 20220819T00
+  initialCyclePoint: 20220819T06
+  finalCyclePoint: 20250524T18
+  CriticalPathType: GetGDASanalysis
+  maxActiveCyclePoints: 60
+experiment:
+  ExperimentName: 'DownloadGDASAnalysis'
+  ExperimentUserPrefix: ''
+job:
+  CPQueueName: economy
+  NCPQueueName: economy
+# needed variables for the experiment to run
+externalanalyses:
+  resource: "GFS.RDA"
+model:
+  outerMesh: 120km
+  innerMesh: 120km
+  ensembleMesh: 120km
+variational:
+  DAType: 3dvar
+  nInnerIterations: [0,]
+firstbackground:
+  resource: "ForecastFromAnalysis"
+observations:
+  resource: PANDACArchive

--- a/scenarios/IASI120km3denvar.yaml
+++ b/scenarios/IASI120km3denvar.yaml
@@ -13,9 +13,9 @@ observations:
     - iasi_metop-c
     IODADirectory:
       variational:
-        iasi_metop-a: /glade/p/mmm/parc/ivette/pandac/Observations/iasi/1h
-        iasi_metop-b: /glade/p/mmm/parc/ivette/pandac/Observations/iasi/1h
-        iasi_metop-c: /glade/p/mmm/parc/ivette/pandac/Observations/iasi/1h
+        iasi_metop-a: /glade/p/mmm/parc/ivette/pandac/Observations/iasi/6h
+        iasi_metop-b: /glade/p/mmm/parc/ivette/pandac/Observations/iasi/6h
+        iasi_metop-c: /glade/p/mmm/parc/ivette/pandac/Observations/iasi/6h
 experiment:
   ExperimentName: '3denvar_OIE120km_WarmStart_IASI'
 model:
@@ -38,20 +38,13 @@ variational:
     iasi_metop-b,
   ]
   # for a 6h obs file
-  #job:
-  #  120km:
-  #    120km:
-  #      3denvar:
-  #        baseSeconds: 3000
-  #        nodes: 8
-  #        PEPerNode: 16
-  #        memory: 109
-  # for a 1h obs file  
   job:
     120km:
       120km:
         3denvar:
-          baseSeconds: 1200
+          baseSeconds: 900
+          nodes: 8
+          PEPerNode: 16
           memory: 109
 job:
   CPQueueName: premium

--- a/scenarios/RealTime.yaml
+++ b/scenarios/RealTime.yaml
@@ -1,8 +1,8 @@
 workflow:
   # test a recent date
   firstCyclePoint: 20220316T00
-  initialCyclePoint: 20220817T18
-  finalCyclePoint: 20250817T18
+  initialCyclePoint: 20220915T00
+  finalCyclePoint: 20250916T18
   VerifyDeterministicDA: True
   VerifyEnsMeanBG: True
   maxActiveCyclePoints: 1
@@ -19,11 +19,16 @@ firstbackground:
   resource: "ForecastFromAnalysis"
 externalanalyses:
   resource: "GFS.NCEPFTP"
-  GetGDASAnalysis: True
 variational:
   DAType: 3dvar
   nInnerIterations: [60,]
   biasCorrection: True
+  job:
+    120km:
+      # Assuming 60 total inner iterations
+      120km:
+        3dvar:
+          baseSeconds: 400
 job:
   CPQueueName: premium
   NCPQueueName: economy

--- a/scenarios/base/job.yaml
+++ b/scenarios/base/job.yaml
@@ -29,8 +29,8 @@ job:
 ## *Retry
 # various retry counts for different types of tasks
   InitializationRetry: '2*PT30S'
-  GFSAnalysisRetry: '80*PT5M'
-  GetObsRetry: '80*PT5M'
+  GFSAnalysisRetry: '40*PT10M'
+  GetObsRetry: '40*PT10M'
   VariationalRetry: '2*PT30S'
   EnsOfVariationalRetry: '1*PT30S'
   CyclingFCRetry: '2*PT30S'

--- a/scenarios/base/model.yaml
+++ b/scenarios/base/model.yaml
@@ -39,10 +39,6 @@ model:
     TimeStep: 720.0
     DiffusionLengthScale: 120000.0
 
-## Download GDAS Analysis
-# OPTIONS: True/False
-  GetGDASAnalysis: False
-
 ## GraphInfoDir
 # directory containing x1.{{nCells}}.graph.info* files
   GraphInfoDir: /glade/p/mmm/parc/liuz/pandac_common/static_from_duda

--- a/scenarios/base/workflow.yaml
+++ b/scenarios/base/workflow.yaml
@@ -51,7 +51,9 @@ workflow:
 # + GenerateObs
 #   - runs only the PrepareObservations mini-workflow
 #   - no dependencies between cycles
-#
+# + GetGDASanalysis
+#   - runs only GetGDASanalysis.csh
+#   - no dependencies between cycles
 # Users may choose whether to run the verification concurrently with and
 # dependent on the critical path tasks (`Normal`), or as an independent post-processing step
 # (`Bypass`). `Normal` and `Bypass` cover most use-cases for "continuous cycling" experiments.


### PR DESCRIPTION
### Description
This PR adds a separate scenario for the downloading of GDAS analyses (atm, sfc, and sfluxgrb) in near real-time from the NCEP FTP. It adds the necessary task specification and critical path for this stand-alone run that only downloads those data. Also, in this PR are included small changes in the computational requirements of the scenario to run 3denvar OIE120km experiments using 6h IASI observations. The `Retry` option to search for new observations and GFS analyses was also modified to 10minutes instead of 5minutes in order to decrease the frequency this request is submitted to Casper. 

Additionally, it is added the possibility to use the GFS 6-h forecast from previous cycle as the "GFS 0-h forecast" for current cycle, for model space verification purposes. While running a few days the real-time run using RDA data on Cheyenne, it was found out that for some specific days and synoptic hours there is missing the GFS 0-h forecast that we use for the model space verification of MPAS 6-h forecast. Therefore, this will only be of relevance for retrospective experiments using raw data. This was solved by adding an if statement in the script  `GetGFSAnalysisFromRDA.csh` which will allow us to use the previous 6-h forecast.

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
