### PR TITLE
Read hybrid weights directly from file

### DIFF
--- a/bin/InitVariationals.csh
+++ b/bin/InitVariationals.csh
@@ -171,10 +171,13 @@ if ( "$DAType" == "3dhybrid" ) then
   sed -i 's@{{ensembleCovarianceWeight}}@'${ensembleCovarianceWeight}'@' $prevYAML
 endif
 
+if ( "$DAType" == "3dhybrid-allsky" ) then
+  sed -i 's@{{hybridCoefficientsDir}}@'${hybridCoefficientsDir}'@' $prevYAML
+endif
 
 # Static Jb term
 # ==============
-if ( "$DAType" == "3dvar" || "$DAType" == "3dhybrid" ) then
+if ( "$DAType" == "3dvar" || "$DAType" =~ *"3dhybrid"* ) then
   # bumpCovControlVariables
   set Variables = ($bumpCovControlVariables)
 #TODO: turn on hydrometeors in static B when applicable by uncommenting below
@@ -201,17 +204,17 @@ if ( "$DAType" == "3dvar" || "$DAType" == "3dhybrid" ) then
   sed -i 's@{{bumpCovStdDevFile}}@'${bumpCovStdDevFile}'@' $prevYAML
   sed -i 's@{{bumpCovVBalPrefix}}@'${bumpCovVBalPrefix}'@' $prevYAML
   sed -i 's@{{bumpCovVBalDir}}@'${bumpCovVBalDir}'@' $prevYAML
-endif # 3dvar || 3dhybrid
+endif # 3dvar || *"3dhybrid"*
 
 
 # Ensemble Jb term
 # ================
 
-if ( "$DAType" == "3denvar" || "$DAType" == "3dhybrid" ) then
+if ( "$DAType" == "3denvar" || "$DAType" =~ *"3dhybrid"* ) then
   ## yaml indentation
   if ( "$DAType" == "3denvar" ) then
     set nEnsPbIndent = 4
-  else if ( "$DAType" == "3dhybrid" ) then
+  else if ( "$DAType" =~ *"3dhybrid"* ) then
     set nEnsPbIndent = 8
   endif
   set indentPb = "`${nSpaces} $nEnsPbIndent`"
@@ -282,7 +285,7 @@ end
 # Ensemble Jb term (member dependent)
 # ===================================
 
-if ( "$DAType" == "3denvar" || "$DAType" == "3dhybrid" ) then
+if ( "$DAType" == "3denvar" || "$DAType" =~ *"3dhybrid"* ) then
   ## members
   # + pure envar: 'background error.members from template'
   # + hybrid envar: 'background error.components[iEnsemble].covariance.members from template'

--- a/config/jedi/applications/3dhybrid-allsky.yaml
+++ b/config/jedi/applications/3dhybrid-allsky.yaml
@@ -1,0 +1,118 @@
+# ObsAnchors and ObsErrorAnchors are automatically prepended above this line
+_iteration: &iterationConfig
+  geometry:
+    nml_file: {{InnerNamelistFile}}
+    streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
+    deallocate non-da fields: true
+    interpolation type: unstructured
+  gradient norm reduction: 1e-3
+  #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
+#  online diagnostics:
+#    tlm taylor test: true
+#    tlm approx test: true
+#    adj tlm test: true
+#    adj obs test: true
+#    online adj test: true
+_member: &memberConfig
+  date: &analysisDate {{thisISO8601Date}}
+  state variables: &incvars [{{AnalysisVariables}}]
+  stream name: ensemble
+output:
+  filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
+  stream name: analysis
+variational:
+  minimizer:
+{{VariationalMinimizer}}
+  iterations:
+{{VariationalIterations}}
+final:
+  diagnostics:
+    departures: oman
+cost function:
+  cost type: 3D-Var
+  window begin: {{windowBegin}}
+  window length: {{windowLength}}
+  jb evaluation: false
+  geometry:
+    nml_file: {{OuterNamelistFile}}
+    streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
+    deallocate non-da fields: true
+    interpolation type: unstructured
+  analysis variables: *incvars
+  background:
+    state variables: [{{StateVariables}}]
+    filename: {{bgStateDir}}{{MemberDir}}/{{bgStatePrefix}}.{{thisMPASFileDate}}.nc
+    date: *analysisDate
+  background error:
+    covariance model: hybrid
+    components:
+    - weight:
+        date: *analysisDate
+        stream name: control
+        filename: {{hybridCoefficientsDir}}/mpas.hyb_coef_sta2.2018-04-15_00.00.00.nc
+      covariance:
+        covariance model: SABER
+        saber central block:
+          saber block name: BUMP_NICAS
+          active variables: &ctlvars [{{bumpCovControlVariables}}]
+          read:
+            io:
+              data directory: {{bumpCovDir}}
+              files prefix: {{bumpCovPrefix}}
+            drivers:
+              multivariate strategy: univariate
+              read local nicas: true
+        saber outer blocks:
+        - saber block name: StdDev
+          read:
+            model file:
+              filename: {{bumpCovStdDevFile}}
+              date: *analysisDate
+              stream name: control
+        - saber block name: BUMP_VerticalBalance
+          read:
+            io:
+              data directory: {{bumpCovVBalDir}}
+              files prefix: {{bumpCovVBalPrefix}}
+            drivers:
+              read local sampling: true
+              read vertical balance: true
+            vertical balance:
+              vbal:
+              - balanced variable: velocity_potential
+                unbalanced variable: stream_function
+                diagonal regression: true
+              - balanced variable: temperature
+                unbalanced variable: stream_function
+              - balanced variable: surface_pressure
+                unbalanced variable: stream_function
+        linear variable change:
+          linear variable change name: Control2Analysis
+          input variables: *ctlvars
+          output variables: *incvars
+    - weight:
+        date: *analysisDate
+        stream name: control
+        filename: {{hybridCoefficientsDir}}/mpas.hyb_coef_ens2.2018-04-15_00.00.00.nc
+      covariance:
+        covariance model: ensemble
+        localization:
+          localization method: SABER
+          saber central block:
+            saber block name: BUMP_NICAS
+            active variables: *incvars
+            read:
+              io:
+                data directory: {{bumpLocDir}}
+                files prefix: {{bumpLocPrefix}}
+              drivers:
+                multivariate strategy: duplicated
+                read local nicas: true
+              model:
+                level for 2d variables: last
+{{EnsemblePbMembers}}
+{{EnsemblePbInflation}}
+  observations:
+    obs perturbations: {{ObsPerturbations}}
+    observers:
+{{Observers}}

