### PR TITLE
Only generate FirstBackground tasks when not doing restart

### DIFF
--- a/initialize/framework/Workflow.py
+++ b/initialize/framework/Workflow.py
@@ -125,7 +125,7 @@ class Workflow(Component):
 
     else:
       # The analysis will run every CyclingWindowHR hours, starting at the restartCyclePoint
-      self._set('AnalysisTimes', '+PT'+str(CyclingWindowHR)+'H')
+      self._set('AnalysisTimes', 'PT'+str(CyclingWindowHR)+'H')
 
       # The forecast will run every CyclingWindowHR hours, starting DA2FCOffsetHR hours after the
       # restartCyclePoint


### PR DESCRIPTION
### Description
When `restart cycle point` is set to a value different from `first cycle point`, all `FirstBackground` tasks and dependencies are omitted from the auto-generated `suite.rc`.

### Issue closed

Fixes #213

### Tests completed
Fixed functionality not currently exercised in standard tests.  Successfully restarted `3denvar_OIE120km_IAU_WarmStart` test scenario from the end of the 2nd cycle.
