### PR TITLE
Correct memory request

### DIFF
--- a/scenarios/IASI120km3denvar.yaml
+++ b/scenarios/IASI120km3denvar.yaml
@@ -57,7 +57,7 @@ variational:
           baseSeconds: 900
           nodes: 8
           PEPerNode: 16
-          memory: 109
+          memory: 109GB
 hpc:
   CriticalQueue: premium
   NonCriticalQueue: premium

--- a/scenarios/IASI30kmIE60km3denvar.yaml
+++ b/scenarios/IASI30kmIE60km3denvar.yaml
@@ -71,7 +71,7 @@ variational:
           baseSeconds: 4500
           nodes: 8
           PEPerNode: 16
-          memory: 109
+          memory: 109GB
 hpc:
   CriticalQueue: premium
   NonCriticalQueue: premium

--- a/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
+++ b/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
@@ -44,7 +44,7 @@ variational:
     30km:
       60km:
         3denvar:
-          memory: 45
+          memory: 45GB
   post: [verifyobs]
 workflow:
   first cycle point: 20180414T18

--- a/test/testinput/3dvar_O30kmIE60km_ColdStart.yaml
+++ b/test/testinput/3dvar_O30kmIE60km_ColdStart.yaml
@@ -31,7 +31,7 @@ variational:
     30km:
       60km:
         3dvar:
-          memory: 45
+          memory: 45GB
   post: [verifyobs]
 workflow:
   # test a recent date


### PR DESCRIPTION
### Description
Memory request is corrected from "45" to "45GB" (for example).
### Issue closed
Closes https://github.com/NCAR/MPAS-Workflow/issues/240

### Files modified:
M       scenarios/IASI120km3denvar.yaml
M       scenarios/IASI30kmIE60km3denvar.yaml
M       test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
M       test/testinput/3dvar_O30kmIE60km_ColdStart.yaml

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
