### PR TITLE
Update data path.

### DIFF
--- a/config/jedi/ObsPlugs/retrieveObsErrors/trainAll.csh
+++ b/config/jedi/ObsPlugs/retrieveObsErrors/trainAll.csh
@@ -1,12 +1,12 @@
 #!/bin/csh -f
-set analysisDir = /glade/scratch/guerrett/pandac/graphics_results/GNSSROSimulations27JAN2023/2ndDoaDob
+set analysisDir = /glade/p/mmm/parc/liuz/pandac_common/obs/2ndDoaDob
 set obsspace = gnssrobndropp1d
 set diagnostic = rltv_doadob
 set coord = impact_height
 set errortype = RelativeObsError
 ./relativeObsErrors.csh "$analysisDir" "$obsspace" "$diagnostic" "$coord" "$errortype"
 
-set analysisDir = /glade/scratch/guerrett/pandac/graphics_results/GNSSROSimulations27JAN2023/Ref_1stDoaDob
+set analysisDir = /glade/p/mmm/parc/liuz/pandac_common/obs/Ref_1stDoaDob
 set obsspace = gnssrorefncep
 set diagnostic = rltv_doadob
 set coord = alt

--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -78,9 +78,9 @@ class Observations(Component):
     'CRTMTABLES': ['/glade/work/guerrett/pandac/fixed_input/crtm_bin/', str],
 
     # static directories for bias correction files
