### PR TITLE
Add MHS in benchmark experiments

### DIFF
--- a/config/jedi/ObsPlugs/da/base/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_metop-a.yaml
@@ -1,0 +1,24 @@
+- obs space:
+    <<: *ObsSpace
+    name: mhs_metop-a
+    _obsdatain: &ObsDataIn
+      engine:
+        type: H5File
+        obsfile: {{InDBDir}}/mhs_metop-a_obs_{{thisValidDate}}.h5
+    _obsdataout: &ObsDataOut
+      engine:
+        type: H5File
+        obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_mhs_metop-a{{ObsOutSuffix}}.h5
+    obsdatain: *{{ObsDataIn}}
+    {{ObsDataOut}}
+    simulated variables: [brightnessTemperature]
+    channels: &mhs_metop-a_channels 3-5
+  obs error: *ObsErrorDiagonal
+  <<: *horizObsLoc
+  obs operator:
+    <<: *clearCRTMObsOperator
+    obs options:
+      <<: *CRTMObsOptions
+      Sensor_ID: mhs_metop-a
+  get values:
+    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_metop-b.yaml
@@ -1,0 +1,24 @@
+- obs space:
+    <<: *ObsSpace
+    name: mhs_metop-b
+    _obsdatain: &ObsDataIn
+      engine:
+        type: H5File
+        obsfile: {{InDBDir}}/mhs_metop-b_obs_{{thisValidDate}}.h5
+    _obsdataout: &ObsDataOut
+      engine:
+        type: H5File
+        obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_mhs_metop-b{{ObsOutSuffix}}.h5
+    obsdatain: *{{ObsDataIn}}
+    {{ObsDataOut}}
+    simulated variables: [brightnessTemperature]
+    channels: &mhs_metop-b_channels 3-5
+  obs error: *ObsErrorDiagonal
+  <<: *horizObsLoc
+  obs operator:
+    <<: *clearCRTMObsOperator
+    obs options:
+      <<: *CRTMObsOptions
+      Sensor_ID: mhs_metop-b
+  get values:
+    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_n18.yaml
@@ -1,0 +1,24 @@
+- obs space:
+    <<: *ObsSpace
+    name: mhs_n18
+    _obsdatain: &ObsDataIn
+      engine:
+        type: H5File
+        obsfile: {{InDBDir}}/mhs_n18_obs_{{thisValidDate}}.h5
+    _obsdataout: &ObsDataOut
+      engine:
+        type: H5File
+        obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_mhs_n18{{ObsOutSuffix}}.h5
+    obsdatain: *{{ObsDataIn}}
+    {{ObsDataOut}}
+    simulated variables: [brightnessTemperature]
+    channels: &mhs_n18_channels 3-5
+  obs error: *ObsErrorDiagonal
+  <<: *horizObsLoc
+  obs operator:
+    <<: *clearCRTMObsOperator
+    obs options:
+      <<: *CRTMObsOptions
+      Sensor_ID: mhs_n18
+  get values:
+    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_n19.yaml
@@ -1,0 +1,24 @@
+- obs space:
+    <<: *ObsSpace
+    name: mhs_n19
+    _obsdatain: &ObsDataIn
+      engine:
+        type: H5File
+        obsfile: {{InDBDir}}/mhs_n19_obs_{{thisValidDate}}.h5
+    _obsdataout: &ObsDataOut
+      engine:
+        type: H5File
+        obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_mhs_n19{{ObsOutSuffix}}.h5
+    obsdatain: *{{ObsDataIn}}
+    {{ObsDataOut}}
+    simulated variables: [brightnessTemperature]
+    channels: &mhs_n19_channels 3-5
+  obs error: *ObsErrorDiagonal
+  <<: *horizObsLoc
+  obs operator:
+    <<: *clearCRTMObsOperator
+    obs options:
+      <<: *CRTMObsOptions
+      Sensor_ID: mhs_n19
+  get values:
+    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/bias/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_metop-a.yaml
@@ -1,0 +1,30 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_mhs_metop-a.h5
+    output file: {{OutDBDir}}{{MemberDir}}/satbias_mhs_metop-a.h5
+    variational bc:
+      predictors: &predictors1
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &mhsmetopatlap {{fixedTlapmeanCov}}/mhs_metop-a_tlapmean.txt
+      - name: lapse_rate
+        tlapse: *mhsmetopatlap
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+    covariance:
+      minimal required obs number: 20
+      variance range: [1.0e-6, 10.]
+      step size: 1.0e-4
+      largest analysis variance: 10000.0
+      prior:
+        input file: {{biasCorrectionDir}}/satbias_cov_mhs_metop-a.h5
+        inflation:
+          ratio: 1.1
+          ratio for small dataset: 2.0
+      output file: {{OutDBDir}}{{MemberDir}}/satbias_cov_mhs_metop-a.h5

--- a/config/jedi/ObsPlugs/da/bias/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_metop-b.yaml
@@ -1,0 +1,30 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_mhs_metop-b.h5
+    output file: {{OutDBDir}}{{MemberDir}}/satbias_mhs_metop-b.h5
+    variational bc:
+      predictors: &predictors1
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &mhsmetopbtlap {{fixedTlapmeanCov}}/mhs_metop-b_tlapmean.txt
+      - name: lapse_rate
+        tlapse: *mhsmetopbtlap
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+    covariance:
+      minimal required obs number: 20
+      variance range: [1.0e-6, 10.]
+      step size: 1.0e-4
+      largest analysis variance: 10000.0
+      prior:
+        input file: {{biasCorrectionDir}}/satbias_cov_mhs_metop-b.h5
+        inflation:
+          ratio: 1.1
+          ratio for small dataset: 2.0
+      output file: {{OutDBDir}}{{MemberDir}}/satbias_cov_mhs_metop-b.h5

--- a/config/jedi/ObsPlugs/da/bias/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_n18.yaml
@@ -1,0 +1,30 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_mhs_n18.h5
+    output file: {{OutDBDir}}{{MemberDir}}/satbias_mhs_n18.h5
+    variational bc:
+      predictors: &predictors1
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &mhs18tlap {{fixedTlapmeanCov}}/mhs_n18_tlapmean.txt
+      - name: lapse_rate
+        tlapse: *mhs18tlap
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+    covariance:
+      minimal required obs number: 20
+      variance range: [1.0e-6, 10.]
+      step size: 1.0e-4
+      largest analysis variance: 10000.0
+      prior:
+        input file: {{biasCorrectionDir}}/satbias_cov_mhs_n18.h5
+        inflation:
+          ratio: 1.1
+          ratio for small dataset: 2.0
+      output file: {{OutDBDir}}{{MemberDir}}/satbias_cov_mhs_n18.h5

--- a/config/jedi/ObsPlugs/da/bias/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_n19.yaml
@@ -1,0 +1,30 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_mhs_n19.h5
+    output file: {{OutDBDir}}{{MemberDir}}/satbias_mhs_n19.h5
+    variational bc:
+      predictors: &predictors1
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &mhs19tlap {{fixedTlapmeanCov}}/mhs_n19_tlapmean.txt
+      - name: lapse_rate
+        tlapse: *mhs19tlap
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+    covariance:
+      minimal required obs number: 20
+      variance range: [1.0e-6, 10.]
+      step size: 1.0e-4
+      largest analysis variance: 10000.0
+      prior:
+        input file: {{biasCorrectionDir}}/satbias_cov_mhs_n19.h5
+        inflation:
+          ratio: 1.1
+          ratio for small dataset: 2.0
+      output file: {{OutDBDir}}{{MemberDir}}/satbias_cov_mhs_n19.h5

