### PR TITLE
 Update the default settings

### DIFF
--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -80,7 +80,7 @@ class Observations(Component):
     'GDASObsErrtable': ['/glade/work/guerrett/pandac/fixed_input/GSI_errtables/HRRRENS_errtable_10sep2018.r3dv', str],
 
     ## CRTM
-    'CRTMTABLES': ['/glade/p/mmm/parc/liuz/pandac_common/crtm_coeffs_v2.4.1/', str],
+    'CRTMTABLES': ['/glade/p/mmm/parc/liuz/pandac_common/crtm_coeffs/', str],
 
     # static directories for bias correction files
     'fixedCoeff': ['/glade/p/mmm/parc/liuz/pandac_common/obs/satbias', str],

--- a/scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml
@@ -1,7 +1,7 @@
 observations:
   resource: PANDACArchiveForVarBC
 experiment:
-  suffix: '_VarBC_120km'
+  suffix: '_VarBC'
 members:
   n: 1
 model:

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -11,7 +11,7 @@ forecast:
       nodes: 8
       PEPerNode: 32
       baseSeconds: 60
-      secondsPerForecastHR: 150
+      secondsPerForecastHR: 80
 
 externalanalyses:
   resource: "GFS.PANDAC"
@@ -19,7 +19,7 @@ externalanalyses:
     GFS:
       PANDAC: # only available 20180418T00-20180524T00
         30km:
-          directory: "/glade/p/mmm/parc/guerrett/pandac/fixed_input/30km/GFSAnaAndDiagnostics"
+          directory: "/glade/p/mmm/parc/liuz/pandac_common/fixed_input/30km/GFSAnaAndDiagnostics"
 members:
   n: 1
 
@@ -49,11 +49,11 @@ variational:
           nodes: 6
           PEPerNode: 32
           memory: 109GB
-          baseSeconds: 700
-          secondsPerEnVarMember: 20
+          baseSeconds: 600
+          secondsPerEnVarMember: 8
 
 workflow:
   first cycle point: 20180414T18
-  #restart cycle point: 20180418T00
+  #restart cycle point: 20180415T00
   final cycle point: 20180415T06
   #final cycle point: 20180514T18

--- a/scenarios/defaults/forecast.yaml
+++ b/scenarios/defaults/forecast.yaml
@@ -8,7 +8,7 @@ forecast:
       secondsPerForecastHR: 500
 
       # cylc retry string
-      retry: '2*PT30S'
+      retry: '0*PT30S'
 
     #{{outerMesh}}:
     #  baseSeconds: int

--- a/scenarios/defaults/hofx.yaml
+++ b/scenarios/defaults/hofx.yaml
@@ -8,7 +8,7 @@ hofx:
       memory: 109GB
 
       # cylc retry string
-      retry: '2*PT30S'
+      retry: '0*PT30S'
 
     #{{outerMesh}}:
     #  seconds: int

--- a/scenarios/defaults/initic.yaml
+++ b/scenarios/defaults/initic.yaml
@@ -12,7 +12,7 @@ initic:
       PEPerNode: 36
 
       # cylc retry string
-      retry: '2*PT30S'
+      retry: '0*PT30S'
 
     30km:
       seconds: 320

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -144,7 +144,7 @@ variational:
       memory: 45GB
 
       # cylc retry string
-      retry: '2*PT30S'
+      retry: '0*PT30S'
 
     ## FORMAT
     #{{outerMesh}}:

--- a/scenarios/defaults/verifymodel.yaml
+++ b/scenarios/defaults/verifymodel.yaml
@@ -6,7 +6,7 @@ verifymodel:
       secondsPerMember: 500
 
       # cylc retry string
-      retry: '1*PT30S'
+      retry: '0*PT30S'
 
     #{{outerMesh}}:
     #  seconds: int

--- a/scenarios/defaults/verifyobs.yaml
+++ b/scenarios/defaults/verifyobs.yaml
@@ -2,7 +2,7 @@ verifyobs:
   # resource requirements
   job:
     # cylc retry string
-    retry: '1*PT30S'
+    retry: '0*PT30S'
 
     seconds: 1100
     secondsPerMember: 120


### PR DESCRIPTION
	modified:   initialize/data/Observations.py
	modified:   scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml
	modified:   scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
	modified:   scenarios/defaults/forecast.yaml
	modified:   scenarios/defaults/hofx.yaml
	modified:   scenarios/defaults/initic.yaml
	modified:   scenarios/defaults/variational.yaml
	modified:   scenarios/defaults/verifymodel.yaml
	modified:   scenarios/defaults/verifyobs.yaml

### Description
Use crtm_coeffs to be consistent with the original crtm version we have used. Turn off 'retry' for some tasks.