### PR TITLE
Feature/adjust final cycle point

### DIFF
--- a/scenarios/3denvar_O30kmIE60km_WarmStart.yaml
+++ b/scenarios/3denvar_O30kmIE60km_WarmStart.yaml
@@ -32,3 +32,8 @@ observations:
       IODASuperObGrid:
         abi_g16: 15X15
         ahi_himawari8: 15X15
+workflow:
+  first cycle point: 20180414T18
+  #restart cycle point: 20180418T00
+  final cycle point: 20180415T06
+  #final cycle point: 20180514T18

--- a/scenarios/3denvar_O30kmIE60km_WarmStart_ABEI.yaml
+++ b/scenarios/3denvar_O30kmIE60km_WarmStart_ABEI.yaml
@@ -34,3 +34,8 @@ observations:
       IODASuperObGrid:
         abi_g16: 15X15
         ahi_himawari8: 15X15
+workflow:
+  first cycle point: 20180414T18
+  #restart cycle point: 20180418T00
+  final cycle point: 20180415T12
+  #final cycle point: 20180514T18

--- a/scenarios/3denvar_O30kmIE60km_WarmStart_ABEI.yaml
+++ b/scenarios/3denvar_O30kmIE60km_WarmStart_ABEI.yaml
@@ -37,5 +37,5 @@ observations:
 workflow:
   first cycle point: 20180414T18
   #restart cycle point: 20180418T00
-  final cycle point: 20180415T12
+  final cycle point: 20180415T06
   #final cycle point: 20180514T18

--- a/scenarios/3denvar_OIE120km_WarmStart.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart.yaml
@@ -15,3 +15,7 @@ variational:
   ensemble:
     forecasts:
       resource: "PANDAC.GEFS"
+workflow:
+  first cycle point: 20180414T18
+  #restart cycle point: 20180418T00
+  final cycle point: 20180415T06

--- a/scenarios/3denvar_OIE120km_WarmStart_IAU.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart_IAU.yaml
@@ -1,6 +1,8 @@
 workflow:
   first cycle point: 20180414T18
-  final cycle point:   20180514T18
+  #restart cycle point: 20180418T00
+  final cycle point:   20180415T06
+  #final cycle point: 20180514T18
 
 extendedforecast:
   #meanTimes: T00  # uncomment to engage

--- a/scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml
@@ -18,3 +18,8 @@ variational:
   ensemble:
     forecasts:
       resource: "PANDAC.GEFS"
+workflow:
+  first cycle point: 20180414T18
+  #restart cycle point: 20180418T00
+  final cycle point: 20180415T06
+  #final cycle point: 20180514T18

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble.yaml
@@ -45,4 +45,6 @@ variational:
 
 workflow:
   first cycle point: 20180414T18
-  final cycle point: 20180514T18
+  #restart cycle point: 20180418T00
+  final cycle point: 20180415T06
+  #final cycle point: 20180514T18

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -54,4 +54,6 @@ variational:
 
 workflow:
   first cycle point: 20180414T18
-  final cycle point: 20180514T18
+  #restart cycle point: 20180418T00
+  final cycle point: 20180415T06
+  #final cycle point: 20180514T18

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml
@@ -75,5 +75,6 @@ variational:
 
 workflow:
   first cycle point: 20180414T18
-  final cycle point: 20180415T18
+  #restart cycle point: 20180418T00
+  final cycle point: 20180415T06
   #final cycle point: 20180514T18

--- a/scenarios/3dhybrid_OIE120km_WarmStart.yaml
+++ b/scenarios/3dhybrid_OIE120km_WarmStart.yaml
@@ -17,3 +17,8 @@ variational:
   ensemble:
     forecasts:
       resource: "PANDAC.GEFS"
+workflow:
+  first cycle point: 20180414T18
+  #restart cycle point: 20180418T00
+  final cycle point:   20180415T06
+  #final cycle point: 20180514T18

--- a/scenarios/3dvar_O30kmIE60km_ColdStart.yaml
+++ b/scenarios/3dvar_O30kmIE60km_ColdStart.yaml
@@ -1,6 +1,8 @@
 workflow:
   first cycle point: 20220217T18
-  final cycle point: 20220228T00
+  #restart cycle point: 20220218T00
+  final cycle point: 20220218T06
+  #final cycle point: 20220228T00
 observations:
   resource: GladeRDAOnline
 members:

--- a/scenarios/3dvar_OIE120km_ColdStart.yaml
+++ b/scenarios/3dvar_OIE120km_ColdStart.yaml
@@ -1,6 +1,8 @@
 workflow:
   first cycle point: 20220217T18
-  final cycle point: 20220228T00
+  #restart cycle point: 20220218T00
+  final cycle point: 20220218T06
+  #final cycle point: 20220228T00
 observations:
   resource: GladeRDAOnline
 members:

--- a/scenarios/3dvar_OIE120km_WarmStart.yaml
+++ b/scenarios/3dvar_OIE120km_WarmStart.yaml
@@ -24,4 +24,6 @@ variational:
 
 workflow:
   first cycle point: 20180414T18
-  final cycle point: 20180514T18
+  #restart cycle point: 20180418T00
+  final cycle point:   20180415T06
+  #final cycle point: 20180514T18

--- a/scenarios/3dvar_OIE120km_WarmStart_PostProcess.yaml
+++ b/scenarios/3dvar_OIE120km_WarmStart_PostProcess.yaml
@@ -37,5 +37,7 @@ variational:
   post: [verifyobs]
 
 workflow:
-  first cycle point: 20180415T00
-  final cycle point: 20180514T18
+  first cycle point: 20180414T18
+  #restart cycle point: 20180418T00
+  final cycle point:   20180415T06
+  #final cycle point: 20180514T18

--- a/scenarios/ABIAHI120km3denvar.yaml
+++ b/scenarios/ABIAHI120km3denvar.yaml
@@ -1,6 +1,8 @@
 workflow:
   first cycle point: 20180414T18
-  final cycle point: 20180514T18
+  #restart cycle point: 20180418T00
+  final cycle point:   20180415T06
+  #final cycle point: 20180514T18
 observations:
   resource: PANDACArchive
   resources:

--- a/scenarios/IASI30kmIE60km3denvar.yaml
+++ b/scenarios/IASI30kmIE60km3denvar.yaml
@@ -1,6 +1,8 @@
 workflow:
   first cycle point: 20180414T18
-  final cycle point: 20180514T18
+  #restart cycle point: 20180418T00
+  final cycle point:   20180415T06
+  #final cycle point: 20180514T18
 observations:
   resource: PANDACArchive
   resources:

--- a/scenarios/eda_OIE120km_WarmStart.yaml
+++ b/scenarios/eda_OIE120km_WarmStart.yaml
@@ -1,3 +1,8 @@
+workflow:
+  first cycle point: 20180414T18
+  #restart cycle point: 20180418T00
+  final cycle point:   20180415T06
+  #final cycle point: 20180514T18
 externalanalyses:
   resource: "GFS.PANDAC"
 firstbackground:

--- a/scenarios/eda_OIE60km_WarmStart.yaml
+++ b/scenarios/eda_OIE60km_WarmStart.yaml
@@ -1,6 +1,8 @@
 workflow:
   first cycle point: 20180414T18
-  final cycle point: 20180514T18
+  #restart cycle point: 20180418T00
+  final cycle point:   20180415T06
+  #final cycle point: 20180514T18
 externalanalyses:
   resource: "GFS.PANDAC"
 firstbackground:


### PR DESCRIPTION
### Description
`Final cycle point` is adjusted. In case waste of computational cost during testing. Once users make sure the setting is correct, they can adjust `Final cycle point` to longer run.

### Files modified:
M       scenarios/3denvar_O30kmIE60km_WarmStart.yaml
M       scenarios/3denvar_O30kmIE60km_WarmStart_ABEI.yaml
M       scenarios/3denvar_OIE120km_WarmStart.yaml
M       scenarios/3denvar_OIE120km_WarmStart_IAU.yaml
M       scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml
M       scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble.yaml
M       scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
M       scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml
M       scenarios/3dhybrid_OIE120km_WarmStart.yaml
M       scenarios/3dvar_O30kmIE60km_ColdStart.yaml
M       scenarios/3dvar_OIE120km_ColdStart.yaml
M       scenarios/3dvar_OIE120km_WarmStart.yaml
M       scenarios/3dvar_OIE120km_WarmStart_PostProcess.yaml
M       scenarios/ABIAHI120km3denvar.yaml
M       scenarios/IASI30kmIE60km3denvar.yaml
M       scenarios/eda_OIE120km_WarmStart.yaml
M       scenarios/eda_OIE60km_WarmStart.yaml

### Tests completed
scenarios/3dvar_OIE120km_WarmStart.yaml
