### PR TITLE
update the static B files

### DIFF
--- a/scenarios/base/variational.yaml
+++ b/scenarios/base/variational.yaml
@@ -247,13 +247,13 @@ variational:
       bumpCovStdDevFile: None
       bumpCovVBalDir: None
     60km:
-      bumpCovDir: /glade/scratch/bjung/pandac/20221025_prebuilt/60km.NICAS_00
-      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20221025_prebuilt/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/scratch/bjung/pandac/20221025_prebuilt/60km.VBAL_00
+      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/60km.NICAS_00
+      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/60km.VBAL_00
     120km:
-      bumpCovDir: /glade/scratch/bjung/pandac/20221025_prebuilt/NICAS_00
-      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20221025_prebuilt/CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/scratch/bjung/pandac/20221025_prebuilt/VBAL_00
+      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/NICAS_00
+      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/VBAL_00
 
   # resource requirements
   job:

--- a/scenarios/base/variational.yaml
+++ b/scenarios/base/variational.yaml
@@ -247,13 +247,13 @@ variational:
       bumpCovStdDevFile: None
       bumpCovVBalDir: None
     60km:
-      bumpCovDir: /glade/scratch/bjung/pandac/20220810_develop/60km.NICAS_00
-      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20220810_develop/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/scratch/bjung/pandac/20220810_develop/60km.VBAL_00
+      bumpCovDir: /glade/scratch/bjung/pandac/20221025_prebuilt/60km.NICAS_00
+      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20221025_prebuilt/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/scratch/bjung/pandac/20221025_prebuilt/60km.VBAL_00
     120km:
-      bumpCovDir: /glade/scratch/bjung/pandac/20220810_develop/NICAS_00
-      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20220810_develop/CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/scratch/bjung/pandac/20220810_develop/VBAL_00
+      bumpCovDir: /glade/scratch/bjung/pandac/20221025_prebuilt/NICAS_00
+      bumpCovStdDevFile: /glade/scratch/bjung/pandac/20221025_prebuilt/CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/scratch/bjung/pandac/20221025_prebuilt/VBAL_00
 
   # resource requirements
   job:


### PR DESCRIPTION
### Description
This is a follow-up PR for https://github.com/NCAR/MPAS-Workflow/pull/166. The static B files were regenerated and their path was updated, based on the `mpas-bundle_gnu-openmpi_25OCT2022_single`.

### Issue closed

Closes #167 

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
