### PR TITLE
Fix the cylc workflow cleanup to use the Cylc8 "cylc clean" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ It is required to set the content of $HOME/.cylc/flow/global.cylc as follows:
 ```
 The [[pbs_cluster]] entries tell cylc how to submit jobs.
 The [instal] section will create both $HOME/cylc-run/MPAS-Workflow and 
-/glade/derecho/scratch/$USER/cylc-run/MPAS-Workflow directories to be created.
+/glade/derecho/scratch/$USER/cylc-run/MPAS-Workflow directories.
 A symlink will be created in $HOME/cylc-run/MPAS-Workflow for each workflow,
 which will point to a directory in the run/cylc-run/MPAS-Workflow where the actual data will be written.
+When setting up symlinks, ensure the run/cylc-run/MPAS-Workflow directory is empty.
 
 Build
 -----

--- a/submit.csh
+++ b/submit.csh
@@ -45,7 +45,6 @@ else
 endif
 
 echo $0 cylc version: `cylc --version`
-date
 
 echo "$0 (INFO): checking if a suite with the same name is already running"
 
@@ -61,8 +60,6 @@ if ( "$NCARHOST" == "derecho" ) then
     echo "$0 (INFO): confirmed that a cylc suite named $SuiteName is not already running"
     echo "$0 (INFO): starting a new suite..."
   endif
-  echo $0 cylc scan -t rich
-  cylc scan -t rich
 else if ( "$NCARHOST" == "cheyenne" ) then
   echo $0 cylc poll $SuiteName 
   cylc poll $SuiteName 
@@ -84,8 +81,8 @@ rm -rf ${cylcWorkDir}/${SuiteName}
 
 if ( "$NCARHOST" == "derecho" ) then
   if ( -e ~/cylc-run/${workflow_dir}/${SuiteName} ) then
-    echo $0 rm -r ~/cylc-run/${workflow_dir}/${SuiteName}
-    rm -r ~/cylc-run/${workflow_dir}/${SuiteName}
+    echo $0 cylc clean ${workflow_dir}/${SuiteName}
+    cylc clean ${workflow_dir}/${SuiteName}
   #  echo "Already has this suite, replay it"
   endif
   echo $0 cylc install --run-name=${SuiteName}


### PR DESCRIPTION
### Description
 * use `cylc clean` when cleaning up before running a new workflow.
     - this is required if using symlinks to put cylc-run data somewhere other than $HOME.
 * update the README w/ additional iniitalizing step when first using symlinks for cylc run data.

### Issue closed
   Fixes Issue [270](https://github.com/NCAR/MPAS-Workflow/issues/270).

 Changes to be committed:
	modified:   README.md
	modified:   submit.csh)

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