--- a/config/jedi/ObsPlugs/da/filters/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filters/mhs_metop-a.yaml
@@ -1,0 +1,8 @@
+  obs filters:
+  - filter: PreQC
+    maxvalue: 0
+  - filter: GOMsaver
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-a.nc4
+  - filter: Background Check
+    threshold: 3.0
+    <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filters/mhs_metop-b.yaml
@@ -1,0 +1,8 @@
+  obs filters:
+  - filter: PreQC
+    maxvalue: 0
+  - filter: GOMsaver
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-b.nc4
+  - filter: Background Check
+    threshold: 3.0
+    <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filters/mhs_n18.yaml
@@ -1,0 +1,8 @@
+  obs filters:
+  - filter: PreQC
+    maxvalue: 0
+  - filter: GOMsaver
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n18.nc4
+  - filter: Background Check
+    threshold: 3.0
+    <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filters/mhs_n19.yaml
@@ -1,0 +1,8 @@
+  obs filters:
+  - filter: PreQC
+    maxvalue: 0
+  - filter: GOMsaver
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n19.nc4
+  - filter: Background Check
+    threshold: 3.0
+    <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
@@ -1,0 +1,8 @@
+  obs filters:
+  - filter: PreQC
+    maxvalue: 0
+  - filter: GOMsaver
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-a.nc4
+  - filter: Background Check
+    threshold: 3.0
+    <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
@@ -1,0 +1,8 @@
+  obs filters:
+  - filter: PreQC
+    maxvalue: 0
+  - filter: GOMsaver
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-b.nc4
+  - filter: Background Check
+    threshold: 3.0
+    <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
@@ -1,0 +1,8 @@
+  obs filters:
+  - filter: PreQC
+    maxvalue: 0
+  - filter: GOMsaver
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n18.nc4
+  - filter: Background Check
+    threshold: 3.0
+    <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
@@ -1,0 +1,8 @@
+  obs filters:
+  - filter: PreQC
+    maxvalue: 0
+  - filter: GOMsaver
+    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n19.nc4
+  - filter: Background Check
+    threshold: 3.0
+    <<: *multiIterationFilter

--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -33,6 +33,10 @@ benchmarkObservations = [
   'amsua_n15',
   'amsua_n18',
   'amsua_n19',
+  'mhs_metop-a',
+  'mhs_metop-b',
+  'mhs_n18',
+  'mhs_n19',
 ]
 
 class Observations(Component):

--- a/scenarios/defaults/observations.yaml
+++ b/scenarios/defaults/observations.yaml
@@ -216,6 +216,10 @@ observations:
       - iasi_metop-a
       - iasi_metop-b
       - iasi_metop-c
+      - mhs_metop-a
+      - mhs_metop-b
+      - mhs_n18
+      - mhs_n19
 
       IODAPrefix:
         gnssrobndropp1d: gnssro
@@ -263,10 +267,10 @@ observations:
           amsua-cld_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/raw_obs
 
           ## mhs
-          mhs_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
-          mhs_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
-          mhs_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
-          mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
+          mhs_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          mhs_metop-b: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          mhs_n18: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
+          mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/no_bias
 
           ## abi
           abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB59X59_no-bias-correct


### PR DESCRIPTION
### Description
Add MHS in benchmark experiments.
Note: There is no qc filters available in UFO for MHS. We keep using non-bias-corrected or bias-corrected GSI-ncdiag files.  And in `scenarios` `3dvar_O30kmIE60km_ColdStart.yaml` and `3dvar_OIE120km_ColdStart.yaml`, we do not assimilate MHS from raw obs (downloaded from RDA)

### Issue closed
Closes https://github.com/NCAR/MPAS-Workflow/issues/232

### Modified and added files:
M     initialize/data/Observations.py
M     scenarios/defaults/observations.yaml
A	config/jedi/ObsPlugs/da/base/mhs_metop-a.yaml
A	config/jedi/ObsPlugs/da/base/mhs_metop-b.yaml
A	config/jedi/ObsPlugs/da/base/mhs_n18.yaml
A	config/jedi/ObsPlugs/da/base/mhs_n19.yaml
A	config/jedi/ObsPlugs/da/bias/mhs_metop-a.yaml
A	config/jedi/ObsPlugs/da/bias/mhs_metop-b.yaml
A	config/jedi/ObsPlugs/da/bias/mhs_n18.yaml
A	config/jedi/ObsPlugs/da/bias/mhs_n19.yaml
A	config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
A	config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
A	config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
A	config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
A	config/jedi/ObsPlugs/da/filters/mhs_n19.yaml
A	config/jedi/ObsPlugs/da/filters/mhs_n18.yaml
A	config/jedi/ObsPlugs/da/filters/mhs_metop-a.yaml
A	config/jedi/ObsPlugs/da/filters/mhs_metop-b.yaml

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC

