### PR TITLE
Blend use of bending angle and refractivity

### DIFF
--- a/config/jedi/ObsPlugs/da/filters/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua_aqua.yaml
@@ -17,8 +17,8 @@
     minvalue: 1.0e-12
     action:
       name: reject
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_aqua.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_aqua.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua_metop-a.yaml
@@ -17,8 +17,8 @@
     minvalue: 1.0e-12
     action:
       name: reject
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-a.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-a.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua_metop-b.yaml
@@ -17,8 +17,8 @@
     minvalue: 1.0e-12
     action:
       name: reject
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-b.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-b.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua_n15.yaml
@@ -17,8 +17,8 @@
     minvalue: 1.0e-12
     action:
       name: reject
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n15.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n15.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua_n18.yaml
@@ -17,8 +17,8 @@
     minvalue: 1.0e-12
     action:
       name: reject
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n18.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n18.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua_n19.yaml
@@ -17,8 +17,8 @@
     minvalue: 1.0e-12
     action:
       name: reject
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n19.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n19.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/gnssrobndropp1d.yaml
+++ b/config/jedi/ObsPlugs/da/filters/gnssrobndropp1d.yaml
@@ -3,7 +3,7 @@
     where:
     - variable:
         name: MetaData/impactHeightRO
-      minvalue: 1.55
+      minvalue: 1550.0
       maxvalue: 28000.0
     - variable:
         name: MetaData/earthRadiusCurvature

--- a/config/jedi/ObsPlugs/da/filters/gnssrobndropp1d.yaml
+++ b/config/jedi/ObsPlugs/da/filters/gnssrobndropp1d.yaml
@@ -3,8 +3,8 @@
     where:
     - variable:
         name: MetaData/impactHeightRO
-      minvalue: 0.0
-      maxvalue: 30000.0
+      minvalue: 1.55
+      maxvalue: 28000.0
     - variable:
         name: MetaData/earthRadiusCurvature
       minvalue: 6250000.0

--- a/config/jedi/ObsPlugs/da/filters/gnssrobndropp1d.yaml
+++ b/config/jedi/ObsPlugs/da/filters/gnssrobndropp1d.yaml
@@ -2,7 +2,7 @@
   - filter: Domain Check
     where:
     - variable:
-        name: MetaData/impactHeightRO
+        name: MetaData/height
       minvalue: 1550.0
       maxvalue: 28000.0
     - variable:

--- a/config/jedi/ObsPlugs/da/filters/gnssrorefncep.yaml
+++ b/config/jedi/ObsPlugs/da/filters/gnssrorefncep.yaml
@@ -4,7 +4,7 @@
     - variable:
         name: MetaData/height
       minvalue: 0.0
-      maxvalue: 30000.0
+      maxvalue: 1500.0
     - variable:
         name: MetaData/earthRadiusCurvature
       minvalue: 6250000.0

--- a/config/jedi/ObsPlugs/da/filters/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filters/mhs_metop-a.yaml
@@ -1,8 +1,8 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-a.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-a.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filters/mhs_metop-b.yaml
@@ -1,8 +1,8 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-b.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-b.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filters/mhs_n18.yaml
@@ -1,8 +1,8 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n18.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n18.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filters/mhs_n19.yaml
@@ -1,8 +1,8 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n19.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n19.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua.yaml
@@ -266,5 +266,5 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_aqua.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_aqua.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a.yaml
@@ -266,5 +266,5 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-a.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-a.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b.yaml
@@ -266,5 +266,5 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-b.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-b.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15.yaml
@@ -266,5 +266,5 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n15.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n15.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18.yaml
@@ -266,5 +266,5 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n18.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n18.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19.yaml
@@ -266,5 +266,5 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n19.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n19.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
@@ -1,8 +1,8 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-a.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-a.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
@@ -1,8 +1,8 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-b.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-b.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
@@ -1,8 +1,8 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n18.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n18.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
@@ -1,8 +1,8 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n19.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n19.nc4
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/hofx/filters/amsua-cld_aqua.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua-cld_aqua.yaml
@@ -13,10 +13,10 @@
 #      channels: *amsua-cld_aqua_channels
 #    minvalue: 170.0
 #    maxvalue: 300.0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_aqua.nc4
-  - filter: YDIAGsaver
-    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_aqua.nc4
-    filter variables:
-    - name: brightness_temperature_assuming_clear_sky
-      channels: *amsua-cld_aqua_channels
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_aqua.nc4
+#  - filter: YDIAGsaver
+#    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_aqua.nc4
+#    filter variables:
+#    - name: brightness_temperature_assuming_clear_sky
+#      channels: *amsua-cld_aqua_channels

--- a/config/jedi/ObsPlugs/hofx/filters/amsua-cld_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua-cld_metop-a.yaml
@@ -13,10 +13,10 @@
 #      channels: *amsua-cld_metop-a_channels
 #    minvalue: 170.0
 #    maxvalue: 300.0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_metop-a.nc4
-  - filter: YDIAGsaver
-    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_metop-a.nc4
-    filter variables:
-    - name: brightness_temperature_assuming_clear_sky
-      channels: *amsua-cld_metop-a_channels
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_metop-a.nc4
+#  - filter: YDIAGsaver
+#    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_metop-a.nc4
+#    filter variables:
+#    - name: brightness_temperature_assuming_clear_sky
+#      channels: *amsua-cld_metop-a_channels

--- a/config/jedi/ObsPlugs/hofx/filters/amsua-cld_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua-cld_metop-b.yaml
@@ -13,10 +13,10 @@
 #      channels: *amsua-cld_metop-b_channels
 #    minvalue: 170.0
 #    maxvalue: 300.0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_metop-b.nc4
-  - filter: YDIAGsaver
-    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_metop-b.nc4
-    filter variables:
-    - name: brightness_temperature_assuming_clear_sky
-      channels: *amsua-cld_metop-b_channels
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_metop-b.nc4
+#  - filter: YDIAGsaver
+#    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_metop-b.nc4
+#    filter variables:
+#    - name: brightness_temperature_assuming_clear_sky
+#      channels: *amsua-cld_metop-b_channels

--- a/config/jedi/ObsPlugs/hofx/filters/amsua-cld_n15.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua-cld_n15.yaml
@@ -13,10 +13,10 @@
 #      channels: *amsua-cld_n15_channels
 #    minvalue: 170.0
 #    maxvalue: 300.0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_n15.nc4
-  - filter: YDIAGsaver
-    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_n15.nc4
-    filter variables:
-    - name: brightness_temperature_assuming_clear_sky
-      channels: *amsua-cld_n15_channels
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_n15.nc4
+#  - filter: YDIAGsaver
+#    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_n15.nc4
+#    filter variables:
+#    - name: brightness_temperature_assuming_clear_sky
+#      channels: *amsua-cld_n15_channels

--- a/config/jedi/ObsPlugs/hofx/filters/amsua-cld_n18.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua-cld_n18.yaml
@@ -13,10 +13,10 @@
 #      channels: *amsua-cld_n18_channels
 #    minvalue: 170.0
 #    maxvalue: 300.0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_n18.nc4
-  - filter: YDIAGsaver
-    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_n18.nc4
-    filter variables:
-    - name: brightness_temperature_assuming_clear_sky
-      channels: *amsua-cld_n18_channels
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_n18.nc4
+#  - filter: YDIAGsaver
+#    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_n18.nc4
+#    filter variables:
+#    - name: brightness_temperature_assuming_clear_sky
+#      channels: *amsua-cld_n18_channels

--- a/config/jedi/ObsPlugs/hofx/filters/amsua-cld_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua-cld_n19.yaml
@@ -13,10 +13,10 @@
 #      channels: *amsua-cld_n19_channels
 #    minvalue: 170.0
 #    maxvalue: 300.0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_n19.nc4
-  - filter: YDIAGsaver
-    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_n19.nc4
-    filter variables:
-    - name: brightness_temperature_assuming_clear_sky
-      channels: *amsua-cld_n19_channels
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua-cld_n19.nc4
+#  - filter: YDIAGsaver
+#    filename: {{OutDBDir}}/{{diagPrefix}}_amsua-cld_n19.nc4
+#    filter variables:
+#    - name: brightness_temperature_assuming_clear_sky
+#      channels: *amsua-cld_n19_channels

--- a/config/jedi/ObsPlugs/hofx/filters/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua_aqua.yaml
@@ -1,5 +1,5 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_aqua.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_aqua.nc4

--- a/config/jedi/ObsPlugs/hofx/filters/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua_metop-a.yaml
@@ -1,5 +1,5 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_metop-a.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_metop-a.nc4

--- a/config/jedi/ObsPlugs/hofx/filters/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua_metop-b.yaml
@@ -1,5 +1,5 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_metop-b.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_metop-b.nc4

--- a/config/jedi/ObsPlugs/hofx/filters/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua_n15.yaml
@@ -1,5 +1,5 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_n15.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_n15.nc4

--- a/config/jedi/ObsPlugs/hofx/filters/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua_n18.yaml
@@ -1,5 +1,5 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_n18.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_n18.nc4

--- a/config/jedi/ObsPlugs/hofx/filters/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/amsua_n19.yaml
@@ -1,5 +1,5 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_n19.nc4
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_amsua_n19.nc4

--- a/config/jedi/ObsPlugs/hofx/filters/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/mhs_metop-a.yaml
@@ -1,22 +1,22 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_metop-a.nc4
-  - filter: YDIAGsaver 
-    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_metop-a.nc4
-    filter variables:
-    - name: brightness_temperature_assuming_clear_sky
-      channels: *mhs_metop-a_channels
-    - name: brightness_temperature_jacobian_air_temperature
-      channels: *mhs_metop-a_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
-      channels: *mhs_metop-a_channels
-    - name: brightness_temperature_jacobian_surface_emissivity
-      channels: *mhs_metop-a_channels
-    - name: brightness_temperature_jacobian_surface_temperature
-      channels: *mhs_metop-a_channels
-    - name: weightingfunction_of_atmosphere_layer
-      channels: *mhs_metop-a_channels
-    - name: pressure_level_at_peak_of_weightingfunction
-      channels: *mhs_metop-a_channels
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_metop-a.nc4
+#  - filter: YDIAGsaver 
+#    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_metop-a.nc4
+#    filter variables:
+#    - name: brightness_temperature_assuming_clear_sky
+#      channels: *mhs_metop-a_channels
+#    - name: brightness_temperature_jacobian_air_temperature
+#      channels: *mhs_metop-a_channels
+#    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+#      channels: *mhs_metop-a_channels
+#    - name: brightness_temperature_jacobian_surface_emissivity
+#      channels: *mhs_metop-a_channels
+#    - name: brightness_temperature_jacobian_surface_temperature
+#      channels: *mhs_metop-a_channels
+#    - name: weightingfunction_of_atmosphere_layer
+#      channels: *mhs_metop-a_channels
+#    - name: pressure_level_at_peak_of_weightingfunction
+#      channels: *mhs_metop-a_channels

--- a/config/jedi/ObsPlugs/hofx/filters/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/mhs_metop-b.yaml
@@ -1,22 +1,22 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_metop-b.nc4
-  - filter: YDIAGsaver 
-    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_metop-b.nc4
-    filter variables:
-    - name: brightness_temperature_assuming_clear_sky
-      channels: *mhs_metop-b_channels
-    - name: brightness_temperature_jacobian_air_temperature
-      channels: *mhs_metop-b_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
-      channels: *mhs_metop-b_channels
-    - name: brightness_temperature_jacobian_surface_emissivity
-      channels: *mhs_metop-b_channels
-    - name: brightness_temperature_jacobian_surface_temperature
-      channels: *mhs_metop-b_channels
-    - name: weightingfunction_of_atmosphere_layer
-      channels: *mhs_metop-b_channels
-    - name: pressure_level_at_peak_of_weightingfunction
-      channels: *mhs_metop-b_channels
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_metop-b.nc4
+#  - filter: YDIAGsaver 
+#    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_metop-b.nc4
+#    filter variables:
+#    - name: brightness_temperature_assuming_clear_sky
+#      channels: *mhs_metop-b_channels
+#    - name: brightness_temperature_jacobian_air_temperature
+#      channels: *mhs_metop-b_channels
+#    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+#      channels: *mhs_metop-b_channels
+#    - name: brightness_temperature_jacobian_surface_emissivity
+#      channels: *mhs_metop-b_channels
+#    - name: brightness_temperature_jacobian_surface_temperature
+#      channels: *mhs_metop-b_channels
+#    - name: weightingfunction_of_atmosphere_layer
+#      channels: *mhs_metop-b_channels
+#    - name: pressure_level_at_peak_of_weightingfunction
+#      channels: *mhs_metop-b_channels

