### PR TITLE
Default minimizer: DRPCG

### DIFF
--- a/initialize/applications/Variational.py
+++ b/initialize/applications/Variational.py
@@ -52,8 +52,8 @@ class Variational(Component):
     # Notes about DRPBlockLanczos:
     # + still experimental, and not reliable for this experiment
     # + only available when EDASize > 1
-    'MinimizerAlgorithm': ['DRIPCG', str,
-      ['DRIPCG', 'DRPLanczos', 'DRPBlockLanczos']
+    'MinimizerAlgorithm': ['DRPCG', str,
+      ['DRPCG','DRIPCG', 'DRPLanczos', 'DRPBlockLanczos']
     ],
 
     ## SelfExclusion, whether exclude own background from the ensemble B perturbations in EnVar during EDA cycling


### PR DESCRIPTION
### Description
Set DRPCG as default minimizer.

### Files modified:
M initialize/applications/Variational.py

### Issue closed
Closes https://github.com/NCAR/MPAS-Workflow/issues/223

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