--- a/initialize/applications/Variational.py
+++ b/initialize/applications/Variational.py
@@ -30,7 +30,7 @@ class Variational(Component):
 
   requiredVariables = {
     ## DAType [Required Parameter]
-    'DAType': [str, ['3dvar', '3denvar', '3dhybrid']],
+    'DAType': [str, ['3dvar', '3denvar', '3dhybrid', '3dhybrid-allsky']],
   }
 
   optionalVariables = {
@@ -196,7 +196,7 @@ class Variational(Component):
       self._set('MinimizerAlgorithm', 'DRPLanczos')
 
     # ensemble
-    if DAType == '3denvar' or DAType == '3dhybrid':
+    if DAType == '3denvar' or '3dhybrid' in DAType:
       # localization
       r1 = 'ensemble.localization'
       r2 = meshes['Ensemble'].name
@@ -247,7 +247,7 @@ class Variational(Component):
     self._set('ensPbNMembers', ensPbNMembers)
 
     # covariance
-    if DAType == '3dvar' or DAType == '3dhybrid':
+    if DAType == '3dvar' or '3dhybrid' in DAType:
       r = meshes['Inner'].name
       self._setOrDie('covariance.bumpCovControlVariables', list, None, 'bumpCovControlVariables')
       self._setOrDie('covariance.bumpCovPrefix', str, None, 'bumpCovPrefix')
@@ -255,6 +255,7 @@ class Variational(Component):
       self._setOrDie('.'.join(['covariance', r, 'bumpCovDir']), str, None, 'bumpCovDir')
       self._setOrDie('.'.join(['covariance', r, 'bumpCovStdDevFile']), str, None, 'bumpCovStdDevFile')
       self._setOrDie('.'.join(['covariance', r, 'bumpCovVBalDir']), str, None, 'bumpCovVBalDir')
+      self._setOrDie('.'.join(['covariance', r, 'hybridCoefficientsDir']), str, None, 'hybridCoefficientsDir')
 
     self._cshVars = list(self._vtable.keys())
 

--- a/scenarios/3dhybrid-allsky_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid-allsky_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -1,0 +1,66 @@
+# settings borrowed from /glade/work/liuz/pandac_hybrid/amsua_clrsky
+experiment:
+  suffix: '_ensB-SE80+RTPP70_VarBC'
+
+firstbackground:
+  resource: "PANDAC.GFS"
+
+forecast:
+  job:
+    30km:
+      nodes: 8
+      PEPerNode: 36
+      baseSeconds: 60
+      secondsPerForecastHR: 80
+
+  #execute: False # the default is True
+  #post: [] # use this when doing extended forecast
+  post: [verifymodel] # this turns off verifyobs
+
+externalanalyses:
+  resource: "GFS.PANDAC"
+  resources:
+    GFS:
+      PANDAC: # only available 20180418T00-20180524T00
+        30km:
+          directory: "/glade/p/mmm/parc/liuz/pandac_common/fixed_input/30km/GFSAnaAndDiagnostics"
+members:
+  n: 1
+
+model:
+  outerMesh: 30km
+  innerMesh: 60km
+  ensembleMesh: 60km
+
+observations:
+  resource: PANDACArchiveForVarBC
+
+variational:
+  DAType: 3dhybrid-allsky
+  biasCorrection: True
+  nInnerIterations: [60,60,]
+  ensemble:
+    forecasts:
+      resource: "PANDAC.EDA"
+
+  # resource requirements
+  job:
+    30km:
+      60km:
+        3dhybrid:
+          nodes: 6
+          PEPerNode: 32
+          memory: 109GB
+          baseSeconds: 600
+          secondsPerEnVarMember: 8
+
+  #execute: False # the default is True
+  #post: [] # this turns off verifyobs
+
+workflow:
+  first cycle point: 20180414T18
+  #restart cycle point: 20180415T00
+  final cycle point: 20180415T06
+  #final cycle point: 20180514T18
+  #CyclingWindowHR: 24 # default is 6 for cycling DA
+  #max active cycle points: 4 # used for independent 'extendedforecast'

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble.yaml
@@ -21,23 +21,21 @@ observations:
     PANDACArchive:
       IODADirectory:
         da:
-          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
-          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
-          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
+          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
         hofx:
-          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/ioda-v3/IODANC_THIN15KM_SUPERO15X15_no-bias-correct
-          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
-          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/ioda-v3/IODANC_SUPEROB15X15_no-bias-correct
+          abi_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          abi-clr_g16: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          ahi_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          ahi-clr_himawari8: /glade/p/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
       IODASuperObGrid:
         abi_g16: 15X15
         ahi_himawari8: 15X15
 
 variational:
-  DAType: 3dhybrid
-  ensembleCovarianceWeight: 0.75
-  staticCovarianceWeight: 0.25
+  DAType: 3dhybrid-allsky
   nInnerIterations: [60,60,]
   ensemble:
     forecasts:

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble.yaml
@@ -35,7 +35,9 @@ observations:
         ahi_himawari8: 15X15
 
 variational:
-  DAType: 3dhybrid-allsky
+  DAType: 3dhybrid
+  ensembleCovarianceWeight: 0.75
+  staticCovarianceWeight: 0.25
   nInnerIterations: [60,60,]
   ensemble:
     forecasts:

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -121,18 +121,22 @@ variational:
     #  bumpCovDir: str
     #  bumpCovStdDevFile: str
     #  bumpCovVBalDir: str
+    #  hybridCoefficientsDir: str
     30km:
       bumpCovDir: None
       bumpCovStdDevFile: None
       bumpCovVBalDir: None
+      hybridCoefficientsDir: None
     60km:
       bumpCovDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/60km.NICAS_00
       bumpCovStdDevFile: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
       bumpCovVBalDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/60km.VBAL_00
+      hybridCoefficientsDir: /glade/p/mmm/parc/liuz/pandac_hybrid/60km.allsky_hybrid
     120km:
       bumpCovDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.NICAS_00
       bumpCovStdDevFile: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
       bumpCovVBalDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.VBAL_00
+      hybridCoefficientsDir: None
 
   # resource requirements
   job:
@@ -197,6 +201,12 @@ variational:
           memory: 45GB
           baseSeconds: 500
           secondsPerEnVarMember: 9
+        3dhybrid-allsky:
+          nodes: 6
+          PEPerNode: 32
+          memory: 45GB
+          baseSeconds: 500
+          secondsPerEnVarMember: 9
         3dvar:
           nodes: 6
           PEPerNode: 32
@@ -218,6 +228,12 @@ variational:
           ##baseSeconds: 200
           ##secondsPerEnVarMember: 6
         3dhybrid:
+          nodes: 4
+          PEPerNode: 36
+          memory: 45GB
+          baseSeconds: 250
+          secondsPerEnVarMember: 6
+        3dhybrid-allsky:
           nodes: 4
           PEPerNode: 36
           memory: 45GB

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -136,7 +136,7 @@ variational:
       bumpCovDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.NICAS_00
       bumpCovStdDevFile: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
       bumpCovVBalDir: /glade/p/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.VBAL_00
-      hybridCoefficientsDir: None
+      hybridCoefficientsDir: /glade/p/mmm/parc/liuz/pandac_hybrid/120km.allsky_hybrid
 
   # resource requirements
   job:


### PR DESCRIPTION
### Description
This PR adds the capability to read the background error covariance weights for the 3dhybrid application from specific pre-weighted files. For this, I added a new application yaml, keeping the previous one for clear-sky runs, and also a scenario to specifically run 3dhybrid experiments with all-sky.

### Issue closed
Closes https://github.com/NCAR/MPAS-Workflow/issues/259

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs

#### Tier 3 (optional):
- [x] 3dhybrid-allsky_O30kmIE60km_SpecifiedEnsemble_VarBC