### PR TITLE
Update IASI setting and computing resource request

### DIFF
--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml
@@ -159,7 +159,7 @@
     minvalue: 1.0e-12
     action:
       name: reject
-  - filter: Gaussian_Thinning
-    horizontal_mesh: {{RADTHINDISTANCE}}
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_iasi_metop-a.nc4
+#  - filter: Gaussian_Thinning # input already thinned IASI data
+#    horizontal_mesh: {{RADTHINDISTANCE}}
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_iasi_metop-a.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml
@@ -159,7 +159,7 @@
     minvalue: 1.0e-12
     action:
       name: reject
-  - filter: Gaussian_Thinning
-    horizontal_mesh: {{RADTHINDISTANCE}}
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_iasi_metop-b.nc4
+#  - filter: Gaussian_Thinning # assimilate already thinned iasi data
+#    horizontal_mesh: {{RADTHINDISTANCE}}
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_iasi_metop-b.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-c.yaml
@@ -159,7 +159,7 @@
     minvalue: 1.0e-12
     action:
       name: reject
-  - filter: Gaussian_Thinning
-    horizontal_mesh: {{RADTHINDISTANCE}}
-  - filter: GOMsaver
-    filename: {{OutDBDir}}/{{geoPrefix}}_iasi_metop-c.nc4
+#  - filter: Gaussian_Thinning # assimilate already thinned iasi data
+#    horizontal_mesh: {{RADTHINDISTANCE}}
+#  - filter: GOMsaver
+#    filename: {{OutDBDir}}/{{geoPrefix}}_iasi_metop-c.nc4

--- a/scenarios/3denvar_OIE120km_WarmStart_VarBC_iasi.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart_VarBC_iasi.yaml
@@ -1,0 +1,46 @@
+observations:
+  resource: PANDACArchiveForVarBC
+experiment:
+  name: '3denvar-60-iter_O120km_VarBC_iasi'
+members:
+  n: 1
+model:
+  outerMesh: 120km
+  innerMesh: 120km
+  ensembleMesh: 120km
+firstbackground:
+  resource: "PANDAC.GFS"
+externalanalyses:
+  resource: "GFS.PANDAC"
+variational:
+  DAType: 3denvar
+  biasCorrection: True
+  ensemble:
+    forecasts:
+      resource: "PANDAC.GEFS"
+  observers: [
+    aircraft,
+    gnssrorefncep,
+    #gnssrobndropp1d,
+    satwind,
+    satwnd,
+    sfc,
+    sondes,
+    amsua_aqua,
+    amsua_metop-a,
+    amsua_metop-b,
+    amsua_n15,
+    amsua_n18,
+    amsua_n19,
+    mhs_metop-a,
+    mhs_metop-b,
+    mhs_n18,
+    mhs_n19,
+    iasi_metop-a,
+    iasi_metop-b,
+  ]
+workflow:
+  first cycle point: 20180424T06
+  #restart cycle point: 20180429T00
+  final cycle point: 20180424T18
+  #final cycle point: 20180514T18

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -9,7 +9,7 @@ forecast:
   job:
     30km:
       nodes: 8
-      PEPerNode: 32
+      PEPerNode: 36
       baseSeconds: 60
       secondsPerForecastHR: 80
 

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml
@@ -1,7 +1,7 @@
 # settings borrowed from /glade/work/liuz/pandac_hybrid/amsua_clrsky
 experiment:
-  #suffix: '_ensB-SE80+RTPP70_VarBC'
-  name: '3dhybrid_O30kmI60km_ensB_VarBC_iasi'
+  #suffix: '_ensB-SE80+RTPP70_VarBC_iasi'
+  name: '3dhybrid_60-60-iter_O30kmI60km_ensB-SE80+RTPP70_VarBC_iasi'
 
 firstbackground:
   resource: "PANDAC.GFS"
@@ -10,9 +10,9 @@ forecast:
   job:
     30km:
       nodes: 8
-      PEPerNode: 32
+      PEPerNode: 36
       baseSeconds: 60
-      secondsPerForecastHR: 150
+      secondsPerForecastHR: 80
 
 externalanalyses:
   resource: "GFS.PANDAC"
@@ -20,7 +20,7 @@ externalanalyses:
     GFS:
       PANDAC: # only available 20180418T00-20180524T00
         30km:
-          directory: "/glade/p/mmm/parc/guerrett/pandac/fixed_input/30km/GFSAnaAndDiagnostics"
+          directory: "/glade/p/mmm/parc/liuz/pandac_common/fixed_input/30km/GFSAnaAndDiagnostics"
 members:
   n: 1
 
@@ -40,7 +40,8 @@ variational:
   nInnerIterations: [60,60,]
   observers: [
     aircraft,
-    gnssrobndropp1d,
+    gnssrorefncep,
+    #gnssrobndropp1d,
     satwind,
     satwnd,
     sfc,
@@ -70,11 +71,11 @@ variational:
           nodes: 6
           PEPerNode: 32
           memory: 109GB
-          baseSeconds: 700
-          secondsPerEnVarMember: 20
+          baseSeconds: 600
+          secondsPerEnVarMember: 9
 
 workflow:
-  first cycle point: 20180414T18
-  #restart cycle point: 20180418T00
-  final cycle point: 20180415T06
+  first cycle point: 20180424T06
+  #restart cycle point: 20180424T18
+  final cycle point: 20180424T18
   #final cycle point: 20180514T18

--- a/scenarios/defaults/forecast.yaml
+++ b/scenarios/defaults/forecast.yaml
@@ -22,10 +22,10 @@ forecast:
       #baseSeconds: 60
       #secondsPerForecastHR: 120
       # more efficient
-      nodes: 4
+      nodes: 8
       PEPerNode: 36
       baseSeconds: 60
-      secondsPerForecastHR: 150
+      secondsPerForecastHR: 120
     60km:
       # faster turnaround
       #nodes: 4
@@ -33,12 +33,12 @@ forecast:
       #baseSeconds: 60
       #secondsPerForecastHR: 40
       # more efficient
-      nodes: 2
+      nodes: 4
       PEPerNode: 36
       baseSeconds: 60
-      secondsPerForecastHR: 40
+      secondsPerForecastHR: 70
     120km:
       nodes: 4
-      PEPerNode: 32
+      PEPerNode: 36
       baseSeconds: 60
-      secondsPerForecastHR: 60
+      secondsPerForecastHR: 20


### PR DESCRIPTION
### Description
1. Turn off ydiag output and thinning of IASI, as we assimilate pre-thinned IASI data.
2. Always use all 36 cores per node for the forecast tasks, instead of 32 cores.
3. Add a scenario for 120km 3DEnVar with IASI.
4. Begin IASI cycling experiment from 2018042412, using the first cycling background at 2018042406 from the new benchmark experiment, which is copied to ~panda_common directory for 120km and 30km.

### List of modified files
M       config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml
M       config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-c.yaml
A       scenarios/3denvar_OIE120km_WarmStart_VarBC_iasi.yaml
M       scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
M       scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml
M       scenarios/defaults/forecast.yaml
