### PR TITLE
BUMP yaml updates

### DIFF
--- a/ExternalAnalysisToMPAS.csh
+++ b/ExternalAnalysisToMPAS.csh
@@ -67,12 +67,18 @@ cd ${WorkDir}
 set outputFile = $filePrefix.$thisMPASFileDate.nc
 
 if ( -e $outputFile ) then
-  echo "$0 (INFO): outputFile ($outputFile) already exists, exiting with success"
-  echo "$0 (INFO): if regenerating the outputFile is desired, delete the original"
+  set oSize = `du -sh $outputFile | sed 's@'$outputFile'@@'`
 
-  date
+  if ( "$oSize" != "0" ) then
+    echo "$0 (INFO): outputFile ($outputFile) already exists, exiting with success"
+    echo "$0 (INFO): if regenerating the outputFile is desired, delete the original"
 
-  exit 0
+    date
+
+    exit 0
+  endif
+
+  rm $outputFile
 endif
 
 # ================================================================================================
@@ -114,6 +120,7 @@ mpiexec ./${InitEXE}
 # ============
 grep "Finished running the init_${MPASCore} core" log.init_${MPASCore}.0000.out
 if ( $status != 0 ) then
+  rm $outputFile
   echo "ERROR in $0 : MPAS-init failed" > ./FAIL
   exit 1
 endif

--- a/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
@@ -1,5 +1,4 @@
 _obs space: &ObsSpace
-  obs perturbations post qc: {{ObsPerturbations}}
   obs perturbations seed: 1
   io pool:
     max pool size: {{maxIODAPoolSize}}

--- a/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
@@ -1,4 +1,5 @@
 _obs space: &ObsSpace
+  obs perturbations post qc: {{ObsPerturbations}}
   obs perturbations seed: 1
   io pool:
     max pool size: {{maxIODAPoolSize}}

--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -5,7 +5,6 @@ _iteration: &iterationConfig
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: {{ObsPerturbations}}
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
 #    tlm taylor test: true

--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -64,5 +64,7 @@ cost function:
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:
+    obs perturbations: {{ObsPerturbations}}
+    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -64,6 +64,5 @@ cost function:
 {{EnsemblePbInflation}}
   observations:
     obs perturbations: {{ObsPerturbations}}
-    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3denvar-specific_multivariate.yaml
+++ b/config/jedi/applications/3denvar-specific_multivariate.yaml
@@ -51,14 +51,19 @@ cost function:
         saber block name: BUMP_NICAS
         active variables: *incvars
         bump:
