### PR TITLE
Fix some memory and core/node usage for derecho

### DIFF
--- a/initialize/applications/Forecast.py
+++ b/initialize/applications/Forecast.py
@@ -103,7 +103,7 @@ class Forecast(Component):
       'secondsPerForecastHR': {'typ': int},
       'nodes': {'typ': int},
       'PEPerNode': {'typ': int},
-      'memory': {'def': '45GB', 'typ': str},
+      'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['CriticalQueue']},
       'account': {'def': hpc['CriticalAccount']},
       'email': {'def': True, 'typ': bool},

--- a/initialize/applications/HofX.py
+++ b/initialize/applications/HofX.py
@@ -162,7 +162,7 @@ class HofX(Component):
       'seconds': {'typ': int},
       'nodes': {'typ': int},
       'PEPerNode': {'typ': int},
-      'memory': {'def': '45GB', 'typ': str},
+      'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['NonCriticalQueue']},
       'account': {'def': hpc['NonCriticalAccount']},
     }

--- a/initialize/applications/Variational.py
+++ b/initialize/applications/Variational.py
@@ -284,7 +284,7 @@ class Variational(Component):
       'secondsPerEnVarMember': {'typ': int},
       nodeCount: {'typ': int},
       'PEPerNode': {'typ': int},
-      'memory': {'def': '45GB', 'typ': str},
+      'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['CriticalQueue']},
       'account': {'def': hpc['CriticalAccount']},
       'email': {'def': True, 'typ': bool},

--- a/initialize/post/VerifyModel.py
+++ b/initialize/post/VerifyModel.py
@@ -87,8 +87,8 @@ class VerifyModel(Component):
       'seconds': {'typ': int},
       'secondsPerMember': {'typ': int},
       'nodes': {'def': 1, 'typ': int},
-      'PEPerNode': {'def': 36, 'typ': int},
-      'memory': {'def': '45GB', 'typ': str},
+      'PEPerNode': {'def': 128, 'typ': int},
+      'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['NonCriticalQueue']},
       'account': {'def': hpc['NonCriticalAccount']},
     }

--- a/initialize/post/VerifyObs.py
+++ b/initialize/post/VerifyObs.py
@@ -96,8 +96,8 @@ class VerifyObs(Component):
       'seconds': {'typ': int},
       'secondsPerMember': {'typ': int},
       'nodes': {'def': 1, 'typ': int},
-      'PEPerNode': {'def': 36, 'typ': int},
-      'memory': {'def': '45GB', 'typ': str},
+      'PEPerNode': {'def': 128, 'typ': int},
+      'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['NonCriticalQueue']},
       'account': {'def': hpc['NonCriticalAccount']},
     }

--- a/scenarios/defaults/forecast.yaml
+++ b/scenarios/defaults/forecast.yaml
@@ -2,8 +2,8 @@ forecast:
   # resource requirements (used for both Forecast and ExtendedForecast)
   job:
     defaults:
-      nodes: 4
-      PEPerNode: 32
+      nodes: 1 
+      PEPerNode: 128
       baseSeconds: 60
       secondsPerForecastHR: 500
 
@@ -22,8 +22,8 @@ forecast:
       #baseSeconds: 60
       #secondsPerForecastHR: 120
       # more efficient
-      nodes: 8
-      PEPerNode: 36
+      nodes: 2
+      PEPerNode: 128
       baseSeconds: 60
       secondsPerForecastHR: 120
     60km:
@@ -33,12 +33,12 @@ forecast:
       #baseSeconds: 60
       #secondsPerForecastHR: 40
       # more efficient
-      nodes: 4
-      PEPerNode: 36
+      nodes: 1
+      PEPerNode: 128
       baseSeconds: 60
       secondsPerForecastHR: 70
     120km:
-      nodes: 4
-      PEPerNode: 36
+      nodes: 1
+      PEPerNode: 128
       baseSeconds: 60
       secondsPerForecastHR: 20

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -238,9 +238,9 @@ variational:
           baseSeconds: 500
           secondsPerEnVarMember: 9
         3dvar:
-          nodes: 6
-          PEPerNode: 32
-          memory: 45GB
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
           baseSeconds: 500
     60km:
       # Assuming 60 total inner iterations
@@ -251,12 +251,6 @@ variational:
           memory: 235GB
           baseSeconds: 200
           secondsPerEnVarMember: 6
-          # double-precision bundle build
-          ##nodes: 6
-          ##PEPerNode: 32
-          ##memory: 45GB
-          ##baseSeconds: 200
-          ##secondsPerEnVarMember: 6
         4denvar:
           nodes: 14 #7 subwindow slots
           PEPerNode: 128

--- a/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
+++ b/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
@@ -44,7 +44,7 @@ variational:
     30km:
       60km:
         3denvar:
-          memory: 45GB
+          memory: 235GB
   post: [verifyobs]
 workflow:
   first cycle point: 20180414T18

--- a/test/testinput/3dvar_O30kmIE60km_ColdStart.yaml
+++ b/test/testinput/3dvar_O30kmIE60km_ColdStart.yaml
@@ -37,7 +37,7 @@ variational:
     30km:
       60km:
         3dvar:
-          memory: 45GB
+          memory: 235GB
   post: [verifyobs]
 workflow:
   # test a recent date


### PR DESCRIPTION
### Description
1. I ran cycling tests for the standard 120km 3DEnVar (scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml), which failed at the forecast step after 3 cycles. The failure is caused by exceeding wall-time (so forecast job was killed). 

2. With a closer look into the job setting, I found it still set to use 36 cores/node by default (though I believe this is not the cause of the failure). So changed 36 cores/node to 128 cores/node. Now 120km forecast step uses 1 node and 128 cores/node. After this change, restarting the cycling ran through 2-day cycles from 2018041418 to 2018041700.

3. Also modified some files for memory use from old 45GB for cheyenne to new 235GB for derecho. I believe we can remove those memory setting as all derecho nodes have the same 235GB, not like cheyenne having 45GB and 109GB nodes. But I will leave that for future PRs. And I do not change the memory setting for ensemble-related files, which can be done in a future PR. This memory change should have fixed a test failure of ~test/testinput/3denvar_O30kmIE60km_WarmStart.yaml.

```
	modified:   initialize/applications/Forecast.py
        modified:   initialize/applications/HofX.py
	modified:   initialize/applications/Variational.py
	modified:   initialize/post/VerifyModel.py
	modified:   initialize/post/VerifyObs.py
	modified:   scenarios/defaults/forecast.yaml
	modified:   scenarios/defaults/variational.yaml
	modified:   test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
	modified:   test/testinput/3dvar_O30kmIE60km_ColdStart.yaml
```