### PR TITLE
Update data path. Continued for 120 km B

### DIFF
--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -105,7 +105,7 @@ variational:
         bumpLocDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/60km.bumploc.duplicated.limited.1200km6km
       120km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/p/mmm/parc/guerrett/pandac/fixed_input/120km/bumploc/h=1200.0km_v=6.0km_06JAN2023code
+        bumpLocDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.bumploc.duplicated.limited.1200km6km
 
   # externally-produced background covariance files (var or hybrid)
   covariance:
@@ -130,9 +130,9 @@ variational:
       bumpCovStdDevFile: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
       bumpCovVBalDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/60km.VBAL_00
     120km:
-      bumpCovDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230125_prebuilt/NICAS_00
-      bumpCovStdDevFile: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230125_prebuilt/CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/p/mmm/parc/bjung/pandac_common/staticB/20230125_prebuilt/VBAL_00
+      bumpCovDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.NICAS_00
+      bumpCovStdDevFile: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.VBAL_00
 
   # resource requirements
   job:

--- a/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
+++ b/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
@@ -39,7 +39,7 @@ variational:
   nInnerIterations: [15,]
   ensemble:
     forecasts:
-      resource: "PANDAC.GEFS"
+      resource: "PANDAC.EDA"
   job:
     30km:
       60km:

--- a/test/testinput/ForecastFromGFSAnalysesMPT.yaml
+++ b/test/testinput/ForecastFromGFSAnalysesMPT.yaml
@@ -3,6 +3,9 @@ suite: ForecastFromExternalAnalyses
 externalanalyses:
   resource: "GFS.RDA"
 
+#build:
+#  forecast directory: path-for-mpas-model-build
+
 experiment:
   name: 'ForecastFromGFSAnalysesMPT_TEST'
 

--- a/test/testinput/ForecastFromGFSAnalysesMPT.yaml
+++ b/test/testinput/ForecastFromGFSAnalysesMPT.yaml
@@ -1,8 +1,5 @@
 suite: ForecastFromExternalAnalyses
 
-build:
-  forecast directory: /glade/p/mmm/parc/liuz/pandac_common/20230406_mpas_bundle/MPAS_intelmpt
-
 externalanalyses:
   resource: "GFS.RDA"
 


### PR DESCRIPTION
### Description

This PR updates ... 1) path for 120 km localization, 2) path for 120 km static B, 3) two yamls under `test/testinput` directory to pass the test.

Note that some yamls under scenario might fail, such as using GEFS-based ensemble at 60 km, which is obsolete now. We might want to update / clean these scenario yamls at some point.

### Files modified:

M       scenarios/defaults/variational.yaml
M       test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
M       test/testinput/ForecastFromGFSAnalysesMPT.yaml

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
