### PR TITLE
Add sensor to amsua_aqua ObsErrorFactorSurfJacob

### DIFF
--- a/config/jedi/ObsPlugs/variational/filtersWithBias/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/variational/filtersWithBias/amsua_aqua.yaml
@@ -114,6 +114,7 @@
         channels: *amsua_aqua_channels
         options:
           channels: *amsua_aqua_channels
+          sensor: amsua_aqua
           obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
           obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 #  Situation dependent Check

--- a/config/jedi/ObsPlugs/variational/filtersWithBias/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/variational/filtersWithBias/amsua_n18.yaml
@@ -242,8 +242,8 @@
       options:
         channels: *amsua_n18_channels
         sensor: amsua_n18
-        use_flag: [ -1, -1, -1, -1, -1,
-                     1,  1, -1, -1, -1,
+        use_flag: [ -1, -1, -1, -1,  1,
+                     1,  1,  1,  1, -1,
                     -1, -1, -1, -1, -1 ]
     maxvalue: 1.0e-12
     action:
@@ -258,8 +258,8 @@
       channels: *amsua_n18_channels
       options:
         channels: *amsua_n18_channels
-        use_flag: [ -1, -1, -1, -1, -1,
-                     1,  1, -1, -1, -1,
+        use_flag: [ -1, -1, -1, -1,  1,
+                     1,  1,  1,  1, -1,
                     -1, -1, -1, -1, -1 ]
     minvalue: 1.0e-12
     action:

--- a/config/jedi/ObsPlugs/variational/filtersWithBias/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/variational/filtersWithBias/amsua_n19.yaml
@@ -243,7 +243,7 @@
         channels: *amsua_n19_channels
         sensor: amsua_n19
         use_flag: [ -1, -1, -1, -1,  1,
-                     1, -1, -1,  1, -1,
+                     1,  1, -1,  1, -1,
                     -1, -1, -1, -1, -1 ]
     maxvalue: 1.0e-12
     action:
@@ -259,7 +259,7 @@
       options:
         channels: *amsua_n19_channels
         use_flag: [ -1, -1, -1, -1,  1,
-                     1, -1, -1,  1, -1,
+                     1,  1, -1,  1, -1,
                     -1, -1, -1, -1, -1 ]
     minvalue: 1.0e-12
     action:


### PR DESCRIPTION
### Description
Follow up from #157.  Add missing `sensor` yaml key for `amsua_aqua`, which only affects runs with amsua VarBC that assimilate aqua.  I.e., not in the test cases.  Also fix channel selection for `amsua_n18` and `amsua_n19` when VarBC is turned on.  Some channels were turned off by mistake.

### Issue closed

None

### Tests completed
Worked in a single cycle of the 3dhybrid 30km-60km experiment with VarBC.