### PR TITLE
Update BUMP yamls

### DIFF
--- a/config/jedi/applications/3denvar-crossed.yaml
+++ b/config/jedi/applications/3denvar-crossed.yaml
@@ -55,7 +55,7 @@ cost function:
             data directory: {{bumpLocDir}}
             files prefix: {{bumpLocPrefix}}
           drivers:
-            multivariate strategy: specific_multivariate
+            multivariate strategy: crossed
             read local nicas: true
           model:
             level for 2d variables: last

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -55,7 +55,7 @@ cost function:
             data directory: {{bumpLocDir}}
             files prefix: {{bumpLocPrefix}}
           drivers:
-            multivariate strategy: common
+            multivariate strategy: duplicated
             read local nicas: true
           model:
             level for 2d variables: last

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -58,7 +58,7 @@ cost function:
               data directory: {{bumpCovDir}}
               files prefix: {{bumpCovPrefix}}
             drivers:
-              multivariate strategy: specific_univariate
+              multivariate strategy: univariate
               read local nicas: true
         saber outer blocks:
         - saber block name: StdDev
@@ -103,7 +103,7 @@ cost function:
                 data directory: {{bumpLocDir}}
                 files prefix: {{bumpLocPrefix}}
               drivers:
-                multivariate strategy: common
+                multivariate strategy: duplicated
                 read local nicas: true
               model:
                 level for 2d variables: last

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -41,7 +41,7 @@ cost function:
           data directory: {{bumpCovDir}}
           files prefix: {{bumpCovPrefix}}
         drivers:
-          multivariate strategy: specific_univariate
+          multivariate strategy: univariate
           read local nicas: true
     saber outer blocks:
     - saber block name: StdDev

--- a/scenarios/base/builds.yaml
+++ b/scenarios/base/builds.yaml
@@ -1,6 +1,6 @@
 builds:
 # default build directory
-  commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_23JAN2023_single
+  commonBuild: /glade/work/bjung/panda-c/build/mpas-bundle_gnu-openmpi_25JAN2023_single
 
   # optional double-precision build
-  #commonBuild: /glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_23JAN2023
+  #commonBuild: /glade/work/bjung/panda-c/build/mpas-bundle_gnu-openmpi_25JAN2023

--- a/scenarios/base/variational.yaml
+++ b/scenarios/base/variational.yaml
@@ -247,13 +247,13 @@ variational:
       bumpCovStdDevFile: None
       bumpCovVBalDir: None
     60km:
-      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/60km.NICAS_00
-      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/60km.VBAL_00
+      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230125_prebuilt/60km.NICAS_00
+      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230125_prebuilt/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230125_prebuilt/60km.VBAL_00
     120km:
-      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/NICAS_00
-      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230106_prebuilt/VBAL_00
+      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230125_prebuilt/NICAS_00
+      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230125_prebuilt/CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230125_prebuilt/VBAL_00
 
   # resource requirements
   job:


### PR DESCRIPTION
### Description
* Companion to https://github.com/JCSDA-internal/mpas-jedi/pull/822.  YAML formats are changed for `multivariate strategy` key of BUMP.  No change in the result is expected.
* Build is updated to 25JAN2023.
* StaticB files are regenerated, due to a change in the group name formatting in some BUMP NetCDF files.
We can still use the previous versions of BUMP localization files.

### Issue closed

Closes #182 

### Tests completed
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
