### PR TITLE
Fix GenerateObs scenario

### DIFF
--- a/scenarios/GenerateObs.yaml
+++ b/scenarios/GenerateObs.yaml
@@ -8,19 +8,25 @@ workflow:
 observations:
   resource: GladeRDAOnline
   convertToIODAObservations:
-  - prepbufr
-  - satwnd
-  - gpsro
   - 1bamua
   - 1bmhs
   - airsev
+  #- cris
+  - gpsro
+  #- mtiasi
+  - prepbufr
+  - satwnd
 experiment:
   ExperimentName: 'GenerateObs'
   ExperimentUserPrefix: ''
 job:
   CPQueueName: economy
   NCPQueueName: economy
-#TODO: make it so that model and variational are not necessary
+#TODO: make it so that below settings are not necessary
+firstbackground:
+  resource: "ForecastFromAnalysis"
+externalanalyses:
+  resource: "GFS.RDA"
 model:
   outerMesh: 120km
   innerMesh: 120km


### PR DESCRIPTION
### Description
@junmeiban reported a problem with the `GenerateObs` scenario.  The issue stems from the fact that we use the `drive.csh` script for all scenarios.  Future efforts (already in feature branches) will replace `drive.csh` with multiple suites that each carry out a more limited set of tasks with fewer if statements.  Until then, the `GenerateObs` scenario needs settings for `firstbackground` and `externalanalyses` added, even though those keys do not apply to generating observations.

### Issue closed
Closes #185 

### Tests completed
Ran GenerateObs scenario for several cycles (results temporarily available [here](/glade/scratch/guerrett/pandac/GenerateObs_TEST_24JAN2023/Observations)).