### PR TITLE
Update the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Starting a cycling experiment on the Derecho HPC
 
  cd MPAS-Workflow
 
+ # run one of the following:
+ source env-setup/machine.sh # if running bash or zsh
+ source env-setup/machine.csh # if running tcshrc
+
  #modify configuration as needed in `scenarios/*.yaml`, `scenarios/defaults/*.yaml`, or
  # `test/testinput/*.yaml`
 
@@ -32,6 +36,8 @@ Starting a cycling experiment on the Derecho HPC
 
 `{{scenarioConfig}}` is a yaml-based configuration file, examples of which are given in
 `scenarios/*.yaml` and `test/testinput/*.yaml`
+
+The workflow uses cylc version 8. That will be loaded when you `source env-setup/machime.[c]sh`
 
 It is required to set the content of $HOME/.cylc/flow/global.cylc as follows:
 ```
@@ -50,12 +56,14 @@ It is required to set the content of $HOME/.cylc/flow/global.cylc as follows:
     #      [[[localhost]]]
     #        run = /glade/derecho/scratch/$USER/
 ```
-The [[pbs_cluster]] entries tell cylc how to submit jobs.
-The [instal] section will create both $HOME/cylc-run/MPAS-Workflow and 
-/glade/derecho/scratch/$USER/cylc-run/MPAS-Workflow directories.
-A symlink will be created in $HOME/cylc-run/MPAS-Workflow for each workflow,
+* The [[pbs_cluster]] entries tell cylc how to submit jobs.
+* The [install] section is optional
+  - If used, the [install] section will create both `$HOME/cylc-run/MPAS-Workflow` and 
+`/glade/derecho/scratch/$USER/cylc-run/MPAS-Workflow` directories.
+    - A symlink will be created in $HOME/cylc-run/MPAS-Workflow for each workflow,
 which will point to a directory in the run/cylc-run/MPAS-Workflow where the actual data will be written.
 When setting up symlinks, ensure the run/cylc-run/MPAS-Workflow directory is empty.
+  - If not used, data for workflows will be written to `$HOME/cycl-run/MPAS-Workflow`
 
 Build
 -----

--- a/README.md
+++ b/README.md
@@ -25,17 +25,7 @@ Starting a cycling experiment on the Derecho HPC
  # run one of the following:
  source env-setup/machine.sh # if running bash or zsh
  source env-setup/machine.csh # if running tcshrc
-
- #modify configuration as needed in `scenarios/*.yaml`, `scenarios/defaults/*.yaml`, or
- # `test/testinput/*.yaml`
-
- ./Run.py {{scenarioConfig}}
- #OR
- ./test.csh
 ```
-
-`{{scenarioConfig}}` is a yaml-based configuration file, examples of which are given in
-`scenarios/*.yaml` and `test/testinput/*.yaml`
 
 The workflow uses cylc version 8. That will be loaded when you `source env-setup/machime.[c]sh`
 
@@ -64,6 +54,19 @@ It is required to set the content of $HOME/.cylc/flow/global.cylc as follows:
 which will point to a directory in the run/cylc-run/MPAS-Workflow where the actual data will be written.
 When setting up symlinks, ensure the run/cylc-run/MPAS-Workflow directory is empty.
   - If not used, data for workflows will be written to `$HOME/cycl-run/MPAS-Workflow`
+
+ Modify configuration as needed in `scenarios/*.yaml`, `scenarios/defaults/*.yaml`, or
+ `test/testinput/*.yaml`
+
+ Execute the workflow:
+ ```
+ ./Run.py {{scenarioConfig}}
+ #OR
+ ./test.csh
+```
+
+`{{scenarioConfig}}` is a yaml-based configuration file, examples of which are given in
+`scenarios/*.yaml` and `test/testinput/*.yaml`
 
 Build
 -----

--- a/env-setup/machine.csh
+++ b/env-setup/machine.csh
@@ -11,9 +11,10 @@ if ( "$NCAR_HOST" == "derecho" ) then
     echo 'CYLC_ENV environment variable is not set, setting it to /glade/work/jwittig/conda-envs/my-cylc8.2'
     setenv CYLC_ENV /glade/work/jwittig/conda-envs/my-cylc8.2
   endif
-#  source /etc/profile.d/z00_modules.csh
+  source /etc/profile.d/z00_modules.csh
 #  module purge
   module load conda/latest
+  module list
 
   conda activate $CYLC_ENV
 else if ( "$NCAR_HOST" == "cheyenne" ) then

--- a/env-setup/machine.csh
+++ b/env-setup/machine.csh
@@ -11,18 +11,8 @@ if ( "$NCAR_HOST" == "derecho" ) then
     echo 'CYLC_ENV environment variable is not set, setting it to /glade/work/jwittig/conda-envs/my-cylc8.2'
     setenv CYLC_ENV /glade/work/jwittig/conda-envs/my-cylc8.2
   endif
-  source /etc/profile.d/z00_modules.csh
-  module purge
-  module load ncarenv/23.06
-  module load intel-oneapi/2023.0.0
-  module load cray-mpich/8.1.25
-  module load parallel-netcdf/1.12.3
-  module load parallelio/2.5.10
-  module load ncl/6.6.2
-  module load hdf5/1.12.2
-  module load netcdf/4.9.2
-  module load ncarcompilers/1.0.0
-  module load nco/5.1.4
+#  source /etc/profile.d/z00_modules.csh
+#  module purge
   module load conda/latest
 
   conda activate $CYLC_ENV

--- a/env-setup/machine.sh
+++ b/env-setup/machine.sh
@@ -12,7 +12,7 @@ if [[ "$NCAR_HOST" == "derecho" ]]; then
     export CYLC_ENV=/glade/work/jwittig/conda-envs/my-cylc8.2
   fi
 
-#  source /etc/profile.d/z00_modules.sh
+  source /etc/profile.d/z00_modules.sh
 #  module purge
   module load conda/latest
   module list

--- a/env-setup/machine.sh
+++ b/env-setup/machine.sh
@@ -12,19 +12,10 @@ if [[ "$NCAR_HOST" == "derecho" ]]; then
     export CYLC_ENV=/glade/work/jwittig/conda-envs/my-cylc8.2
   fi
 
-  source /etc/profile.d/z00_modules.sh
-  module purge
-  module load ncarenv/23.06
-  module load intel-oneapi/2023.0.0
-  module load cray-mpich/8.1.25
-  module load parallel-netcdf/1.12.3
-  module load parallelio/2.5.10
-  module load ncl/6.6.2
-  module load hdf5/1.12.2
-  module load netcdf/4.9.2
-  module load ncarcompilers/1.0.0
-  module load nco/5.1.4
+#  source /etc/profile.d/z00_modules.sh
+#  module purge
   module load conda/latest
+  module list
 
   conda activate $CYLC_ENV
 


### PR DESCRIPTION
### Description
Update the README file to describe how to run workflows with cylc 8.
Remove loading extraneous modules from the env-setup files.

### Tests completed
I tested this with 
  1. a bash login shell, the .bashrc had nothing in it
  2. a tcsh login shell, the .tcshrc has nothing in it
  3. a zsh login shell, the .zshrc sourced /etc/profile.d/z00_modules.sh

#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] 4denvar_OIE120km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