-    'fixedCoeff': ['/glade/p/mmm/parc/liuz/pandac_hybrid/fix_input/satbias', str],
-    'fixedTlapmeanCov': ['/glade/p/mmm/parc/liuz/pandac_hybrid/fix_input/satbias/2018', str],
-    'initialVARBCcoeff': ['/glade/p/mmm/parc/liuz/pandac_hybrid/fix_input/satbias/2018', str],
+    'fixedCoeff': ['/glade/p/mmm/parc/liuz/pandac_common/obs/satbias', str],
+    'fixedTlapmeanCov': ['/glade/p/mmm/parc/liuz/pandac_common/obs/satbias/2018', str],
+    'initialVARBCcoeff': ['/glade/p/mmm/parc/liuz/pandac_common/obs/satbias/2018', str],
   }
 
   def __init__(self,

--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -75,7 +75,7 @@ class Observations(Component):
     'GDASObsErrtable': ['/glade/work/guerrett/pandac/fixed_input/GSI_errtables/HRRRENS_errtable_10sep2018.r3dv', str],
 
     ## CRTM
-    'CRTMTABLES': ['/glade/work/guerrett/pandac/fixed_input/crtm_bin/', str],
+    'CRTMTABLES': ['/glade/p/mmm/parc/liuz/pandac_common/crtm_coeffs_v2.4.1', str],
 
     # static directories for bias correction files
     'fixedCoeff': ['/glade/p/mmm/parc/liuz/pandac_common/obs/satbias', str],

--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -75,7 +75,7 @@ class Observations(Component):
     'GDASObsErrtable': ['/glade/work/guerrett/pandac/fixed_input/GSI_errtables/HRRRENS_errtable_10sep2018.r3dv', str],
 
     ## CRTM
-    'CRTMTABLES': ['/glade/p/mmm/parc/liuz/pandac_common/crtm_coeffs_v2.4.1', str],
+    'CRTMTABLES': ['/glade/p/mmm/parc/liuz/pandac_common/crtm_coeffs_v2.4.1/', str],
 
     # static directories for bias correction files
     'fixedCoeff': ['/glade/p/mmm/parc/liuz/pandac_common/obs/satbias', str],

--- a/scenarios/defaults/externalanalyses.yaml
+++ b/scenarios/defaults/externalanalyses.yaml
@@ -32,11 +32,11 @@ externalanalyses:
     GFS:
       PANDAC: # only available 20180415T00-20180525T00
         120km:
-          directory: "/glade/p/mmm/parc/guerrett/pandac/fixed_input/120km/GFSAna"
+          directory: "/glade/p/mmm/parc/liuz/pandac_common/120km/120km_GFSANA"
         60km:
-          directory: "/glade/p/mmm/parc/guerrett/pandac/fixed_input/60km/GFSAna"
+          directory: "/glade/p/mmm/parc/liuz/pandac_common/60km/60km_GFSANA"
         30km:
-          directory: "/glade/p/mmm/parc/guerrett/pandac/fixed_input/30km/GFSAna"
+          directory: "/glade/p/mmm/parc/liuz/pandac_common/30km/30km_GFSANA"
       RDA:
         common:
           PrepareExternalAnalysisTasks:

--- a/scenarios/defaults/firstbackground.yaml
+++ b/scenarios/defaults/firstbackground.yaml
@@ -34,7 +34,7 @@ firstbackground:
         60km: # only available 20180414T18, 20200723T18
           directory: "/glade/p/mmm/parc/guerrett/pandac/fixed_input/60km/SingleFCFirstCycle/{{FirstCycleDate}}"
         30km: # only available 20180414T18
-          directory: "/glade/p/mmm/parc/guerrett/pandac/fixed_input/30km/SingleFCFirstCycle/{{FirstCycleDate}}"
+          directory: "/glade/p/mmm/parc/liuz/pandac_common/30km/30km_1stCycle_background_single/{{FirstCycleDate}}"
       LaggedGEFS:
         common:
           PrepareFirstBackground: "LinkWarmStartBackgrounds => ForecastFinished__"

--- a/scenarios/defaults/firstbackground.yaml
+++ b/scenarios/defaults/firstbackground.yaml
@@ -30,9 +30,9 @@ firstbackground:
         common:
           PrepareFirstBackground: "LinkWarmStartBackgrounds => ForecastFinished__"
         120km: # only available 20180414T18, 20200723T18
-          directory: "/glade/p/mmm/parc/guerrett/pandac/fixed_input/120km/SingleFCFirstCycle/{{FirstCycleDate}}"
+          directory: "/glade/p/mmm/parc/liuz/pandac_common/120km/120km_1stCycle_background_single/{{FirstCycleDate}}"
         60km: # only available 20180414T18, 20200723T18
-          directory: "/glade/p/mmm/parc/guerrett/pandac/fixed_input/60km/SingleFCFirstCycle/{{FirstCycleDate}}"
+          directory: "/glade/p/mmm/parc/liuz/pandac_common/60km/60km_1stCycle_background_single/{{FirstCycleDate}}"
         30km: # only available 20180414T18
           directory: "/glade/p/mmm/parc/liuz/pandac_common/30km/30km_1stCycle_background_single/{{FirstCycleDate}}"
       LaggedGEFS:

--- a/scenarios/defaults/observations.yaml
+++ b/scenarios/defaults/observations.yaml
@@ -101,95 +101,95 @@ observations:
       IODADirectory:
         da:
           ##anchor
-          aircraft: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrobndropp1d: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrobndnbam: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrobndmo: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrobndmo-nopseudo: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrorefncep: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrorefncep_tunedErrors: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          satwind: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          sfc: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          sondes: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
+          aircraft: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrobndropp1d: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrobndnbam: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrobndmo: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrobndmo-nopseudo: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrorefncep: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrorefncep_tunedErrors: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          satwind: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          sfc: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          sondes: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
 
           ## amsua
-          amsua_aqua: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua_n15: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua-cld_aqua: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua-cld_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua-cld_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua-cld_n15: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua-cld_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          amsua-cld_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
+          amsua_aqua: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua_n15: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua-cld_aqua: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua-cld_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua-cld_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua-cld_n15: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua-cld_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          amsua-cld_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
 
           ## mhs
-          mhs_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          mhs_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          mhs_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
+          mhs_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          mhs_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          mhs_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
 
           ## abi
-          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB59X59_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO59X59_no-bias-correct
+          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB59X59_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO59X59_no-bias-correct
 
           ## ahi
-          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
-          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
+          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
+          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
 
           ## iasi
-          iasi_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/1h
-          iasi_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/1h
-          iasi_metop-c: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/1h
+          iasi_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/1h
+          iasi_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/1h
+          iasi_metop-c: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/1h
 
         hofx:
           ## anchor
-          aircraft: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrobndropp1d: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrobndnbam: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrobndmo: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrobndmo-nopseudo: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrorefncep: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          gnssrorefncep_tunedErrors: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          satwind: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          sfc: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
-          sondes: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/conv_obs
+          aircraft: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrobndropp1d: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrobndnbam: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrobndmo: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrobndmo-nopseudo: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrorefncep: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          gnssrorefncep_tunedErrors: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          satwind: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          sfc: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
+          sondes: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/conv_obs
 
           ## amsua
-          amsua_aqua: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua_n15: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua-cld_aqua: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua-cld_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua-cld_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua-cld_n15: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua-cld_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          amsua-cld_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
+          amsua_aqua: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua_n15: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua-cld_aqua: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua-cld_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua-cld_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua-cld_n15: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua-cld_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          amsua-cld_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
 
           ## mhs
-          mhs_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          mhs_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          mhs_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
+          mhs_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          mhs_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          mhs_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
 
           ## abi
-          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB59X59_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO59X59_no-bias-correct
+          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB59X59_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO59X59_no-bias-correct
 
           ## ahi
-          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
-          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
+          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
+          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
 
           ## iasi
-          iasi_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/1h
-          iasi_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/1h
-          iasi_metop-c: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/1h
+          iasi_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/1h
+          iasi_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/1h
+          iasi_metop-c: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/1h
 
       IODASuperObGrid:
         abi_g16: 59X59
@@ -236,97 +236,97 @@ observations:
       IODADirectory:
         da:
           ##anchor
-          aircraft: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrobndropp1d: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrobndnbam: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrobndmo: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrobndmo-nopseudo: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrorefncep: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrorefncep_tunedErrors: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          satwind: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          satwnd: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          sfc: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          sondes: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
+          aircraft: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrobndropp1d: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrobndnbam: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrobndmo: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrobndmo-nopseudo: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrorefncep: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrorefncep_tunedErrors: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          satwind: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          satwnd: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          sfc: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          sondes: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
 
           ## amsua
-          amsua_aqua: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua_n15: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_aqua: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_n15: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
+          amsua_aqua: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua_n15: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_aqua: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_n15: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
 
           ## mhs
-          mhs_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          mhs_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          mhs_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
-          mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/bias_corr
+          mhs_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          mhs_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          mhs_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
 
           ## abi
-          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB59X59_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO59X59_no-bias-correct
+          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB59X59_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO59X59_no-bias-correct
 
           ## ahi
-          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
-          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
+          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
+          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB101X101_no-bias-correct
 
           ## iasi
-          iasi_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/1h
-          iasi_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/1h
-          iasi_metop-c: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/1h
+          iasi_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/1h
+          iasi_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/1h
+          iasi_metop-c: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/1h
 
         hofx:
           ## anchor
-          aircraft: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrobndropp1d: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrobndnbam: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrobndmo: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrobndmo-nopseudo: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrorefncep: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          gnssrorefncep_tunedErrors: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          satwind: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          satwnd: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          sfc: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          sondes: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
+          aircraft: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrobndropp1d: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrobndnbam: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrobndmo: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrobndmo-nopseudo: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrorefncep: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          gnssrorefncep_tunedErrors: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          satwind: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          satwnd: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          sfc: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          sondes: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
 
           ## amsua
-          amsua_aqua: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua_n15: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_aqua: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_n15: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
-          amsua-cld_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/raw_obs
+          amsua_aqua: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua_n15: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_aqua: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_n15: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
+          amsua-cld_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
 
           ## mhs
-          mhs_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          mhs_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          mhs_n18: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
-          mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/no_bias
+          mhs_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          mhs_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          mhs_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
 
           ## abi
-          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
+          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
 
           ## ahi
-          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
-          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
+          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
+          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
 
           ## iasi
-          iasi_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/6h
-          iasi_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/6h
-          iasi_metop-c: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/iasi/6h
+          iasi_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/6h
+          iasi_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/6h
+          iasi_metop-c: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi/6h
 
       IODASuperObGrid:
         abi_g16: 15X15
@@ -373,18 +373,18 @@ observations:
 
       IODADirectory:
         da:
-          common: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/GenerateObs/Observations
-          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
-          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
-          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
+          common: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/GenerateObs/Observations
+          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
+          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
+          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
 
         hofx:
-          common: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/GenerateObs/Observations
-          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
-          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
-          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obsiodav3_221216/newobs_2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
+          common: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/GenerateObs/Observations
+          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
+          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
+          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
 
       IODASuperObGrid:
         abi_g16: 15X15

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -78,7 +78,7 @@ variational:
         EDA:
           60km:
             maxMembers: 80
-            directory0: '/glade/scratch/guerrett/pandac/guerrett_eda_3denvar-60-iter_NMEM80_RTPP0.7_SelfExclusion_OIE60km_WarmStart/CyclingFC/{{prevDateTime}}'
+            directory0: '/glade/p/mmm/parc/liuz/pandac_common/60km/60km_EnsFC_80EDA/{{prevDateTime}}'
             memberPrefix: mem
             memberNDigits: 3
 

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -44,7 +44,7 @@ variational:
         GEFS:
           120km:
             maxMembers: 20
-            directory0: '/glade/p/mmm/parc/guerrett/pandac/fixed_input/120km/EnsForCov/{{prevDateTime}}'
+            directory0: '/glade/p/mmm/parc/liuz/pandac_common/120km/120km_EnsFC/{{prevDateTime}}'
             filePrefix: EnsForCov
             memberNDigits: 2
 


### PR DESCRIPTION
### Description
This PR is about updating the data path:
1. Change the path for "analysisDir" in config/jedi/ObsPlugs/retrieveObsErrors/trainAll.csh
2. Change the path for bias correction files and crtm_2.4.1 coefs in initialize/data/Observations.py
3. Change the path for 120km/60km/30km GFSANA in scenarios/defaults/externalanalyses.yaml
4. Change the path for 120km/60km/30km_1stCycle_background (in single precision) : in scenarios/defaults/firstbackground.yaml
5. The obs links (in scenarios/defaults/observations.yaml) are pointed to @liujake ’s pandac_common directory; I have not touched obs path in  scenarios/*.yaml yet.
6. Change the path for 60km_EnsFC_80EDA and 120km_GEFS_ensemble(20-member):  in scenarios/defaults/variational.yaml


### Files modified:
M       config/jedi/ObsPlugs/retrieveObsErrors/trainAll.csh
M       initialize/data/Observations.py
M       scenarios/defaults/externalanalyses.yaml
M       scenarios/defaults/firstbackground.yaml
M       scenarios/defaults/observations.yaml
M       scenarios/defaults/variational.yaml

P.S.:
The issue #225 cannot be closed so far.
The path for static B, ensemble localization, mpas_bundle(single precision), and mpas_model (outside bundle, intel+mpt)   will be updated in a separated PR. 

### Tests completed
#### Tier 1:
 - [x] 3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml

