### PR TITLE
 Change default settings

### DIFF
--- a/config/jedi/ObsPlugs/da/filters/gnssrobndropp1d.yaml
+++ b/config/jedi/ObsPlugs/da/filters/gnssrobndropp1d.yaml
@@ -3,8 +3,8 @@
     where:
     - variable:
         name: MetaData/height
-      minvalue: 1550.0
-      maxvalue: 28000.0
+      minvalue: 0.0
+      maxvalue: 30000.0
     - variable:
         name: MetaData/earthRadiusCurvature
       minvalue: 6250000.0

--- a/config/jedi/ObsPlugs/da/filters/gnssrorefncep.yaml
+++ b/config/jedi/ObsPlugs/da/filters/gnssrorefncep.yaml
@@ -4,7 +4,7 @@
     - variable:
         name: MetaData/height
       minvalue: 0.0
-      maxvalue: 1500.0
+      maxvalue: 30000.0
     - variable:
         name: MetaData/earthRadiusCurvature
       minvalue: 6250000.0

--- a/config/mpas/forecast/namelist.atmosphere
+++ b/config/mpas/forecast/namelist.atmosphere
@@ -4,7 +4,7 @@
     config_start_time = 'startTime'
     config_run_duration = 'fcLength'
     config_split_dynamics_transport = true
-    config_number_of_sub_steps = 4
+    config_number_of_sub_steps = 2
     config_dynamics_split_steps = 3
     config_h_mom_eddy_visc2 = 0.0
     config_h_mom_eddy_visc4 = 0.0

--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -22,7 +22,7 @@ benchmarkObservations = [
   # anchor
   'aircraft',
   'gnssrorefncep',
-  'gnssrobndropp1d',
+#  'gnssrobndropp1d',
   'satwind',
   'satwnd',
   'sfc',

--- a/scenarios/defaults/model.yaml
+++ b/scenarios/defaults/model.yaml
@@ -9,13 +9,13 @@ model:
     #  DiffusionLengthScale: float # only used for {{outerMesh}}
     30km:
       nCells: 655362
-      TimeStep: 240.0
+      TimeStep: 180.0
       DiffusionLengthScale: 30000.0
     60km:
       nCells: 163842
-      TimeStep: 480.0
+      TimeStep: 360.0
       DiffusionLengthScale: 60000.0
     120km:
       nCells: 40962
-      TimeStep: 900.0
+      TimeStep: 720.0
       DiffusionLengthScale: 120000.0


### PR DESCRIPTION
### Description
Low level T and Q degradation issues in 120km and 30km experiments are caused by the scale-aware new Tiedtke scheme merged on April 25 in the model repo. So we will use the model code version before that merge for the MPAS-JEDI 2.0 release, though we will still keep the code in the 'release-stable' branch as the scale-aware scheme may be beneficial for higher resolution, e.g., < 10km mesh. This PR includes:
1. change back time step from 8dx to 6dx and a line in namelist.atmosphere, though I see 8dx seems also work without the last change in model.
2.  Reset gnssrorefncep and gnssrobndropp1d yamls to use refractivity and bending angle from 0-30km.
3. Set use of gnssrorefncep as the default in the Workflow. We can evaluate the impact of using bending angle as part of sensitivity experiments.

### List of modified files
M       config/jedi/ObsPlugs/da/filters/gnssrobndropp1d.yaml
M       config/jedi/ObsPlugs/da/filters/gnssrorefncep.yaml
M       config/mpas/forecast/namelist.atmosphere
M       initialize/data/Observations.py
M       scenarios/defaults/model.yaml
