### PR TITLE
Fix IAU python environment

### DIFF
--- a/bin/Forecast.csh
+++ b/bin/Forecast.csh
@@ -64,7 +64,6 @@ source config/auto/members.csh
 source config/auto/model.csh
 source config/auto/staticstream.csh
 source config/auto/workflow.csh
-source config/environmentJEDI.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}
@@ -158,9 +157,10 @@ if ( ${self_IAU} == True ) then
     # Initial condition (mpasin.YYYY-MM-DD_HH.00.00.nc)
     ln -sfv ${BGFile} ${ICFilePrefix}.${BGFileExt} || exit 1
   else		# either analysis or background does not exist; IAU is off.
-    echo "IAU was on, but no input files. So it is off and initialized at ${thisValidDate}."
-    set self_IAU          = False
-    set self_FCLengthHR   = ${CyclingWindowHR}
+    echo "IAU is enabled, but one of two input files is missing."
+    echo "Thus IAU is turned off at this cycle and the forecast is initialized at ${thisValidDate}."
+    set self_IAU = False
+    set self_FCLengthHR = ${CyclingWindowHR}
   endif
 endif
 
@@ -320,6 +320,11 @@ else
 
   # Run the executable
   # ==================
+  # load JEDI environment here to avoid conflict between multiple python versions
+  cd ${mainScriptDir}
+  source config/environmentJEDI.csh
+  cd -
+
   set log = log.${MPASCore}.0000.out
   foreach f ($log $ForecastEXE)
     if ( -e $f ) rm -v $f

--- a/initialize/config/Scenario.py
+++ b/initialize/config/Scenario.py
@@ -40,7 +40,7 @@ setenv ${nestedConfigFunctionName} "source $setNestedConfig $defaultsConfig $sce
   def initialize(self):
     '''
     Creates a script used to parse a particular section of the complete scenario configuration
-    YAML in any c-shell script.  The primary remaining usage is in applications/PrepJEDI.csh
+    YAML in any c-shell script.  The primary remaining usage is in bin/PrepJEDI.csh
 
     It should be sourced in a section-specific configuration shell script after all
     other "config/*.csh" dependencies are sourced as follows

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -71,7 +71,7 @@ class Build(Component):
       #self._set('ForecastBuildDir', '/glade/p/mmm/parc/liuz/pandac_common/20220309_mpas_bundle/code/MPAS-gnumpt-single')
       #self._set('ForecastEXE', model['MPASCore']+'_model')
 
-      # Note: this also requires modifying applications/forecast.csh:
+      # Note: this also requires modifying bin/Forecast.csh:
       #-source config/environmentJEDI.csh
       #+source config/environmentMPT.csh
       #-  mpiexec ./${ForecastEXE}

--- a/scenarios/3denvar_OIE120km_WarmStart_IAU.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart_IAU.yaml
@@ -1,6 +1,6 @@
 workflow:
   first cycle point: 20180414T18
-  final cycle point:   20180418T00
+  final cycle point:   20180514T18
 
 extendedforecast:
   #meanTimes: T00  # uncomment to engage
@@ -8,7 +8,7 @@ extendedforecast:
   outIntervalHR: 12
 
 forecast:
-  post: [verifymodel]
+  post: []
 observations:
   resource: PANDACArchive
 members:
@@ -34,6 +34,6 @@ variational:
 forecast:
   IAU: True
 job:
-  CPAccountNumber: NMMM0043
-  NCPAccountNumber: NMMM0043
-  SingleProcAccountNumber: NMMM0015
+  CPAccountNumber: NMMM0013
+  NCPAccountNumber: NMMM0013
+  SingleProcAccountNumber: NMMM0013

--- a/scenarios/3denvar_OIE120km_WarmStart_IAU.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart_IAU.yaml
@@ -1,6 +1,6 @@
 workflow:
   first cycle point: 20180414T18
-  final cycle point:   20180514T18
+  final cycle point:   20180418T00
 
 extendedforecast:
   #meanTimes: T00  # uncomment to engage
@@ -8,7 +8,7 @@ extendedforecast:
   outIntervalHR: 12
 
 forecast:
-  post: []
+  post: [verifymodel]
 observations:
   resource: PANDACArchive
 members:
@@ -18,7 +18,7 @@ model:
   innerMesh: 120km
   ensembleMesh: 120km
 experiment:
-  suffix: '_IAUfix2'
+  suffix: '_IAU'
 firstbackground:
   resource: "PANDAC.GFS"
 externalanalyses:
@@ -34,6 +34,6 @@ variational:
 forecast:
   IAU: True
 job:
-  CPAccountNumber: NMMM0013
-  NCPAccountNumber: NMMM0013
-  SingleProcAccountNumber: NMMM0013
+  CPAccountNumber: NMMM0043
+  NCPAccountNumber: NMMM0043
+  SingleProcAccountNumber: NMMM0015

--- a/scenarios/defaults/observations.yaml
+++ b/scenarios/defaults/observations.yaml
@@ -1,7 +1,7 @@
 observations:
   resources:
     # resource options available for selection with observations.resource
-    # the selected resource is parsed in applications/PrepJEDI.csh
+    # the selected resource is parsed in bin/PrepJEDI.csh
 
     ## IODADirectory (used below)
     # locations of raw bufr and prepbufr observation data, separated by resource


### PR DESCRIPTION
### Description
Fixes an issue with the python environment for IAU reported by @syha.  The issue is caused by conflicts/differences between the spack-stack python version and available modules and the python provided by CISL's conda module.

### Issue closed

None

### Tests completed
 - [x] scenarios/3denvar_OIE120km_WarmStart_IAU (ran for 3 cycles)