### PR TITLE
Refactor saber blocks in yaml, update build

### DIFF
--- a/config/builds.csh
+++ b/config/builds.csh
@@ -92,5 +92,5 @@ setenv iodaupgradeBuildDir ${commonBuild}/bin
 
 # Mean state calculator
 # ---------------------
-setenv meanStateExe      average_netcdf_files_parallel_mpas_gnu-openmpi.x
-setenv meanStateBuildDir /glade/work/guerrett/pandac/work/meanState
+setenv meanStateExe      average_netcdf_files_parallel_mpas.x
+setenv meanStateBuildDir /glade/work/guerrett/pandac/work/meanState/spack-stack_gcc-10.1.0_openmpi-4.1.1

--- a/config/environmentJEDI.csh
+++ b/config/environmentJEDI.csh
@@ -3,25 +3,44 @@
 if ( $?config_environmentJEDI ) exit 0
 setenv config_environmentJEDI 1
 
-# default is gnu-openmpi
+## BuildCompiler
+# {compiler}-{mpi-implementation} combination that selects the JEDI module used to build
+# the executables described in config/builds.csh
+# OPTIONS: gnu-openmpi, intel-impi
+setenv BuildCompiler 'gnu-openmpi'
 
-source /etc/profile.d/modules.csh  # note: needed on non-computing nodes, MPAS-Workflow
+
+source /etc/profile.d/modules.csh
 module purge
 module unuse /glade/u/apps/ch/modulefiles/default/compilers
 setenv MODULEPATH_ROOT /glade/work/jedipara/cheyenne/spack-stack/modulefiles
 module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/compilers
 module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/misc
 
-limit stacksize unlimited
-module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-2.0.0-gnu-10.1.0/install/modulefiles/Core
+
+if ( $BuildCompiler =~  *"gnu"* ) then
+#ulimit -s unlimited
+module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
 module load stack-gcc/10.1.0
 module load stack-openmpi/4.1.1
 module load jedi-mpas-env/1.0.0
-module list
 
+else if ( $BuildCompiler =~  *"intel"* ) then
+#ulimit -s unlimited
+module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-19.1.1.217/install/modulefiles/Core
+module load stack-intel/19.1.1.217
+module load stack-intel-mpi/2019.7.217
+module load jedi-mpas-env/1.0.0
+
+endif 
+
+
+limit stacksize unlimited
 setenv OOPS_TRACE 0
 setenv OOPS_DEBUG 0
 #setenv OOPS_TRAPFPE 1
 setenv GFORTRAN_CONVERT_UNIT 'big_endian:101-200'
 setenv F_UFMTENDIAN 'big:101-200'
 setenv OMP_NUM_THREADS 1
+
+module list

--- a/config/environmentJEDI.csh
+++ b/config/environmentJEDI.csh
@@ -19,20 +19,18 @@ module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/misc
 
 
 if ( $BuildCompiler =~  *"gnu"* ) then
-#ulimit -s unlimited
-module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
-module load stack-gcc/10.1.0
-module load stack-openmpi/4.1.1
-module load jedi-mpas-env/1.0.0
+  module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
+  module load stack-gcc/10.1.0
+  module load stack-openmpi/4.1.1
+  module load jedi-mpas-env/1.0.0
 
 else if ( $BuildCompiler =~  *"intel"* ) then
-#ulimit -s unlimited
-module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-19.1.1.217/install/modulefiles/Core
-module load stack-intel/19.1.1.217
-module load stack-intel-mpi/2019.7.217
-module load jedi-mpas-env/1.0.0
+  module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-19.1.1.217/install/modulefiles/Core
+  module load stack-intel/19.1.1.217
+  module load stack-intel-mpi/2019.7.217
+  module load jedi-mpas-env/1.0.0
 
-endif 
+endif
 
 
 limit stacksize unlimited

--- a/config/environmentJEDI.csh
+++ b/config/environmentJEDI.csh
@@ -3,35 +3,25 @@
 if ( $?config_environmentJEDI ) exit 0
 setenv config_environmentJEDI 1
 
