### PR TITLE
   Update to 2.0 release code location and spack-stack-1.3.1 build env

### DIFF
--- a/config/environmentJEDI.csh
+++ b/config/environmentJEDI.csh
@@ -5,28 +5,27 @@ setenv config_environmentJEDI 1
 
 source config/auto/build.csh # for bundleCompilerUsed
 
+echo "Loading Spack-Stack 1.3.1"
 source /etc/profile.d/modules.csh
 module purge
+setenv LMOD_TMOD_FIND_FIRST yes
 module unuse /glade/u/apps/ch/modulefiles/default/compilers
 setenv MODULEPATH_ROOT /glade/work/jedipara/cheyenne/spack-stack/modulefiles
 module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/compilers
 module use /glade/work/jedipara/cheyenne/spack-stack/modulefiles/misc
-
+module use /glade/work/epicufsrt/contrib/spack-stack/spack-stack-1.3.1/envs/unified-env/install/modulefiles/Core
 
 if ( "$bundleCompilerUsed" =~  *"gnu"* ) then
-  module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-3.0.0-gnu-10.1.0/install/modulefiles/Core
   module load stack-gcc/10.1.0
   module load stack-openmpi/4.1.1
-  module load jedi-mpas-env/1.0.0
 
 else if ( "$bundleCompilerUsed" =~  *"intel"* ) then
-  module use /glade/work/jedipara/cheyenne/spack-stack/spack-stack-v1/envs/skylab-3.0.0-intel-19.1.1.217/install/modulefiles/Core
   module load stack-intel/19.1.1.217
   module load stack-intel-mpi/2019.7.217
-  module load jedi-mpas-env/1.0.0
-
+  
 endif
 
+module load jedi-mpas-env/unified-dev
 limit stacksize unlimited
 setenv OOPS_TRACE 0
 setenv OOPS_DEBUG 0

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -16,7 +16,7 @@ class Build(Component):
   variablesWithDefaults = {
     ## mpas bundle
     # mpas-bundle build directory
-    'mpas bundle': ['/glade/p/mmm/parc/jban/pandac_common/code_230526_single/build', str],
+    'mpas bundle': ['/glade/p/mmm/parc/liuz/pandac_common/mpas-bundle-code-build/mpas_bundle_2.0_gnuSP/build', str],
 
     # optional double-precision build
     #'mpas bundle': ['/glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_22MAR2023', str],
@@ -24,7 +24,7 @@ class Build(Component):
     # forecast directory
     # defaults to bundle build, otherwise specify full directory
     #'forecast directory': ['bundle', str],
-    'forecast directory': ['/glade/p/mmm/parc/liuz/pandac_common/mpas-bundle-code-build/20230422_mpas_bundle_SP/MPAS_intelmpt', str],
+    'forecast directory': ['/glade/p/mmm/parc/liuz/pandac_common/mpas-bundle-code-build/mpas_bundle_2.0_gnuSP/MPAS_intelmpt', str],
 
     ## bundle compiler used
     # {compiler}-{mpi-implementation}/{version} combination that selects the JEDI module used to build


### PR DESCRIPTION
### Description
Update to the MPAS-JEDI-2.0 code location built with spack-stack-1.3.1 gnu compiler. Note that the build are based upon the public JCSDA repo, but with CMakeLists.txt changes for single precision build, ROPP and RTTOV libs' build on so that we can assimilate bending angles with ROPP 1D or 2D operators and test radiance DA with RTTOV or RTTOVCPP interface. Also updated is the location of MPAS model build with intel+mpt.

### Issue closed

Closes #225 

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
