### PR TITLE
Bump files and node settings for Derecho.

### DIFF
--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -122,7 +122,7 @@ variational:
         bumpLocDir: /glade/campaign/mmm/parc/liuz/pandac_common/fixed_input/30km/bumploc/h=1200.0km_v=6.0km_06JAN2023code
       60km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/60km.bumploc.duplicated.limited.1200km6km
+        bumpLocDir: /glade/derecho/scratch/nystrom/pandac/60km.bumploc.duplicated.limited_derecho
       120km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
         bumpLocDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.bumploc.duplicated.limited.1200km6km
@@ -148,10 +148,10 @@ variational:
       bumpCovVBalDir: None
       hybridCoefficientsDir: None
     60km:
-      bumpCovDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/60km.NICAS_00
-      bumpCovStdDevFile: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/60km.VBAL_00
-      hybridCoefficientsDir: /glade/campaign/mmm/parc/liuz/pandac_hybrid/60km.allsky_hybrid
+      hybridCoefficientsDir: /glade/p/mmm/parc/liuz/pandac_hybrid/60km.allsky_hybrid
+      bumpCovDir: /glade/derecho/scratch/bjung/pandac/20230923_release_v2.0.0_derecho/60km.NICAS_00global
+      bumpCovStdDevFile: /glade/derecho/scratch/bjung/pandac/20230923_release_v2.0.0_derecho/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/derecho/scratch/bjung/pandac/20230923_release_v2.0.0_derecho/60km.VBAL_00
     120km:
       bumpCovDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.NICAS_00
       bumpCovStdDevFile: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
@@ -163,9 +163,9 @@ variational:
     defaults:
       baseSeconds: 1500
       secondsPerEnVarMember: 10
-      nodes: 8
-      PEPerNode: 16
-      memory: 45GB
+      nodes: 2
+      PEPerNode: 128
+      memory: 235GB
 
       # cylc retry string
       retry: '0*PT30S'
@@ -191,50 +191,50 @@ variational:
       # Assuming 120 total inner iterations
       30km:
         3denvar:
-          nodes: 64
-          PEPerNode: 8
-          memory: 45GB
+          nodes: 4
+          PEPerNode: 128
+          memory: 235GB
         4denvar:
-          nodes: 448
-          PEPerNode: 8
-          memory: 45GB
+          nodes: 28
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 1500
           secondsPerEnVarMember: 5
         3dvar:
-          nodes: 64
-          PEPerNode: 8
-          memory: 45GB
+          nodes: 4
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 1500
         ensemble: # i.e., EDASize > 1, multiple background members treated per executable
           3denvar:
             nodesPerMember: 3
-            PEPerNode: 12
-            memory: 45GB
+            PEPerNode: 128
+            memory: 235GB
             baseSeconds: 1200
             secondsPerEnVarMember: 10
       60km:
         3denvar:
-          nodes: 6
-          PEPerNode: 32
-          memory: 45GB
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 400
           secondsPerEnVarMember: 9
         4denvar:
-          nodes: 42
-          PEPerNode: 32
-          memory: 45GB
+          nodes: 14
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 800
           secondsPerEnVarMember: 24
         3dhybrid:
-          nodes: 6
-          PEPerNode: 32
-          memory: 45GB
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 500
           secondsPerEnVarMember: 9
         3dhybrid-allsky:
-          nodes: 6
-          PEPerNode: 32
-          memory: 45GB
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 500
           secondsPerEnVarMember: 9
         3dvar:
@@ -246,9 +246,9 @@ variational:
       # Assuming 60 total inner iterations
       60km:
         3denvar:
-          nodes: 4
-          PEPerNode: 36
-          memory: 45GB
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 200
           secondsPerEnVarMember: 6
           # double-precision bundle build
@@ -258,59 +258,59 @@ variational:
           ##baseSeconds: 200
           ##secondsPerEnVarMember: 6
         4denvar:
-          nodes: 28 #7 subwindow slots
-          PEPerNode: 36
-          memory: 45GB
+          nodes: 14 #7 subwindow slots
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 600
           secondsPerEnVarMember: 10
         3dhybrid:
-          nodes: 4
-          PEPerNode: 36
-          memory: 45GB
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 250
           secondsPerEnVarMember: 6
         3dhybrid-allsky:
-          nodes: 4
-          PEPerNode: 36
-          memory: 45GB
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 250
           secondsPerEnVarMember: 6
         3dvar:
-          nodes: 6
-          PEPerNode: 32
-          memory: 45GB
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 250
         ensemble:
           3denvar:
