### PR TITLE
Add share queue as option for single processor jobs

### DIFF
--- a/initialize/framework/HPC.py
+++ b/initialize/framework/HPC.py
@@ -40,7 +40,7 @@ class HPC(Component):
     # SingleProc*: used for single-processor jobs, both critical and non-critical paths
     # IMPORTANT: must NOT be executed on login node to comply with CISL requirements
     'SingleProcAccount': ['NMMM0015', str],
-    'SingleProcQueue': ['casper@casper-pbs', str, ['casper@casper-pbs']],
+    'SingleProcQueue': ['casper@casper-pbs', str, ['casper@casper-pbs', 'share']],
   }
   def __init__(self, config:Config):
     super().__init__(config)


### PR DESCRIPTION
### Description
Casper compute nodes are down today, which means we cannot use the high-throughput queue.  I tried replacing that queue selection with the share queue, and it worked.  This gives everybody the option to run whenever Casper is under maintenance.

### Issue closed

None

### Tests completed
Successfully ran an experiment with `hpc.SingleProcQueue` set to `share`.  