### PR TITLE
Add a placeholder for extended forecast setting

### DIFF
--- a/env-setup/cheyenne.csh
+++ b/env-setup/cheyenne.csh
@@ -1,9 +1,9 @@
 #!/bin/tcsh -f
 
 # Use deactivate to remove NPL from environment if it is activated
-which deactivate >& /dev/null
+which conda >& /dev/null
 if ($? == 0) then
-  deactivate
+  conda deactivate
 endif
 
 source /etc/profile.d/modules.csh

--- a/env-setup/cheyenne.sh
+++ b/env-setup/cheyenne.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -f
 
 # Use deactivate to remove NPL from environment if it is activated
-type deactivate >& /dev/null
+type conda >& /dev/null
 if [ $? -eq 0 ]; then
-  deactivate
+  conda deactivate
 fi
 
 source /etc/profile.d/modules.sh

--- a/scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml
@@ -18,8 +18,22 @@ variational:
   ensemble:
     forecasts:
       resource: "PANDAC.GEFS"
+  #execute: False # the default is True
+  #post: [] # this turns off verifyobs
+forecast:
+  #execute: False # the default is True
+  #post: [] # use this when doing extended forecast
+  post: [verifymodel] # this turns off verifyobs
+#extendedforecast:
+#  meanTimes: T00 # T00, T12
+#  lengthHR: 120
+#  outIntervalHR: 24
+#  execute: True # this is the default setting
+#  post: [verifymodel,verifyobs] # can be replaced by [verifyobs,verifymodel]
 workflow:
   first cycle point: 20180414T18
   #restart cycle point: 20180418T00
   final cycle point: 20180415T06
   #final cycle point: 20180514T18
+  #CyclingWindowHR: 24 # default is 6 for cycling DA
+  #max active cycle points: 4 # used for independent 'extendedforecast'

--- a/scenarios/3denvar_OIE120km_WarmStart_VarBC_iasi.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart_VarBC_iasi.yaml
@@ -39,8 +39,22 @@ variational:
     iasi_metop-a,
     iasi_metop-b,
   ]
+  #execute: False # the default is True
+  #post: [] # this turns off verifyobs
+forecast:
+  #execute: False # the default is True
+  #post: [] # use this when doing extended forecast
+  post: [verifymodel] # this turns off verifyobs
+#extendedforecast:
+#  meanTimes: T00 # T00, T12
+#  lengthHR: 120
+#  outIntervalHR: 24
+#  execute: True # this is the default setting
+#  post: [verifymodel,verifyobs] # can be replaced by [verifyobs,verifymodel]
 workflow:
   first cycle point: 20180424T06
   #restart cycle point: 20180429T00
   final cycle point: 20180424T18
   #final cycle point: 20180514T18
+  #CyclingWindowHR: 24 # default is 6 for cycling DA
+  #max active cycle points: 4 # used for independent 'extendedforecast'

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -13,6 +13,10 @@ forecast:
       baseSeconds: 60
       secondsPerForecastHR: 80
 
+  #execute: False # the default is True
+  #post: [] # use this when doing extended forecast
+  post: [verifymodel] # this turns off verifyobs
+
 externalanalyses:
   resource: "GFS.PANDAC"
   resources:
@@ -52,8 +56,13 @@ variational:
           baseSeconds: 600
           secondsPerEnVarMember: 8
 
+  #execute: False # the default is True
+  #post: [] # this turns off verifyobs
+
 workflow:
   first cycle point: 20180414T18
   #restart cycle point: 20180415T00
   final cycle point: 20180415T06
   #final cycle point: 20180514T18
+  #CyclingWindowHR: 24 # default is 6 for cycling DA
+  #max active cycle points: 4 # used for independent 'extendedforecast'

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml
@@ -14,6 +14,10 @@ forecast:
       baseSeconds: 60
       secondsPerForecastHR: 80
 
+  #execute: False # the default is True
+  #post: [] # use this when doing extended forecast
+  post: [verifymodel] # this turns off verifyobs
+
 externalanalyses:
   resource: "GFS.PANDAC"
   resources:
@@ -74,8 +78,13 @@ variational:
           baseSeconds: 600
           secondsPerEnVarMember: 9
 
+  #execute: False # the default is True
+  #post: [] # this turns off verifyobs
+
 workflow:
   first cycle point: 20180424T06
   #restart cycle point: 20180424T18
   final cycle point: 20180424T18
   #final cycle point: 20180514T18
+  #CyclingWindowHR: 24 # default is 6 for cycling DA
+  #max active cycle points: 4 # used for independent 'extendedforecast'


### PR DESCRIPTION
### Description
1. Use 'conda deactivate' in cheyenne.csh/sh
2. Turn off observation space verification for cycling forecasts.
3. Add yaml setting placeholder in 4 scenarios for extended forecast and verification.

Warning: do NOT use Workflow for the extended forecasts yet, because 'sfc_surface' file is not properly linked. See issue #222 .

### List of modified files
M       env-setup/cheyenne.csh
M       env-setup/cheyenne.sh
M       scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml
M       scenarios/3denvar_OIE120km_WarmStart_VarBC_iasi.yaml
M       scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
M       scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml

### Tests completed
Played with 120km extended forecast