### PR TITLE
Correct channels used in amua-cld_*.yaml

### DIFF
--- a/config/jedi/ObsPlugs/da/base/amsua-cld_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_aqua.yaml
@@ -12,7 +12,7 @@
     obsdatain: *{{ObsDataIn}}
     {{ObsDataOut}}
     simulated variables: [brightnessTemperature]
-    channels: &amsua-cld_aqua_channels 1-5,15
+    channels: &amsua-cld_aqua_channels 3,15
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc
   obs operator:

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_metop-a.yaml
@@ -12,7 +12,7 @@
     obsdatain: *{{ObsDataIn}}
     {{ObsDataOut}}
     simulated variables: [brightnessTemperature]
-    channels: &amsua-cld_metop-a_channels 1-5,15
+    channels: &amsua-cld_metop-a_channels 1-4,15
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc
   obs operator:

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_metop-b.yaml
@@ -12,7 +12,7 @@
     obsdatain: *{{ObsDataIn}}
     {{ObsDataOut}}
     simulated variables: [brightnessTemperature]
-    channels: &amsua-cld_metop-b_channels 1-5,15
+    channels: &amsua-cld_metop-b_channels 1-4
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc
   obs operator:

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_n15.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_n15.yaml
@@ -12,7 +12,7 @@
     obsdatain: *{{ObsDataIn}}
     {{ObsDataOut}}
     simulated variables: [brightnessTemperature]
-    channels: &amsua-cld_n15_channels 1-5,15
+    channels: &amsua-cld_n15_channels 1-4,15
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc
   obs operator:

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_n18.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_n18.yaml
@@ -12,7 +12,7 @@
     obsdatain: *{{ObsDataIn}}
     {{ObsDataOut}}
     simulated variables: [brightnessTemperature]
-    channels: &amsua-cld_n18_channels 1-5,15
+    channels: &amsua-cld_n18_channels 1-4,15
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc
   obs operator:

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_n19.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_n19.yaml
@@ -12,7 +12,7 @@
     obsdatain: *{{ObsDataIn}}
     {{ObsDataOut}}
     simulated variables: [brightnessTemperature]
-    channels: &amsua-cld_n19_channels 1-5,15
+    channels: &amsua-cld_n19_channels 1-4,15
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc
   obs operator:


### PR DESCRIPTION
### Description
Correct channels used in amua-cld_*.yaml 
Note: For amsua-metop_b, ch15 is all missing values. For amsua-aqua, ch1,ch2, and ch4 are all missing values. So far, we do not use "amsua-aqua" for cloudy-sky assimilation.

###Files modified:
M       config/jedi/ObsPlugs/da/base/amsua-cld_aqua.yaml
M       config/jedi/ObsPlugs/da/base/amsua-cld_metop-a.yaml
M       config/jedi/ObsPlugs/da/base/amsua-cld_metop-b.yaml
M       config/jedi/ObsPlugs/da/base/amsua-cld_n15.yaml
M       config/jedi/ObsPlugs/da/base/amsua-cld_n18.yaml
M       config/jedi/ObsPlugs/da/base/amsua-cld_n19.yaml

### Issue closed
Closes https://github.com/NCAR/MPAS-Workflow/issues/254

### Tests completed
Tested by using allsky AMSUA cycling experiment