-          datadir: {{bumpLocDir}}
-          prefix: {{bumpLocPrefix}}
-          strategy: specific_multivariate
-          load_nicas_local: true
-          io_keys: [temperature-temperature,spechum-spechum,uReconstructZonal-uReconstructZonal,uReconstructMeridional-uReconstructMeridional,surface_pressure-surface_pressure,qc-qc,qi-qi,qr-qr,qs-qs,qg-qg]
-          #io_values: [dynamic,dynamic,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
-          io_values: [dynamic,cloud,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
-          lev2d: last
+          io:
+            data directory: {{bumpLocDir}}
+            files prefix: {{bumpLocPrefix}}
+          drivers:
+            multivariate strategy: specific_multivariate
+            read local nicas: true
+          model:
+            level for 2d variables: last
+          #TODO: update following keys
+          #io_keys: [temperature-temperature,spechum-spechum,uReconstructZonal-uReconstructZonal,uReconstructMeridional-uReconstructMeridional,surface_pressure-surface_pressure,qc-qc,qi-qi,qr-qr,qs-qs,qg-qg]
+          ##io_values: [dynamic,dynamic,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
+          #io_values: [dynamic,cloud,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]
+          #lev2d: last
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -5,7 +5,6 @@ _iteration: &iterationConfig
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: {{ObsPerturbations}}
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
 #    tlm taylor test: true

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -61,5 +61,7 @@ cost function:
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:
+    obs perturbations: {{ObsPerturbations}}
+    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -51,11 +51,14 @@ cost function:
         saber block name: BUMP_NICAS
         active variables: *incvars
         bump:
-          datadir: {{bumpLocDir}}
-          prefix: {{bumpLocPrefix}}
-          strategy: common
-          lev2d: last
-          load_nicas_local: true
+          io:
+            data directory: {{bumpLocDir}}
+            files prefix: {{bumpLocPrefix}}
+          drivers:
+            multivariate strategy: common
+            read local nicas: true
+          model:
+            level for 2d variables: last
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -61,6 +61,5 @@ cost function:
 {{EnsemblePbInflation}}
   observations:
     obs perturbations: {{ObsPerturbations}}
-    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -5,7 +5,6 @@ _iteration: &iterationConfig
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: {{ObsPerturbations}}
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
 #    tlm taylor test: true

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -102,6 +102,5 @@ cost function:
 {{EnsemblePbInflation}}
   observations:
     obs perturbations: {{ObsPerturbations}}
-    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -57,7 +57,7 @@ cost function:
             io:
               data directory: {{bumpCovDir}}
               files prefix: {{bumpCovPrefix}}
-            driver:
+            drivers:
               multivariate strategy: specific_univariate
               read local nicas: true
         saber outer blocks:

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -54,10 +54,12 @@ cost function:
           saber block name: BUMP_NICAS
           active variables: &ctlvars [{{bumpCovControlVariables}}]
           bump:
-            datadir: {{bumpCovDir}}
-            prefix: {{bumpCovPrefix}}
-            strategy: specific_univariate
-            load_nicas_local: true
+            io:
+              data directory: {{bumpCovDir}}
+              files prefix: {{bumpCovPrefix}}
+            driver:
+              multivariate strategy: specific_univariate
+              read local nicas: true
         saber outer blocks:
         - saber block name: StdDev
           input fields:
@@ -68,14 +70,21 @@ cost function:
               stream name: control
         - saber block name: BUMP_VerticalBalance
           bump:
-            datadir: {{bumpCovVBalDir}}
-            prefix: {{bumpCovVBalPrefix}}
-            load_vbal: true
-            #load_samp_global: true
-            load_samp_local: true
-            vbal_block:     [ true,  true,false, false,false,false,  true,false,false,false]
-            vbal_diag_reg:  [ true, false,false, false,false,false, false,false,false,false]
-            vbal_diag_auto: [false, false,false, false,false,false, false,false,false,false]
+            io:
+              data directory: {{bumpCovVBalDir}}
+              files prefix: {{bumpCovVBalPrefix}}
+            drivers:
+              read local sampling: true
+              read vertical balance: true
+            vertical balance:
+              vbal:
+              - balanced variable: velocity_potential
+                unbalanced variable: stream_function
+                diagonal regression: true
+              - balanced variable: temperature
+                unbalanced variable: stream_function
+              - balanced variable: surface_pressure
+                unbalanced variable: stream_function
         linear variable change:
           linear variable change name: Control2Analysis
           input variables: *ctlvars
@@ -90,11 +99,14 @@ cost function:
             saber block name: BUMP_NICAS
             active variables: *incvars
             bump:
-              datadir: {{bumpLocDir}}
-              prefix: {{bumpLocPrefix}}
-              strategy: common
-              load_nicas_local: true
-              lev2d: last
+              io:
+                data directory: {{bumpLocDir}}
+                files prefix: {{bumpLocPrefix}}
+              drivers:
+                multivariate strategy: common
+                read local nicas: true
+              model:
+                level for 2d variables: last
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -106,5 +106,7 @@ cost function:
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:
+    obs perturbations: {{ObsPerturbations}}
+    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -37,10 +37,12 @@ cost function:
       saber block name: BUMP_NICAS
       active variables: &ctlvars [{{bumpCovControlVariables}}]
       bump:
-        datadir: {{bumpCovDir}}
-        prefix: {{bumpCovPrefix}}
-        strategy: specific_univariate
-        load_nicas_local: true
+        io:
+          data directory: {{bumpCovDir}}
+          files prefix: {{bumpCovPrefix}}
+        driver:
+          multivariate strategy: specific_univariate
+          read local nicas: true
     saber outer blocks:
     - saber block name: StdDev
       input fields:
@@ -51,14 +53,21 @@ cost function:
           stream name: control
     - saber block name: BUMP_VerticalBalance
       bump:
-        datadir: {{bumpCovVBalDir}}
-        prefix: {{bumpCovVBalPrefix}}
-        load_vbal: true
-        #load_samp_global: true
-        load_samp_local: true
-        vbal_block:     [ true,  true,false, false,false,false,  true,false,false,false]
-        vbal_diag_reg:  [ true, false,false, false,false,false, false,false,false,false]
-        vbal_diag_auto: [false, false,false, false,false,false, false,false,false,false]
+        io:
+          data directory: {{bumpCovVBalDir}}
+          files prefix: {{bumpCovVBalPrefix}}
+        drivers:
+          read local sampling: true
+          read vertical balance: true
+        vertical balance:
+          vbal:
+          - balanced variable: velocity_potential
+            unbalanced variable: stream_function
+            diagonal regression: true
+          - balanced variable: temperature
+            unbalanced variable: stream_function
+          - balanced variable: surface_pressure
+            unbalanced variable: stream_function
     linear variable change:
       linear variable change name: Control2Analysis
       input variables: *ctlvars

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -40,7 +40,7 @@ cost function:
         io:
           data directory: {{bumpCovDir}}
           files prefix: {{bumpCovPrefix}}
-        driver:
+        drivers:
           multivariate strategy: specific_univariate
           read local nicas: true
     saber outer blocks:

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -70,5 +70,7 @@ cost function:
       input variables: *ctlvars
       output variables: *incvars
   observations:
+    obs perturbations: {{ObsPerturbations}}
+    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -67,6 +67,5 @@ cost function:
       output variables: *incvars
   observations:
     obs perturbations: {{ObsPerturbations}}
-    post qc perturbations: true
     observers:
 {{Observers}}

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -5,7 +5,6 @@ _iteration: &iterationConfig
     deallocate non-da fields: true
     interpolation type: unstructured
   gradient norm reduction: 1e-3
-  obs perturbations: {{ObsPerturbations}}
 {{ObsAnchors}}
 output:
   filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,6 +1,6 @@
 builds:
 # default build directory
-  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_28DEC2022_single
+  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_06JAN2023_single
 
   # optional double-precision build
-  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_feature--clean_yamls
+  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_06JAN2023

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,6 +1,6 @@
 builds:
 # default build directory
-  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_28DEC2022_single
+  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_28DEC2022_single
 
   # optional double-precision build
-  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_28DEC2022
+  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_feature--clean_yamls

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,6 +1,6 @@
 builds:
 # default build directory
-  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_25OCT2022_single
+  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_28DEC2022_single
 
   # optional double-precision build
-  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_25OCT2022
+  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_28DEC2022

--- a/scenarios/base/variational.yaml
+++ b/scenarios/base/variational.yaml
@@ -220,13 +220,13 @@ variational:
       #  bumpLocDir: str
       30km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/30km/bumploc/h=1200.0km_v=6.0km_10AUG2022code
+        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/30km/bumploc/h=1200.0km_v=6.0km_06JAN2023code
       60km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/60km/bumploc/h=1200.0km_v=6.0km_10AUG2022code
+        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/60km/bumploc/h=1200.0km_v=6.0km_06JAN2023code
       120km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/120km/bumploc/h=1200.0km_v=6.0km_10AUG2022code
+        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/120km/bumploc/h=1200.0km_v=6.0km_06JAN2023code
 
   # externally-produced background covariance files (var or hybrid)
   covariance:

--- a/scenarios/base/variational.yaml
+++ b/scenarios/base/variational.yaml
@@ -247,13 +247,13 @@ variational:
       bumpCovStdDevFile: None
       bumpCovVBalDir: None
     60km:
-      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/60km.NICAS_00
-      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/60km.VBAL_00
+      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/60km.NICAS_00
+      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/60km.VBAL_00
     120km:
-      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/NICAS_00
-      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20221025_prebuilt/VBAL_00
+      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/NICAS_00
+      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/VBAL_00
 
   # resource requirements
   job:


### PR DESCRIPTION
### Description
Companion to https://github.com/JCSDA-internal/mpas-jedi/pull/811.  YAML formats are changed for climatological B and localization.  Refactoring only.

Build is updated to 06JAN2023, which will be updated on the merge date to be consistent with develop code on that date.

Some additional changes are made in `ExternalAnalysisToMPAS.csh` to improve its restart behavior when failing on the first attempt.

### Issue closed

Closes #174 

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart