### PR TITLE
Fix VarBC issue for the case with missing obs input files

### DIFF
--- a/PrepJEDI.csh
+++ b/PrepJEDI.csh
@@ -293,7 +293,8 @@ foreach instrument ($observations)
   foreach i ($instrumentsAllowingBiasCorrection)
     if ("$instrument" == "$i") then
       set allowsBiasCorrection = True
-      if ( ! -f ${InDBDir}/${instrument}_obs_${thisValidDate}.h5 ) then # obs file not exsit
+      # if no obs file exists, link satbias file from the previous cycle
+      if ( ! -f ${InDBDir}/${instrument}_obs_${thisValidDate}.h5 ) then
           ln -sf ${biasCorrectionDir}/satbias_${i}.h5 ${CyclingDAWorkDir}/${thisValidDate}/dbOut
       endif
     endif

--- a/PrepJEDI.csh
+++ b/PrepJEDI.csh
@@ -293,19 +293,8 @@ foreach instrument ($observations)
   foreach i ($instrumentsAllowingBiasCorrection)
     if ("$instrument" == "$i") then
       set allowsBiasCorrection = True
-      set dateListback = (`$dateList ${FirstCycleDate} ${thisCycleDate} ${self_WindowHR}`)
-      set foundsatbias = False
-      foreach dt (${dateListback})
-        # check for satbias file at dt
-        if ( -e ${CyclingDAWorkDir}/${dt}/dbOut/satbias_${i}.h5 ) then
-          set biasCorrectionDir = ${CyclingDAWorkDir}/${dt}/dbOut
-          set foundsatbias = True
-          break
-        endif
-      end
-      # if no online updated satbias files exist, use first cycle's satbias file
-      if ($foundsatbias == False) then
-        set biasCorrectionDir = $initialVARBCcoeff
+      if ( ! -f ${InDBDir}/${instrument}_obs_${thisValidDate}.h5 ) then # obs file not exsit
+          ln -sf ${biasCorrectionDir}/satbias_${i}.h5 ${CyclingDAWorkDir}/${thisValidDate}/dbOut
       endif
     endif
   end


### PR DESCRIPTION
### Description
PrepJEDI.csh sets correctly 'satbias_*.h5' input files' directory (i.e., from 'fixed_input' or previous cycle's dbOut) in Lines 235-240, but incorrectly sets it for the case with missing obs input files (e.g., IASI for the period of April/May2018). This PR fixed it by linking satbias files from the previously cycle (or fixed_input for the first cycle) for missing obs input.

### Issue closed

Closes #196 

### Tests completed
Cycling experiment with missing IASI files.
 