-            nodesPerMember: 3
-            PEPerNode: 12
-            memory: 45GB
+            nodesPerMember: 2
+            PEPerNode: 128
+            memory: 235GB
             baseSeconds: 1200
             secondsPerEnVarMember: 10
     120km:
       # Assuming 60 total inner iterations
       120km:
         3denvar:
-          nodes: 4
-          PEPerNode: 32
-          memory: 45GB
+          nodes: 1
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 200
           secondsPerEnVarMember: 15
         3dvar:
-          nodes: 4
-          PEPerNode: 32
-          memory: 45GB
+          nodes: 1
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 300
         4denvar:
-          nodes: 28 #7 subwindow slots
-          PEPerNode: 32
-          memory: 45GB
+          nodes: 7 #7 subwindow slots
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 600
           secondsPerEnVarMember: 10
         ensemble:
           3denvar:
-            nodesPerMember: 3
-            PEPerNode: 12
-            memory: 45GB
+            nodesPerMember: 1
+            PEPerNode: 128
+            memory: 235GB
             baseSeconds: 1200
             secondsPerEnVarMember: 10

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -192,7 +192,7 @@ variational:
       30km:
         3denvar:
           nodes: 4
-          PEPerNode: 128
+          PEPerNode: 64
           memory: 235GB
         4denvar:
           nodes: 28
@@ -202,12 +202,12 @@ variational:
           secondsPerEnVarMember: 5
         3dvar:
           nodes: 4
-          PEPerNode: 128
+          PEPerNode: 64
           memory: 235GB
           baseSeconds: 1500
         ensemble: # i.e., EDASize > 1, multiple background members treated per executable
           3denvar:
-            nodesPerMember: 3
+            nodesPerMember: 4
             PEPerNode: 128
             memory: 235GB
             baseSeconds: 1200
@@ -217,7 +217,7 @@ variational:
           nodes: 2
           PEPerNode: 128
           memory: 235GB
-          baseSeconds: 400
+          baseSeconds: 800
           secondsPerEnVarMember: 9
         4denvar:
           nodes: 14

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -148,7 +148,7 @@ variational:
       bumpCovVBalDir: None
       hybridCoefficientsDir: None
     60km:
-      hybridCoefficientsDir: /glade/p/mmm/parc/liuz/pandac_hybrid/60km.allsky_hybrid
+      hybridCoefficientsDir: /glade/campaign/mmm/parc/liuz/pandac_hybrid/60km.allsky_hybrid
       bumpCovDir: /glade/derecho/scratch/bjung/pandac/20230923_release_v2.0.0_derecho/60km.NICAS_00global
       bumpCovStdDevFile: /glade/derecho/scratch/bjung/pandac/20230923_release_v2.0.0_derecho/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
       bumpCovVBalDir: /glade/derecho/scratch/bjung/pandac/20230923_release_v2.0.0_derecho/60km.VBAL_00

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -122,7 +122,7 @@ variational:
         bumpLocDir: /glade/campaign/mmm/parc/liuz/pandac_common/fixed_input/30km/bumploc/h=1200.0km_v=6.0km_06JAN2023code
       60km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
-        bumpLocDir: /glade/derecho/scratch/nystrom/pandac/60km.bumploc.duplicated.limited_derecho
+        bumpLocDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.bumploc.duplicated.limited.1200km6km
       120km:
         bumpLocPrefix: bumploc_1200.0km_6.0km
         bumpLocDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.bumploc.duplicated.limited.1200km6km
@@ -149,9 +149,9 @@ variational:
       hybridCoefficientsDir: None
     60km:
       hybridCoefficientsDir: /glade/campaign/mmm/parc/liuz/pandac_hybrid/60km.allsky_hybrid
-      bumpCovDir: /glade/derecho/scratch/bjung/pandac/20230923_release_v2.0.0_derecho/60km.NICAS_00global
-      bumpCovStdDevFile: /glade/derecho/scratch/bjung/pandac/20230923_release_v2.0.0_derecho/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/derecho/scratch/bjung/pandac/20230923_release_v2.0.0_derecho/60km.VBAL_00
+      bumpCovDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.NICAS_00global
+      bumpCovStdDevFile: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.VBAL_00
     120km:
       bumpCovDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.NICAS_00
       bumpCovStdDevFile: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc


### PR DESCRIPTION
### Description
We cannot submit jobs on Cheyenne anymore, and we have to switch to Derecho for our new experiments. The default node and core configurations and bump files (60 km mesh) are updated for Derecho. Note that we use 6x32=192 cores on cheyenne for hybrid-3DEnVar, now we use 2x128=256 cores on derecho.

We may also need new bump files for the 30-km mesh.

Closes #(if applicable)

### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
