### PR TITLE
Bug fix in gdasfile list and log file name in ObsToIODA

### DIFF
--- a/ObsToIODA.csh
+++ b/ObsToIODA.csh
@@ -75,28 +75,28 @@ foreach gdasfile ( *"gdas."* )
    ln -sfv ${obs2iodaBuildDir}/${obs2iodaEXEC} ./
    set inst = `echo "$gdasfile" | cut -d'.' -f2`
    if ( ${gdasfile} =~ *"mtiasi"* ) then
-     ./${obs2iodaEXEC} ${SPLIThourly} ${gdasfile} >&! log-convert_${inst}
+     ./${obs2iodaEXEC} ${SPLIThourly} ${gdasfile} >&! log-converter_${inst}
    else if ( ${gdasfile} =~ *"prepbufr"* ) then
      set inst = `echo "$gdasfile" | cut -d'.' -f1`
      # run obs2ioda for preburf with additional QC as in GSI
-     ./${obs2iodaEXEC} ${gdasfile} >&! log-convert_${inst}
+     ./${obs2iodaEXEC} ${gdasfile} >&! log-converter_${inst}
      # for surface obs, run obs2ioda for prepbufr without additional QC
      mkdir -p sfc
      cd sfc
      ln -sfv ${obs2iodaBuildDir}/${obs2iodaEXEC} ./
-     ./${obs2iodaEXEC} ${noGSIQCFilters} ../${gdasfile} >&! log-convert_sfc
+     ./${obs2iodaEXEC} ${noGSIQCFilters} ../${gdasfile} >&! log-converter_sfc
      # replace surface obs file with file created without additional QC
      mv sfc_obs_${thisCycleDate}.h5 ../sfc_obs_${thisCycleDate}.h5
      cd ..
      rm -rf sfc
    else
-     ./${obs2iodaEXEC} ${gdasfile} >&! log-convert_${inst}
+     ./${obs2iodaEXEC} ${gdasfile} >&! log-converter_${inst}
    endif
    # Check status
    # ============
-   grep "all done!" log-convert_${inst}
+   grep "all done!" log-converter_${inst}
    if ( $status != 0 ) then
-     echo "$0 (ERROR): Pre-processing observations to IODA-v2 failed" > ./FAIL-convert_${inst}
+     echo "$0 (ERROR): Pre-processing observations to IODA-v2 failed" > ./FAIL-converter_${inst}
      exit 1
    endif
   # remove BURF/PrepBUFR files

--- a/ObsToIODA.csh
+++ b/ObsToIODA.csh
@@ -40,7 +40,7 @@ cd ${WorkDir}
 # ================================================================================================
 
 # Remove log files from previous executions
-rm -rf log-*
+rm log-*
 
 if ( "${observations__resource}" == "PANDACArchive" ) then
   echo "$0 (INFO): PANDACArchive observations are already in IODA format, exiting"

--- a/ObsToIODA.csh
+++ b/ObsToIODA.csh
@@ -40,7 +40,7 @@ cd ${WorkDir}
 # ================================================================================================
 
 # Remove log files from previous executions
-rm -rf log_*
+rm -rf log-*
 
 if ( "${observations__resource}" == "PANDACArchive" ) then
   echo "$0 (INFO): PANDACArchive observations are already in IODA format, exiting"
@@ -54,7 +54,7 @@ setenv SPLIThourly "-split"
 # observations as in GSI
 setenv noGSIQCFilters "-noqc"
 
-foreach gdasfile ( ${convertToIODAObservations} )
+foreach gdasfile ( *"gdas."* )
    echo "Running ${obs2iodaEXEC} for ${gdasfile}"
    # link SpcCoeff files for converting IR radiances to brightness temperature
    if ( ${gdasfile} =~ *"cris"* && ${ccyy} >= '2021' ) then
@@ -73,28 +73,30 @@ foreach gdasfile ( ${convertToIODAObservations} )
    # ==================
    rm ./${obs2iodaEXEC}
    ln -sfv ${obs2iodaBuildDir}/${obs2iodaEXEC} ./
+   set inst = `echo "$gdasfile" | cut -d'.' -f2`
    if ( ${gdasfile} =~ *"mtiasi"* ) then
-     ./${obs2iodaEXEC} ${SPLIThourly} ${gdasfile} >&! log_${gdasfile}
+     ./${obs2iodaEXEC} ${SPLIThourly} ${gdasfile} >&! log-convert_${inst}
    else if ( ${gdasfile} =~ *"prepbufr"* ) then
+     set inst = `echo "$gdasfile" | cut -d'.' -f1`
      # run obs2ioda for preburf with additional QC as in GSI
-     ./${obs2iodaEXEC} ${gdasfile} >&! log_${gdasfile}
+     ./${obs2iodaEXEC} ${gdasfile} >&! log-convert_${inst}
      # for surface obs, run obs2ioda for prepbufr without additional QC
      mkdir -p sfc
      cd sfc
      ln -sfv ${obs2iodaBuildDir}/${obs2iodaEXEC} ./
-     ./${obs2iodaEXEC} ${noGSIQCFilters} ../${gdasfile} >&! log_sfc
+     ./${obs2iodaEXEC} ${noGSIQCFilters} ../${gdasfile} >&! log-convert_sfc
      # replace surface obs file with file created without additional QC
      mv sfc_obs_${thisCycleDate}.h5 ../sfc_obs_${thisCycleDate}.h5
      cd ..
      rm -rf sfc
    else
-     ./${obs2iodaEXEC} ${gdasfile} >&! log_${gdasfile}
+     ./${obs2iodaEXEC} ${gdasfile} >&! log-convert_${inst}
    endif
    # Check status
    # ============
-   grep "all done!" log_${gdasfile}
+   grep "all done!" log-convert_${inst}
    if ( $status != 0 ) then
-     echo "$0 (ERROR): Pre-processing observations to IODA-v2 failed" > ./FAIL-converter
+     echo "$0 (ERROR): Pre-processing observations to IODA-v2 failed" > ./FAIL-convert_${inst}
      exit 1
    endif
   # remove BURF/PrepBUFR files
@@ -115,14 +117,14 @@ if ( "${convertToIODAObservations}" =~ *"prepbufr"* || "${convertToIODAObservati
     if ( -f ${ty}_obs_${thisValidDate}.h5 ) then
       set ty_obs = ${ty}_obs_${thisValidDate}.h5
       set ty_obs_base = `echo "$ty_obs" | cut -d'.' -f1`
-      ./${iodaupgradeEXEC} ${ty_obs} ${ty_obs_base}_tmp.h5 >&! log_${ty}_upgrade
+      ./${iodaupgradeEXEC} ${ty_obs} ${ty_obs_base}_tmp.h5 >&! log-upgrade_${ty}
       rm -rf $ty_obs
       mv ${ty_obs_base}_tmp.h5 $ty_obs
       # Check status
       # ============
-      grep "Success!" log_${ty}_upgrade
+      grep "Success!" log-upgrade_${ty}
       if ( $status != 0 ) then
-        echo "$0 (ERROR): ioda-upgrade failed for $ty" > ./FAIL-${ty}_upgrade
+        echo "$0 (ERROR): ioda-upgrade failed for $ty" > ./FAIL-upgrade_${ty}
         exit 1
       endif
     endif

--- a/ObsToIODA.csh
+++ b/ObsToIODA.csh
@@ -39,6 +39,9 @@ cd ${WorkDir}
 
 # ================================================================================================
 
+# Remove log files from previous executions
+rm -rf log_*
+
 if ( "${observations__resource}" == "PANDACArchive" ) then
   echo "$0 (INFO): PANDACArchive observations are already in IODA format, exiting"
   exit 0
@@ -51,7 +54,7 @@ setenv SPLIThourly "-split"
 # observations as in GSI
 setenv noGSIQCFilters "-noqc"
 
-foreach gdasfile ( *"gdas"* )
+foreach gdasfile ( ${convertToIODAObservations} )
    echo "Running ${obs2iodaEXEC} for ${gdasfile}"
    # link SpcCoeff files for converting IR radiances to brightness temperature
    if ( ${gdasfile} =~ *"cris"* && ${ccyy} >= '2021' ) then


### PR DESCRIPTION
### Description
This small PR fixes a bug when the ObsToIODA task is executed in the same directory more than once. The loop over the 
`*gdas*` files is improved and the gdas prefix is removed from the naming of the log files. The deletion of previous log files is also added. I re-run the tests with ColdStart initialization twice and no error was found.

### Issue closed
Closes #148 

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