-## BuildCompiler
-# {compiler}-{mpi-implementation} combination that selects the JEDI module used to build
-# the executables described in config/builds.csh
-# OPTIONS: gnu-openmpi, intel-impi
-setenv BuildCompiler 'gnu-openmpi/10.1.0'
+# default is gnu-openmpi
 
-source /etc/profile.d/modules.csh
-setenv OPT /glade/work/jedipara/cheyenne/opt/modules
+source /etc/profile.d/modules.csh  # note: needed on non-computing nodes, MPAS-Workflow
 module purge
-module use $OPT/modulefiles/core
-module load jedi/${BuildCompiler}
-module load json
-module load json-schema-validator
-module load atlas/ecmwf-0.29.0 # temp. patch until JEDI stack recovers
+module unuse /glade/u/apps/ch/modulefiles/default/compilers
+setenv MODULEPATH_ROOT /glade/work/jedipara/cheyenne/spack-stack/modulefiles
+module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/compilers
+module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/misc
+
 limit stacksize unlimited
+module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-2.0.0-gnu-10.1.0/install/modulefiles/Core
+module load stack-gcc/10.1.0
+module load stack-openmpi/4.1.1
+module load jedi-mpas-env/1.0.0
+module list
+
 setenv OOPS_TRACE 0
 setenv OOPS_DEBUG 0
 #setenv OOPS_TRAPFPE 1
 setenv GFORTRAN_CONVERT_UNIT 'big_endian:101-200'
 setenv F_UFMTENDIAN 'big:101-200'
 setenv OMP_NUM_THREADS 1
-
-## CustomPIO
-# whether to unload the JEDI module PIO module
-# A custom PIO build (outside JEDI modules) must be used consistently across all MPAS-JEDI and
-# MPAS-Model executable builds
-set CustomPIO = False
-if ( CustomPIO == True ) then
-  module unload pio
-endif
-
-module list

--- a/config/environmentJEDI.csh
+++ b/config/environmentJEDI.csh
@@ -7,7 +7,7 @@ setenv config_environmentJEDI 1
 # {compiler}-{mpi-implementation} combination that selects the JEDI module used to build
 # the executables described in config/builds.csh
 # OPTIONS: gnu-openmpi, intel-impi
-setenv BuildCompiler 'gnu-openmpi'
+set BuildCompiler = 'gnu-openmpi'
 
 
 source /etc/profile.d/modules.csh
@@ -18,14 +18,14 @@ module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/compilers
 module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/misc
 
 
-if ( $BuildCompiler =~  *"gnu"* ) then
-  module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-1.0.0-gnu-10.1.0/install/modulefiles/Core
+if ( "$BuildCompiler" =~  *"gnu"* ) then
+  module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-2.0.0-gnu-10.1.0/install/modulefiles/Core
   module load stack-gcc/10.1.0
   module load stack-openmpi/4.1.1
   module load jedi-mpas-env/1.0.0
 
-else if ( $BuildCompiler =~  *"intel"* ) then
-  module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-1.0.0-intel-19.1.1.217/install/modulefiles/Core
+else if ( "$BuildCompiler" =~  *"intel"* ) then
+  module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-2.0.0-intel-19.1.1.217/install/modulefiles/Core
   module load stack-intel/19.1.1.217
   module load stack-intel-mpi/2019.7.217
   module load jedi-mpas-env/1.0.0

--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -48,10 +48,9 @@ cost function:
     covariance model: ensemble
     localization:
       localization method: SABER
-      saber block:
+      saber central block:
         saber block name: BUMP_NICAS
-        input variables: *incvars
-        output variables: *incvars
+        active variables: *incvars
         bump:
           datadir: {{bumpLocDir}}
           prefix: {{bumpLocPrefix}}

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -48,10 +48,9 @@ cost function:
     covariance model: ensemble
     localization:
       localization method: SABER
-      saber block:
+      saber central block:
         saber block name: BUMP_NICAS
