### PR TITLE
Adjusts Forecast Output for 3D and 4D Applications

### DIFF
--- a/initialize/applications/Forecast.py
+++ b/initialize/applications/Forecast.py
@@ -45,6 +45,10 @@ class Forecast(Component):
     # whether to use incremental analysis update
     'IAU': [False, bool],
 
+    ## 4D
+    # whether to use 4D forecast outputs
+    'FourD': [False, bool],
+
     ## post
     # list of tasks for Post
     'post': [['verifyobs', 'verifymodel'], list]
@@ -78,15 +82,19 @@ class Forecast(Component):
     ###################
 
     IAU = self['IAU']
+    FourD = self['FourD']
 
     window = workflow['CyclingWindowHR']
     subwindow = workflow['subwindow']
     if IAU:
       outIntervalHR = window // 2
       lengthHR = 3 * outIntervalHR
-    else:
+    elif FourD:
       outIntervalHR = subwindow
       lengthHR = window + window // 2
+    else:
+      outIntervalHR = window
+      lengthHR = window
 
     self._set('outIntervalHR', outIntervalHR)
     self._set('lengthHR', lengthHR)
@@ -126,7 +134,7 @@ class Forecast(Component):
     for mm in range(1, self.NN+1, 1):
       # fcArgs explanation
       # DACycling (True), IC ~is~ a DA analysis for which re-coupling is required
-      # DeleteZerothForecast (True), not used anywhere else in the workflow
+      # DeleteZerothForecast (False), not used anywhere else in the workflow
       args = [
         mm,
         lengthHR,
@@ -134,7 +142,7 @@ class Forecast(Component):
         IAU,
         mesh.name,
         True,
-        True,
+        False,
         updateSea,
         self.workDir+'/{{thisCycleDate}}'+self.memFmt.format(mm),
         warmIC[mm-1].directory(),

--- a/scenarios/4denvar_O30kmIE60km_WarmStart_VarBC_7slots_2outer_80mem.yaml
+++ b/scenarios/4denvar_O30kmIE60km_WarmStart_VarBC_7slots_2outer_80mem.yaml
@@ -25,3 +25,5 @@ variational:
   ensemble:
     forecasts:
       resource: "PANDAC.GEFS_4DEnVar_80mem"
+forecast:
+  FourD: True

--- a/scenarios/4denvar_OIE120km_WarmStart_VarBC_7slots.yaml
+++ b/scenarios/4denvar_OIE120km_WarmStart_VarBC_7slots.yaml
@@ -27,6 +27,7 @@ variational:
   #execute: False
   #post: []
 forecast:
+  FourD: True
 #  execute: False
 #  post: []
 #extendedforecast:

--- a/scenarios/4denvar_OIE60km_WarmStart_VarBC_7slots_2outer.yaml
+++ b/scenarios/4denvar_OIE60km_WarmStart_VarBC_7slots_2outer.yaml
@@ -24,3 +24,5 @@ variational:
   ensemble:
     forecasts:
       resource: "PANDAC.GEFS_4DEnVar"
+forecast:
+  FourD: True

--- a/test/testinput/4denvar_OIE120km_WarmStart.yaml
+++ b/test/testinput/4denvar_OIE120km_WarmStart.yaml
@@ -5,6 +5,7 @@ externalanalyses:
 firstbackground:
   resource: "PANDAC.GFS_4DEnVAR"
 forecast:
+  FourD: True
   post: [verifyobs, verifymodel]
 hpc:
   CriticalQueue: economy


### PR DESCRIPTION
### Description
Added `FourD` yaml forecast option for 4D applications. When set to `True` the forecast output will be the subwindow frequency and when `False`, the default, the forecast output will be the window length.

The initial forecast output is also now retained instead of deleted.

### Issue closed

Closes #280

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] 4denvar_OIE120km_WarmStart_TEST
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
