### PR TITLE
Allow surface update for extended forecast

### DIFF
--- a/initialize/applications/ExtendedForecast.py
+++ b/initialize/applications/ExtendedForecast.py
@@ -170,7 +170,7 @@ class ExtendedForecast(Component):
       self.fc.mesh.name,
       True,
       False,
-      False,
+      True,
       self.workDir+'/{{thisCycleDate}}/mean',
       meanInternalAnaIC.directory(),
       meanInternalAnaIC.prefix(),


### PR DESCRIPTION
### Description
This PR change the default option for `updateSea` in the arguments for the execution of the extended forecast to `True`, ensuring that we always update the sea surface temperature and xice fields.

### Issue closed

Closes https://github.com/NCAR/MPAS-Workflow/issues/222

### Tests completed
 - [x] 3denvar_OIE120km_WarmStart
 - [x] 3denvar_O30kmIE60km_WarmStart
*Ran these tests once to create the analysis and a second time with yaml snippets for `extendedforecast` to run the forecast up to the specified forecast length.

List of modified files:
M       initialize/applications/ExtendedForecast.py