### PR TITLE
Add QC filter to simulate IR channels only over water and change the graphics default folder

### DIFF
--- a/config/jedi/ObsPlugs/hofx/filters/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/abi_g16.yaml
@@ -7,7 +7,7 @@
   - filter: Domain Check
     filter variables:
     - name: brightnessTemperature
-      channels: 7,11-16
+      channels: 7,11,13-16
     where:
     - variable:
         name: water_area_fraction@GeoVaLs

--- a/config/jedi/ObsPlugs/hofx/filters/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/abi_g16.yaml
@@ -4,6 +4,15 @@
     - variable:
         name: MetaData/sensorZenithAngle
       maxvalue: 65.0
+  - filter: Domain Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: 7,11-16
+    where:
+    - variable:
+        name: water_area_fraction@GeoVaLs
+      minvalue: 1.0
+    <<: *multiIterationFilter
   - filter: Perform Action
     filter variables:
     - name: brightnessTemperature

--- a/config/jedi/ObsPlugs/hofx/filters/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/ahi_himawari8.yaml
@@ -7,7 +7,7 @@
   - filter: Domain Check
     filter variables:
     - name: brightnessTemperature
-      channels: 7,11-16
+      channels: 7,11,13-16
     where:
     - variable:
         name: water_area_fraction@GeoVaLs

--- a/config/jedi/ObsPlugs/hofx/filters/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/ahi_himawari8.yaml
@@ -4,6 +4,15 @@
     - variable:
         name: MetaData/sensorZenithAngle
       maxvalue: 65.0
+  - filter: Domain Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: 7,11-16
+    where:
+    - variable:
+        name: water_area_fraction@GeoVaLs
+      minvalue: 1.0
+    <<: *multiIterationFilter
   - filter: Perform Action
     filter variables:
     - name: brightnessTemperature

--- a/initialize/post/VerifyModel.py
+++ b/initialize/post/VerifyModel.py
@@ -25,7 +25,7 @@ class VerifyModel(Component):
   workDir = 'Verification'
   diagnosticsDir = 'diagnostic_stats/model'
   variablesWithDefaults = {
-    'script directory': ['/glade/work/guerrett/pandac/fixed_input/graphics_10APR2023', str],
+    'script directory': ['/glade/work/ivette/pandac/graphics/graphics_7SEPT2023', str],
   }
 
   def __init__(self,

--- a/initialize/post/VerifyObs.py
+++ b/initialize/post/VerifyObs.py
@@ -26,7 +26,7 @@ class VerifyObs(Component):
   workDir = 'Verification'
   diagnosticsDir = 'diagnostic_stats/obs'
   variablesWithDefaults = {
-    'script directory': ['/glade/work/guerrett/pandac/fixed_input/graphics_10APR2023', str],
+    'script directory': ['/glade/work/ivette/pandac/graphics/graphics_7SEPT2023', str],
   }
 
   def __init__(self,

--- a/scenarios/defaults/observations.yaml
+++ b/scenarios/defaults/observations.yaml
@@ -134,7 +134,7 @@ observations:
 
           ## abi
           abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
 
           ## ahi
           ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
@@ -180,7 +180,7 @@ observations:
 
           ## abi
           abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
 
           ## ahi
           ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
@@ -274,7 +274,7 @@ observations:
 
           ## abi
           abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
 
           ## ahi
           ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
@@ -321,7 +321,7 @@ observations:
 
           ## abi
           abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_const-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPERO15X15_const-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_const-bias-correct
 
           ## ahi
           ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_const-bias-correct
@@ -379,14 +379,14 @@ observations:
         da:
           common: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/GenerateObs/Observations
           abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
           ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
           ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
 
         hofx:
           common: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/GenerateObs/Observations
           abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
           ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
           ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
 

--- a/scenarios/defaults/observations.yaml
+++ b/scenarios/defaults/observations.yaml
@@ -320,12 +320,12 @@ observations:
           mhs_n19: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/bias_corr
 
           ## abi
-          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_const-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_const-bias-correct
+          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
 
           ## ahi
-          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_const-bias-correct
-          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_const-bias-correct
+          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
+          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
 
           ## iasi
           iasi_metop-a: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/iasi_thin145km


### PR DESCRIPTION
### Description
This PR adds a domain check filter to calculate hofx only over water for ABI and AHI infrared channels.
Also, the typo in abi-clr_g16 observations path is fixed and the default folder for the graphics is changed to include the most recent changes to do binning for all-sky ABI/AHI. All ABI/AHI data input directories are changed to no-bias-correct ones.

### Issue closed
Closes #252 

### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs

#### Tier 3:
- [x]  3dvar_OIE120km_WarmStart.yaml with `verifyobs` on in the forecast section