-        input variables: *incvars
-        output variables: *incvars
+        active variables: *incvars
         bump:
           datadir: {{bumpLocDir}}
           prefix: {{bumpLocPrefix}}

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -51,28 +51,24 @@ cost function:
         value: {{staticCovarianceWeight}}
       covariance:
         covariance model: SABER
-        saber blocks:
-        - saber block name: BUMP_NICAS
-          saber central block: true
-          iterative inverse: true
-          input variables: &ctlvars [{{bumpCovControlVariables}}]
-          output variables: *ctlvars
+        saber central block:
+          saber block name: BUMP_NICAS
+          active variables: &ctlvars [{{bumpCovControlVariables}}]
           bump:
             datadir: {{bumpCovDir}}
             prefix: {{bumpCovPrefix}}
             strategy: specific_univariate
             load_nicas_local: true
             verbosity: main
+        saber outer blocks:
         - saber block name: StdDev
-          input variables: *ctlvars
-          output variables: *ctlvars
-          file:
-            filename: {{bumpCovStdDevFile}}
-            date: *analysisDate
-            stream name: control
+          input fields:
+          - parameter: StdDev
+            file:
+              filename: {{bumpCovStdDevFile}}
+              date: *analysisDate
+              stream name: control
         - saber block name: BUMP_VerticalBalance
-          input variables: *ctlvars
-          output variables: *ctlvars
           bump:
             datadir: {{bumpCovVBalDir}}
             prefix: {{bumpCovVBalPrefix}}
@@ -93,10 +89,9 @@ cost function:
         covariance model: ensemble
         localization:
           localization method: SABER
-          saber block:
+          saber central block:
             saber block name: BUMP_NICAS
-            input variables: *incvars
-            output variables: *incvars
+            active variables: *incvars
             bump:
               datadir: {{bumpLocDir}}
               prefix: {{bumpLocPrefix}}

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -34,28 +34,24 @@ cost function:
     date: &analysisDate {{thisISO8601Date}}
   background error:
     covariance model: SABER
-    saber blocks:
-    - saber block name: BUMP_NICAS
-      saber central block: true
-      iterative inverse: true
-      input variables: &ctlvars [{{bumpCovControlVariables}}]
-      output variables: *ctlvars
+    saber central block:
+      saber block name: BUMP_NICAS
+      active variables: &ctlvars [{{bumpCovControlVariables}}]
       bump:
         datadir: {{bumpCovDir}}
         prefix: {{bumpCovPrefix}}
         strategy: specific_univariate
         load_nicas_local: true
         verbosity: main
+    saber outer blocks:
     - saber block name: StdDev
-      input variables: *ctlvars
-      output variables: *ctlvars
-      file:
-        filename: {{bumpCovStdDevFile}}
-        date: *analysisDate
-        stream name: control
+      input fields:
+      - parameter: StdDev
+        file:
+          filename: {{bumpCovStdDevFile}}
+          date: *analysisDate
+          stream name: control
     - saber block name: BUMP_VerticalBalance
-      input variables: *ctlvars
-      output variables: *ctlvars
       bump:
         datadir: {{bumpCovVBalDir}}
         prefix: {{bumpCovVBalPrefix}}

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,6 +1,6 @@
 builds:
 # default build directory
-  commonBuild: /glade/p/mmm/parc/ivette/pandac/jedi/22SEP2022/mpas-bundle_gnu-openmpi_28SEP2022_single
+  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_25OCT2022_single
 
   # optional double-precision build
-  #commonBuild: /glade/p/mmm/parc/ivette/pandac/jedi/22SEP2022/mpas-bundle_gnu-openmpi_28SEP2022
+  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_25OCT2022


### PR DESCRIPTION
### Description
The SABER blocks conventions were modified in develop-branch source code.  This PR updates the workflow to use the latest conventions, including using an updated build version, and the spack-stack environment.  Both single and double precision builds are provided.

@metdyn provided the new `environmentJEDI.csh`.

@byoung-joo provided the templates for climatological B yaml formatting in https://github.com/JCSDA-internal/mpas-jedi/pull/793.

### Issue closed

Closes #161 

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
