### PR TITLE
Change time step from 6dx to 8dx

### DIFF
--- a/config/mpas/forecast/namelist.atmosphere
+++ b/config/mpas/forecast/namelist.atmosphere
@@ -4,7 +4,7 @@
     config_start_time = 'startTime'
     config_run_duration = 'fcLength'
     config_split_dynamics_transport = true
-    config_number_of_sub_steps = 2
+    config_number_of_sub_steps = 4
     config_dynamics_split_steps = 3
     config_h_mom_eddy_visc2 = 0.0
     config_h_mom_eddy_visc4 = 0.0

--- a/scenarios/defaults/model.yaml
+++ b/scenarios/defaults/model.yaml
@@ -9,13 +9,13 @@ model:
     #  DiffusionLengthScale: float # only used for {{outerMesh}}
     30km:
       nCells: 655362
-      TimeStep: 180.0
+      TimeStep: 240.0
       DiffusionLengthScale: 30000.0
     60km:
       nCells: 163842
-      TimeStep: 360.0
+      TimeStep: 480.0
       DiffusionLengthScale: 60000.0
     120km:
       nCells: 40962
-      TimeStep: 720.0
+      TimeStep: 960.0
       DiffusionLengthScale: 120000.0

--- a/scenarios/defaults/model.yaml
+++ b/scenarios/defaults/model.yaml
@@ -17,5 +17,5 @@ model:
       DiffusionLengthScale: 60000.0
     120km:
       nCells: 40962
-      TimeStep: 960.0
+      TimeStep: 900.0
       DiffusionLengthScale: 120000.0


### PR DESCRIPTION
### Description
Latest code is more stable and allows a larger time step of 8dx.
One exception is for 120km mesh, I have to change it from 960s (22.5 time steps) 
to 900s (24 time steps for 6-h cycling forecasts) in order to pass all Tier 1 tests.

### Issue closed

Closes #238 

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
