### PR TITLE
Update YAML files for obs perturbation restructuring

### DIFF
--- a/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
@@ -1,5 +1,4 @@
 _obs space: &ObsSpace
-  obs perturbations post qc: {{ObsPerturbations}}
   obs perturbations seed: 1
   io pool:
     max pool size: {{maxIODAPoolSize}}

--- a/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
@@ -1,4 +1,5 @@
 _obs space: &ObsSpace
+  obs perturbations post qc: {{ObsPerturbations}}
   obs perturbations seed: 1
   io pool:
     max pool size: {{maxIODAPoolSize}}

--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -5,7 +5,6 @@ _iteration: &iterationConfig
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: {{ObsPerturbations}}
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
 #    tlm taylor test: true

--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -64,5 +64,7 @@ cost function:
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:
+    obs perturbations: {{ObsPerturbations}}
+    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -64,6 +64,5 @@ cost function:
 {{EnsemblePbInflation}}
   observations:
     obs perturbations: {{ObsPerturbations}}
-    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -5,7 +5,6 @@ _iteration: &iterationConfig
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: {{ObsPerturbations}}
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
 #    tlm taylor test: true

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -61,5 +61,7 @@ cost function:
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:
+    obs perturbations: {{ObsPerturbations}}
+    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -61,6 +61,5 @@ cost function:
 {{EnsemblePbInflation}}
   observations:
     obs perturbations: {{ObsPerturbations}}
-    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -5,7 +5,6 @@ _iteration: &iterationConfig
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: {{ObsPerturbations}}
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
 #    tlm taylor test: true

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -102,6 +102,5 @@ cost function:
 {{EnsemblePbInflation}}
   observations:
     obs perturbations: {{ObsPerturbations}}
-    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -106,5 +106,7 @@ cost function:
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:
+    obs perturbations: {{ObsPerturbations}}
+    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -70,5 +70,7 @@ cost function:
       input variables: *ctlvars
       output variables: *incvars
   observations:
+    obs perturbations: {{ObsPerturbations}}
+    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -67,6 +67,5 @@ cost function:
       output variables: *incvars
   observations:
     obs perturbations: {{ObsPerturbations}}
-    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -5,7 +5,6 @@ _iteration: &iterationConfig
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: {{ObsPerturbations}}
 {{ObsAnchors}}
 output:
   filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,6 +1,6 @@
 builds:
 # default build directory
-  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_28DEC2022_single
+  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_28DEC2022_single
 
   # optional double-precision build
-  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_28DEC2022
+  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_28DEC2022

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,6 +1,6 @@
 builds:
 # default build directory
-  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_25OCT2022_single
+  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_28DEC2022_single
 
   # optional double-precision build
-  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_25OCT2022
+  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_28DEC2022


### PR DESCRIPTION
### Description
The OOPS obs perturbations code is refactored to ensure safety/correctness of all possible user configurations. In particular it is no longer possible to perturb observations in outer iterations 2 and larger.  Previously the develop branch of MPAS-Workflow was perturbing observations in all outer iterations, but we only used 1 outer iteration for EDA.  So there will be no effect on previous experimental results, but this does improve the workflow for future EDA experiments.  See https://github.com/JCSDA-internal/mpas-jedi/pull/801 for mpas-jedi changes to EDA ctest yamls.

The build is updated to 28DEC2022 hashes.

### Issue closed
Closes #162 

### Tests completed
 - [ ] ~~3dvar_OIE120km_WarmStart~~
 - [x] 3denvar_OIE120km_WarmStart
 - [ ] ~~3dvar_OIE120km_ColdStart~~
 - [ ] ~~3dvar_O30kmIE60km_ColdStart~~
 - [ ] ~~3denvar_O30kmIE60km_WarmStart~~
 - [x] eda_OIE120km_WarmStart

Some tests avoided to speed up development on other branches.  This PR _should_ only affect the EDA test.  One non-EDA test is run too just to be sure.