### PR TITLE
Fix linking satbias file if no obs file exists

### DIFF
--- a/bin/PrepJEDI.csh
+++ b/bin/PrepJEDI.csh
@@ -298,7 +298,7 @@ foreach instrument ($observers)
       set allowsBiasCorrection = True
       # if no obs file exists, link satbias file from the previous cycle
       if ( ! -f ${InDBDir}/${instrument}_obs_${thisValidDate}.h5 ) then
-        ln -sf ${biasCorrectionDir}/satbias_${i}.h5 ${CyclingDADir}/${thisValidDate}/dbOut
+        ln -sf ${biasCorrectionDir}/satbias_${i}.h5 ${CyclingDADir}/dbOut
       endif
     endif
   end

--- a/bin/PrepJEDI.csh
+++ b/bin/PrepJEDI.csh
@@ -298,7 +298,7 @@ foreach instrument ($observers)
       set allowsBiasCorrection = True
       # if no obs file exists, link satbias file from the previous cycle
       if ( ! -f ${InDBDir}/${instrument}_obs_${thisValidDate}.h5 ) then
-        ln -sf ${biasCorrectionDir}/satbias_${i}.h5 ${CyclingDADir}/dbOut
+        ln -sf ${biasCorrectionDir}/satbias_${i}.h5 ${DAWorkDir}/${thisValidDate}/dbOut
       endif
     endif
   end


### PR DESCRIPTION
### Description
This PR reviews linking satbias files when the observation file does not exist. An HDF5 error arises because it cannot open the file, but that's actually because the file does not exist. In the `PrepJEDI.csh`, we link the satbias file from previous cycle and use the variable `${CyclingDADir}` to indicate where to link it. However, `CyclingDADir` already includes the date information (as defined in `getCycleVars.csh`), then `${CyclingDADir}/${thisValidDate}/dbOut` produces a wrong path. The cleaner solution is to use the variable `DAWorkDir` that does not include date information and keep `${thisValidDate}` to ensure the targeted path is correct. This is equivalent to `${CyclingDADir}/dbOut`. 

### Issue closed
Closes https://github.com/NCAR/MPAS-Workflow/issues/292

### Tests completed
- Tested in suite that failed because satbias files was not found
