### PR TITLE
Remove obsolete 'verbosity' key in the saber section

### DIFF
--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -60,7 +60,6 @@ cost function:
           #io_values: [dynamic,dynamic,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
           io_values: [dynamic,cloud,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
           lev2d: last
-#          verbosity: main
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -60,7 +60,7 @@ cost function:
           #io_values: [dynamic,dynamic,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
           io_values: [dynamic,cloud,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
           lev2d: last
-          verbosity: main
+#          verbosity: main
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -57,7 +57,6 @@ cost function:
           strategy: common
           lev2d: last
           load_nicas_local: true
-#          verbosity: main
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -57,7 +57,7 @@ cost function:
           strategy: common
           lev2d: last
           load_nicas_local: true
-          verbosity: main
+#          verbosity: main
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -59,7 +59,6 @@ cost function:
             prefix: {{bumpCovPrefix}}
             strategy: specific_univariate
             load_nicas_local: true
-#            verbosity: main
         saber outer blocks:
         - saber block name: StdDev
           input fields:
@@ -78,7 +77,6 @@ cost function:
             vbal_block:     [ true,  true,false, false,false,false,  true,false,false,false]
             vbal_diag_reg:  [ true, false,false, false,false,false, false,false,false,false]
             vbal_diag_auto: [false, false,false, false,false,false, false,false,false,false]
-#            verbosity: main
         linear variable change:
           linear variable change name: Control2Analysis
           input variables: *ctlvars
@@ -98,7 +96,6 @@ cost function:
               strategy: common
               load_nicas_local: true
               lev2d: last
-#              verbosity: main
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -59,7 +59,7 @@ cost function:
             prefix: {{bumpCovPrefix}}
             strategy: specific_univariate
             load_nicas_local: true
-            verbosity: main
+#            verbosity: main
         saber outer blocks:
         - saber block name: StdDev
           input fields:
@@ -78,7 +78,7 @@ cost function:
             vbal_block:     [ true,  true,false, false,false,false,  true,false,false,false]
             vbal_diag_reg:  [ true, false,false, false,false,false, false,false,false,false]
             vbal_diag_auto: [false, false,false, false,false,false, false,false,false,false]
-            verbosity: main
+#            verbosity: main
         linear variable change:
           linear variable change name: Control2Analysis
           input variables: *ctlvars
@@ -98,7 +98,7 @@ cost function:
               strategy: common
               load_nicas_local: true
               lev2d: last
-              verbosity: main
+#              verbosity: main
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -42,7 +42,6 @@ cost function:
         prefix: {{bumpCovPrefix}}
         strategy: specific_univariate
         load_nicas_local: true
-#        verbosity: main
     saber outer blocks:
     - saber block name: StdDev
       input fields:
@@ -61,7 +60,6 @@ cost function:
         vbal_block:     [ true,  true,false, false,false,false,  true,false,false,false]
         vbal_diag_reg:  [ true, false,false, false,false,false, false,false,false,false]
         vbal_diag_auto: [false, false,false, false,false,false, false,false,false,false]
-#        verbosity: main
     linear variable change:
       linear variable change name: Control2Analysis
       input variables: *ctlvars

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -42,7 +42,7 @@ cost function:
         prefix: {{bumpCovPrefix}}
         strategy: specific_univariate
         load_nicas_local: true
-        verbosity: main
+#        verbosity: main
     saber outer blocks:
     - saber block name: StdDev
       input fields:
@@ -61,7 +61,7 @@ cost function:
         vbal_block:     [ true,  true,false, false,false,false,  true,false,false,false]
         vbal_diag_reg:  [ true, false,false, false,false,false, false,false,false,false]
         vbal_diag_auto: [false, false,false, false,false,false, false,false,false,false]
-        verbosity: main
+#        verbosity: main
     linear variable change:
       linear variable change name: Control2Analysis
       input variables: *ctlvars


### PR DESCRIPTION
### Description

Comment out 'verbosity' key in the saber section, which does not exist anymore.

### Issue closed
Closes #173

### Tests completed
 - [x] 3denvar_O30kmIE60km_WarmStart
 
Mostly not needed.  Will test more in follow-on PRs