--- a/config/jedi/ObsPlugs/hofx/filters/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/mhs_n18.yaml
@@ -1,22 +1,22 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_n18.nc4
-  - filter: YDIAGsaver 
-    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_n18.nc4
-    filter variables:
-    - name: brightness_temperature_assuming_clear_sky
-      channels: *mhs_n18_channels
-    - name: brightness_temperature_jacobian_air_temperature
-      channels: *mhs_n18_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
-      channels: *mhs_n18_channels
-    - name: brightness_temperature_jacobian_surface_emissivity
-      channels: *mhs_n18_channels
-    - name: brightness_temperature_jacobian_surface_temperature
-      channels: *mhs_n18_channels
-    - name: weightingfunction_of_atmosphere_layer
-      channels: *mhs_n18_channels
-    - name: pressure_level_at_peak_of_weightingfunction
-      channels: *mhs_n18_channels
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_n18.nc4
+#  - filter: YDIAGsaver 
+#    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_n18.nc4
+#    filter variables:
+#    - name: brightness_temperature_assuming_clear_sky
+#      channels: *mhs_n18_channels
+#    - name: brightness_temperature_jacobian_air_temperature
+#      channels: *mhs_n18_channels
+#    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+#      channels: *mhs_n18_channels
+#    - name: brightness_temperature_jacobian_surface_emissivity
+#      channels: *mhs_n18_channels
+#    - name: brightness_temperature_jacobian_surface_temperature
+#      channels: *mhs_n18_channels
+#    - name: weightingfunction_of_atmosphere_layer
+#      channels: *mhs_n18_channels
+#    - name: pressure_level_at_peak_of_weightingfunction
+#      channels: *mhs_n18_channels

--- a/config/jedi/ObsPlugs/hofx/filters/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/mhs_n19.yaml
@@ -1,22 +1,22 @@
   obs filters:
   - filter: PreQC
     maxvalue: 0
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_n19.nc4
-  - filter: YDIAGsaver 
-    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_n19.nc4
-    filter variables:
-    - name: brightness_temperature_assuming_clear_sky
-      channels: *mhs_n19_channels
-    - name: brightness_temperature_jacobian_air_temperature
-      channels: *mhs_n19_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
-      channels: *mhs_n19_channels
-    - name: brightness_temperature_jacobian_surface_emissivity
-      channels: *mhs_n19_channels
-    - name: brightness_temperature_jacobian_surface_temperature
-      channels: *mhs_n19_channels
-    - name: weightingfunction_of_atmosphere_layer
-      channels: *mhs_n19_channels
-    - name: pressure_level_at_peak_of_weightingfunction
-      channels: *mhs_n19_channels
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_mhs_n19.nc4
+#  - filter: YDIAGsaver 
+#    filename: {{OutDBDir}}/{{diagPrefix}}_mhs_n19.nc4
+#    filter variables:
+#    - name: brightness_temperature_assuming_clear_sky
+#      channels: *mhs_n19_channels
+#    - name: brightness_temperature_jacobian_air_temperature
+#      channels: *mhs_n19_channels
+#    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+#      channels: *mhs_n19_channels
+#    - name: brightness_temperature_jacobian_surface_emissivity
+#      channels: *mhs_n19_channels
+#    - name: brightness_temperature_jacobian_surface_temperature
+#      channels: *mhs_n19_channels
+#    - name: weightingfunction_of_atmosphere_layer
+#      channels: *mhs_n19_channels
+#    - name: pressure_level_at_peak_of_weightingfunction
+#      channels: *mhs_n19_channels

--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -21,6 +21,7 @@ from initialize.framework.HPC import HPC
 benchmarkObservations = [
   # anchor
   'aircraft',
+  'gnssrorefncep',
   'gnssrobndropp1d',
   'satwind',
   'satwnd',

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -243,7 +243,7 @@ variational:
           PEPerNode: 32
           memory: 45GB
           baseSeconds: 200
-          secondsPerEnVarMember: 5
+          secondsPerEnVarMember: 15
         3dvar:
           nodes: 4
           PEPerNode: 32

--- a/scenarios/defaults/verifymodel.yaml
+++ b/scenarios/defaults/verifymodel.yaml
@@ -17,5 +17,5 @@ verifymodel:
       seconds: 480
       secondsPerMember: 100
     120km:
-      seconds: 120
-      secondsPerMember: 40
+      seconds: 400
+      secondsPerMember: 80


### PR DESCRIPTION
### Description
From @junmeiban 's several cycling experiments, we see some degradation of T and Q below model level 13-15 (~1.5 km height) when assimilating bending angle from 0-30km and compared to assimilation of refractivity. Limiting the use of bending angle below certain height does not solve the problem. Overall impact above 1.5km is positive with bending angle vs. refractivity. So this PR makes the blended use of two: keep using refractivity below 1.5km and use bending angle above 1.5km. Also note that bending angle QC filter uses 'height' now (more intuitive) instead of 'ImpactHeightRO' (~2km = 0km geometric height).

Other maintenance changes:
1. Changed 5 min DA wall time to >8min. No guarantee DA jobs will finish with 5 min.
2. Changed 120km verifymodel wall time from 5min to 8min
3. Turned off geoval and ydiags files output in DA and hofx mode for amsua and mhs

### List of modified files
M       config/jedi/ObsPlugs/da/filters/amsua_aqua.yaml
M       config/jedi/ObsPlugs/da/filters/amsua_metop-a.yaml
M       config/jedi/ObsPlugs/da/filters/amsua_metop-b.yaml
M       config/jedi/ObsPlugs/da/filters/amsua_n15.yaml
M       config/jedi/ObsPlugs/da/filters/amsua_n18.yaml
M       config/jedi/ObsPlugs/da/filters/amsua_n19.yaml
M       config/jedi/ObsPlugs/da/filters/gnssrobndropp1d.yaml
M       config/jedi/ObsPlugs/da/filters/gnssrorefncep.yaml
M       config/jedi/ObsPlugs/da/filters/mhs_metop-a.yaml
M       config/jedi/ObsPlugs/da/filters/mhs_metop-b.yaml
M       config/jedi/ObsPlugs/da/filters/mhs_n18.yaml
M       config/jedi/ObsPlugs/da/filters/mhs_n19.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua-cld_aqua.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua-cld_metop-a.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua-cld_metop-b.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua-cld_n15.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua-cld_n18.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua-cld_n19.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua_aqua.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua_metop-a.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua_metop-b.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua_n15.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua_n18.yaml
M       config/jedi/ObsPlugs/hofx/filters/amsua_n19.yaml
M       config/jedi/ObsPlugs/hofx/filters/mhs_metop-a.yaml
M       config/jedi/ObsPlugs/hofx/filters/mhs_metop-b.yaml
M       config/jedi/ObsPlugs/hofx/filters/mhs_n18.yaml
M       config/jedi/ObsPlugs/hofx/filters/mhs_n19.yaml
M       initialize/data/Observations.py
M       initialize/framework/HPC.py
M       scenarios/3denvar_OIE120km_WarmStart_IAU.yaml
M       scenarios/defaults/variational.yaml
M       scenarios/defaults/verifymodel.yaml

### Tests completed
Ran a cycling experiment, but the low level issues remain and need further investigation.