### PR TITLE
Aggregate geoval and ydiags files for each processor

### DIFF
--- a/bin/ConcatenateObsFeedback.csh
+++ b/bin/ConcatenateObsFeedback.csh
@@ -1,0 +1,71 @@
+#!/bin/csh -f
+
+# (C) Copyright 2023 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+date
+
+# Process arguments
+# =================
+## args
+
+# ArgAppType: str, hofx, variational
+set ArgAppType = "$1"
+
+# ArgSubPath: str, /mean, /mem
+set ArgSubPath = "$2"
+
+# Setup environment
+# =================
+source config/environmentNPL.csh
+source config/tools.csh
+source config/auto/experiment.csh
+source config/auto/workflow.csh
+source config/auto/naming.csh
+source config/auto/observations.csh
+set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
+set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
+set thisCycleDate = ${yymmdd}${hh}
+
+# Concatenate the geovals and ydiag feedback files
+# =======================================
+if ( ${ArgAppType} == "hofx" ) then
+  set AppCategory = ${ArgAppType}
+  set obsFeedbackDir = ${VerifyObsWorkDir}/${backgroundSubDir}${ArgSubPath}/${thisCycleDate}/${OutDBDir}
+else if ( ${ArgAppType} == "variational" ) then
+  set AppCategory = "da"
+  set obsFeedbackDir = ${DAWorkDir}/${thisCycleDate}/${OutDBDir}
+endif
+
+set WorkDir = ${obsFeedbackDir}
+echo "WorkDir = ${WorkDir}"
+mkdir -p ${WorkDir}
+cd ${WorkDir}
+
+if ( -e CONCATENATESUCCESS ) then
+  echo "$0 (INFO): CONCATENATESUCCESS file already exists, exiting with success"
+  echo "$0 (INFO): if regenerating the concatenated files is desired, delete CONCATENATESUCCESS"
+  date
+  exit 0
+endif
+
+set pyScript = "concatenate"
+setenv myCommand `$concatenate ${thisCycleDate} ${AppCategory} ${obsFeedbackDir}`
+echo "$myCommand"
+${myCommand} >& log.${pyScript}
+
+# check if the concatenated files were created successfully
+grep "Finished __main__ successfully" log.${pyScript}
+if ( $status != 0 ) then
+  echo "ERROR in $0 : ${pyScript} failed" > ./FAIL
+  exit 1
+else
+  rm -rf *.nc4
+  touch CONCATENATESUCCESS
+endif
+
+date
+
+exit 0

--- a/config/environmentNPL.csh
+++ b/config/environmentNPL.csh
@@ -1,0 +1,29 @@
+#!/bin/csh -f
+
+if ( $?config_environmentNPL ) exit 0
+setenv config_environmentNPL 1
+
+if ( "$NCAR_HOST" == "derecho" ) then
+  source /etc/profile.d/z00_modules.csh
+  module purge
+  module load conda/latest
+  module list
+  conda activate npl
+else if ( "$NCAR_HOST" == "cheyenne" ) then
+  source /etc/profile.d/modules.csh
+  module purge
+  module load ncarenv/1.3
+  module load gnu/10.1.0
+  module load ncarcompilers/0.5.0
+  module load netcdf/4.8.1
+  module load conda/latest
+  conda activate npl
+
+  module load cylc
+  module load graphviz
+  module load git
+  git lfs install
+  module list
+else
+  echo "unknown NCAR_HOST " $NCAR_HOST
+endif

--- a/config/tools.csh
+++ b/config/tools.csh
@@ -21,6 +21,7 @@ set pyTools = ( \
   TimeFmtChange \
   update_sensorScanPosition \
   updateXTIME \
+  concatenate \
 )
 foreach tool ($pyTools)
   setenv ${tool} "python ${pyDir}/${tool}.py"

--- a/initialize/applications/EnKF.py
+++ b/initialize/applications/EnKF.py
@@ -82,8 +82,8 @@ class EnKF(Component):
 
     ## maxIODAPoolSize
     # maximum number of IO pool members in IODA writer class
-    # OPTIONS: 1 to NPE, default: 10
-    'maxIODAPoolSize': [10, int],
+    # OPTIONS: 1 to NPE, default: 1
+    'maxIODAPoolSize': [1, int],
 
     ## radianceThinningDistance
     # distance (km) used for the Gaussian Thinning filter for all radiance-based observations

--- a/initialize/applications/HofX.py
+++ b/initialize/applications/HofX.py
@@ -89,8 +89,8 @@ class HofX(Component):
 
     ## maxIODAPoolSize
     # maximum number of IO pool members in IODA writer class
-    # OPTIONS: 1 to NPE, default: 10
-    'maxIODAPoolSize': [10, int],
+    # OPTIONS: 1 to NPE, default: 1
+    'maxIODAPoolSize': [1, int],
 
     ## radianceThinningDistance
     # distance (km) used for the Gaussian Thinning filter for all radiance-based observations

--- a/initialize/applications/HofX.py
+++ b/initialize/applications/HofX.py
@@ -102,7 +102,7 @@ class HofX(Component):
 
     ## concatenateObsFeedback
     # whether to concatenate the geovals and ydiag feedback files
-    'concatenateObsFeedback': [False, bool],
+    'concatenateObsFeedback': [False, bool]
   }
 
   def __init__(self,
@@ -224,26 +224,24 @@ class HofX(Component):
     script = $origin/bin/'''+self.base+'''.csh '''+executeArgs+'''
 '''+task.job()+task.directives()]
 
-    if self['concatenateObsFeedback']:
-      attr = {
+      if self['concatenateObsFeedback']:
+        concatattr = {
         'seconds': {'def': 300},
         'nodes': {'def': 1},
         'PEPerNode': {'def': 128},
         'memory': {'def': '235GB', 'typ': str},
         'queue': {'def': hpc['CriticalQueue']},
         'account': {'def': hpc['CriticalAccount']},
-      }
-      concatjob = Resource(self._conf, attr, ('concat.job', mesh.name))
-      concattask = TaskLookup[hpc.system](concatjob)
-
-      self._tasks += ['''
-  [[ConcatenateObsFeedback_HofXBG]]
-    inherit = '''+self.tf.group+''', BATCH
-    script = $origin/bin/ConcatenateObsFeedback.csh "'''+self.lower+'''" "'''+memFmt+'''"
+        }
+        concatjob = Resource(self._conf, concatattr, ('concat.job'))
+        concattask = TaskLookup[hpc.system](concatjob)
+        self._tasks += ['''
+  [[ConcatenateObsFeedback'''+suffix+''']]
+    inherit = BATCH
+    script = $origin/bin/ConcatenateObsFeedback.csh "'''+self.lower+'''" "'''+memFmt.format(mm+1)+'''"
 '''+concattask.job()+concattask.directives()]
-
-      self._dependencies += ['''
-        '''+self.tf.finished+''' => ConcatenateObsFeedback_HofXBG''']
+        self._dependencies += ['''
+        '''+execute+''' => ConcatenateObsFeedback'''+suffix]
 
     self._tasks += ['''
   [['''+clean+''']]

--- a/initialize/applications/Variational.py
+++ b/initialize/applications/Variational.py
@@ -129,8 +129,8 @@ class Variational(Component):
 
     ## maxIODAPoolSize
     # maximum number of IO pool members in IODA writer class
-    # OPTIONS: 1 to NPE, default: 10
-    'maxIODAPoolSize': [10, int],
+    # OPTIONS: 1 to NPE, default: 1
+    'maxIODAPoolSize': [1, int],
 
     ## radianceThinningDistance
     # distance (km) used for the Gaussian Thinning filter for all radiance-based observations

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -51,7 +51,8 @@ class Build(Component):
       # Mean state calculator
       # FIXME the source for the app in this directory was copied from
       # /glade/work/guerrett/pandac/work/meanState/spack-stack_gcc-10.1.0_openmpi-4.1.1
-      meanStateBuildDir = '/glade/work/jwittig/repos1/mpas-bundle-r2.0/build-gnu-derecho-single/bin'
+      # meanStateBuildDir = '/glade/work/jwittig/repos1/mpas-bundle-r2.0/build-gnu-derecho-single/bin'
+      meanStateBuildDir = '/glade/work/jwittig/repos1/mpas-bundle-dev-new/build-gnu-1p-ss1.6.0/bin'
     elif system == 'cheyenne':
       self.variablesWithDefaults['mpas bundle'] = \
         ['/glade/p/mmm/parc/liuz/pandac_common/mpas-bundle-code-build/mpas_bundle_2.0_gnuSP/build', str]

--- a/scenarios/3dhybrid-allsky_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid-allsky_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -15,7 +15,7 @@ forecast:
 
   #execute: False # the default is True
   #post: [] # use this when doing extended forecast
-  post: [verifymodel] # this turns off verifyobs
+  post: [verifyobs] #verifymodel] # this turns off verifyobs
 
 externalanalyses:
   resource: "GFS.PANDAC"
@@ -42,25 +42,15 @@ variational:
   ensemble:
     forecasts:
       resource: "PANDAC.EDA"
-
-  # resource requirements
-  job:
-    30km:
-      60km:
-        3dhybrid:
-          nodes: 6
-          PEPerNode: 32
-          memory: 109GB
-          baseSeconds: 600
-          secondsPerEnVarMember: 8
-
   #execute: False # the default is True
   #post: [] # this turns off verifyobs
+hofx:
+  concatenateObsFeedback: True
 
 workflow:
   first cycle point: 20180414T18
   #restart cycle point: 20180415T00
-  final cycle point: 20180415T06
+  final cycle point: 20180415T00
   #final cycle point: 20180514T18
   #CyclingWindowHR: 24 # default is 6 for cycling DA
   #max active cycle points: 4 # used for independent 'extendedforecast'

--- a/scenarios/3dhybrid-allsky_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid-allsky_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -15,7 +15,7 @@ forecast:
 
   #execute: False # the default is True
   #post: [] # use this when doing extended forecast
-  post: [verifyobs] #verifymodel] # this turns off verifyobs
+  post: [verifymodel] # this turns off verifyobs
 
 externalanalyses:
   resource: "GFS.PANDAC"
@@ -50,7 +50,7 @@ hofx:
 workflow:
   first cycle point: 20180414T18
   #restart cycle point: 20180415T00
-  final cycle point: 20180415T00
+  final cycle point: 20180415T06
   #final cycle point: 20180514T18
   #CyclingWindowHR: 24 # default is 6 for cycling DA
   #max active cycle points: 4 # used for independent 'extendedforecast'

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -232,10 +232,10 @@ variational:
           baseSeconds: 500
           secondsPerEnVarMember: 9
         3dhybrid-allsky:
-          nodes: 2
-          PEPerNode: 128
+          nodes: 4
+          PEPerNode: 64
           memory: 235GB
-          baseSeconds: 500
+          baseSeconds: 800
           secondsPerEnVarMember: 9
         3dvar:
           nodes: 2

--- a/tools/concatenate.py
+++ b/tools/concatenate.py
@@ -7,7 +7,7 @@ import netCDF4
 import argparse
 import logging
 
-logging.basicConfig(filename='log.concatenate', filemode='w', format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S', level=logging.DEBUG)
+logging.basicConfig(filename='log.concatenate', filemode='w', format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S', level=logging.DEBUG)
 
 IODAfloat_missing_value = float(-3.3687953e+38)
 YDIAGfloat_missing_value = float(9.969209968386869e+36)
@@ -16,7 +16,7 @@ YDIAGfloat_missing_value = float(9.969209968386869e+36)
 def from_h5(fn,var):
     try:
       return h5.File(fn, 'r')[var]
-    except OSError as error : 
+    except OSError as error:
       logging.warning(error)
       pass
 

--- a/tools/concatenate.py
+++ b/tools/concatenate.py
@@ -1,0 +1,87 @@
+import h5py as h5
+import dask.array as da
+import time
+import glob, os, sys
+import numpy as np
+import netCDF4
+import argparse
+import logging
+_logger = logging.getLogger(__name__)
+
+IODAfloat_missing_value = float(-3.3687953e+38)
+YDIAGfloat_missing_value = float(9.969209968386869e+36)
+
+
+def from_h5(fn,var):
+    try:
+      return h5.File(fn, 'r')[var]
+    except OSError as error : 
+      print(error)
+      pass
+
+
+def create_nc_all(variables,dimensions,data,nlocs,file_name):
+    ftype = 'f4'
+    ncdf = netCDF4.Dataset(file_name,'w', format='NETCDF4')
+    ncdf.createDimension('nlocs', nlocs)
+
+    for dim,varname in zip(dimensions,variables):
+      ncdf.createDimension(dim.name, dim.size)
+      ncdf.createVariable(varname, ftype, ('nlocs',dim.name), fill_value=IODAfloat_missing_value)
+      ncdf[varname][:] = data[varname]
+    ncdf.close()
+
+
+def main(app,diagnostic_dir,prefix):
+    st = time.time()
+
+    # Determine obsSpace suffix
+    file_0000 = prefix+'_'+args.app+'_*_0000.nc4'
+    files = np.sort(glob.glob(diagnostic_dir + '/'+  file_0000, recursive=True))
+
+    if len(files) == 0:
+      _logger.info('No '+prefix+' files to concatenate \n if concatenating files is desired, verify that geoval and ydiags file exist')
+      _logger.info('Finished '+__name__+' successfully')
+    else:
+      s = '_'
+      suffix_s = [s.join(fi.split('/')[-1].split('_')[2:-1]) if len(fi.split('/')[-1].split('_')[2:-1]) > 1 else fi.split('/')[-1].split('_')[2:-1] for fi in files]
+
+      ncfiles = []
+      for suffix in suffix_s:
+        filename = prefix+'_'+app+'_'+suffix+'_*.nc4'
+
+        files = np.sort(glob.glob(diagnostic_dir + '/'+ filename, recursive=True))
+        nfiles = len(files)
+
+        variables = list(netCDF4.Dataset(files[0],'r').variables.keys())
+        dimensions = list(netCDF4.Dataset(files[0],'r').dimensions.values())[1:] # remove nlocs
+
+        data_dict = {}
+        missing_val = YDIAGfloat_missing_value if prefix == 'ydiags' else IODAfloat_missing_value
+
+        for v in variables:
+          var = da.concatenate([da.ma.masked_equal(da.from_array(from_h5(files[ind],v), chunks="auto"), missing_val) for ind in range(nfiles)])
+          data_dict.update({v: var})
+        
+        nlocs = data_dict[variables[0]].shape[0]
+
+        output_file_name = diagnostic_dir + '/'+ prefix+'_'+app+'_'+suffix+'_all.nc'
+        create_nc_all(variables,dimensions,data_dict,nlocs,output_file_name)
+        ncfiles.append(os.path.isfile(output_file_name))
+
+      if all(ncfiles):
+        _logger.info('Finished '+__name__+' successfully')
+      else:
+        _logger.info('nc files were not created...exiting')
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Concatenate JEDI application diagnostics from GOMsaver and YDIAGsaver filters', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('app', type=str, help='JEDI application category (e.g., da or hofx)')
+    parser.add_argument('obsFeedbackDir', type=str, help='Observation feedback files directory')
+    args = parser.parse_args()
+
+    diagTypes = ['geoval','ydiags']
+    for prefix in diagTypes:
+      main(args.app, args.obsFeedbackDir, prefix)

--- a/tools/concatenate.py
+++ b/tools/concatenate.py
@@ -6,7 +6,8 @@ import numpy as np
 import netCDF4
 import argparse
 import logging
-_logger = logging.getLogger(__name__)
+
+logging.basicConfig(filename='log.concatenate', filemode='w', format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S', level=logging.DEBUG)
 
 IODAfloat_missing_value = float(-3.3687953e+38)
 YDIAGfloat_missing_value = float(9.969209968386869e+36)
@@ -16,7 +17,7 @@ def from_h5(fn,var):
     try:
       return h5.File(fn, 'r')[var]
     except OSError as error : 
-      print(error)
+      logging.warning(error)
       pass
 
 
@@ -39,40 +40,38 @@ def main(app,diagnostic_dir,prefix):
     file_0000 = prefix+'_'+args.app+'_*_0000.nc4'
     files = np.sort(glob.glob(diagnostic_dir + '/'+  file_0000, recursive=True))
 
-    if len(files) == 0:
-      _logger.info('No '+prefix+' files to concatenate \n if concatenating files is desired, verify that geoval and ydiags file exist')
-      _logger.info('Finished '+__name__+' successfully')
-    else:
-      s = '_'
-      suffix_s = [s.join(fi.split('/')[-1].split('_')[2:-1]) if len(fi.split('/')[-1].split('_')[2:-1]) > 1 else fi.split('/')[-1].split('_')[2:-1] for fi in files]
+    ncfiles = []
+    s = '_'
+    suffix_s = [s.join(fi.split('/')[-1].split('_')[2:-1]) if len(fi.split('/')[-1].split('_')[2:-1]) > 1 else fi.split('/')[-1].split('_')[2:-1] for fi in files]
 
-      ncfiles = []
-      for suffix in suffix_s:
-        filename = prefix+'_'+app+'_'+suffix+'_*.nc4'
+    for suffix in suffix_s:
+      logging.info('Working on: '+ prefix+ ' '+ suffix)
+      filename = prefix+'_'+app+'_'+suffix+'_*.nc4'
 
-        files = np.sort(glob.glob(diagnostic_dir + '/'+ filename, recursive=True))
-        nfiles = len(files)
+      files = np.sort(glob.glob(diagnostic_dir + '/'+ filename, recursive=True))
+      nfiles = len(files)
 
-        variables = list(netCDF4.Dataset(files[0],'r').variables.keys())
-        dimensions = list(netCDF4.Dataset(files[0],'r').dimensions.values())[1:] # remove nlocs
+      variables = list(netCDF4.Dataset(files[0],'r').variables.keys())
+      dimensions = list(netCDF4.Dataset(files[0],'r').dimensions.values())[1:] # remove nlocs
 
-        data_dict = {}
-        missing_val = YDIAGfloat_missing_value if prefix == 'ydiags' else IODAfloat_missing_value
+      data_dict = {}
+      missing_val = YDIAGfloat_missing_value if prefix == 'ydiags' else IODAfloat_missing_value
 
-        for v in variables:
-          var = da.concatenate([da.ma.masked_equal(da.from_array(from_h5(files[ind],v), chunks="auto"), missing_val) for ind in range(nfiles)])
-          data_dict.update({v: var})
-        
-        nlocs = data_dict[variables[0]].shape[0]
+      for v in variables:
+        var = da.concatenate([da.ma.masked_equal(da.from_array(from_h5(files[ind],v), chunks="auto"), missing_val) for ind in range(nfiles)])
+        data_dict.update({v: var})
 
-        output_file_name = diagnostic_dir + '/'+ prefix+'_'+app+'_'+suffix+'_all.nc'
-        create_nc_all(variables,dimensions,data_dict,nlocs,output_file_name)
-        ncfiles.append(os.path.isfile(output_file_name))
+      nlocs = data_dict[variables[0]].shape[0]
 
-      if all(ncfiles):
-        _logger.info('Finished '+__name__+' successfully')
-      else:
-        _logger.info('nc files were not created...exiting')
+      output_file_name = diagnostic_dir + '/'+ prefix+'_'+app+'_'+suffix+'.nc4'
+      try:
+        os.remove(output_file_name)
+      except OSError:
+        pass
+      create_nc_all(variables,dimensions,data_dict,nlocs,output_file_name)
+      ncfiles.append(os.path.isfile(output_file_name))
+
+    return ncfiles
 
 
 if __name__ == '__main__':
@@ -84,4 +83,9 @@ if __name__ == '__main__':
 
     diagTypes = ['geoval','ydiags']
     for prefix in diagTypes:
-      main(args.app, args.obsFeedbackDir, prefix)
+      ncfiles = main(args.app, args.obsFeedbackDir, prefix)
+
+    if all(ncfiles):
+      logging.info('Finished '+__name__+' successfully')
+    else:
+      logging.error('Concatenated files were not created, exiting')

--- a/tools/dateList.py
+++ b/tools/dateList.py
@@ -12,7 +12,7 @@ def main(dateIni, dateEnd, delta):
       datestr  = date.strftime("%Y%m%d%H")
       print(datestr)
       date = date - timedelta(hours=int(delta))
-
+            
 if __name__ == '__main__': 
     dateIni = str(sys.argv[1])
     dateEnd = str(sys.argv[2])

--- a/tools/dateList.py
+++ b/tools/dateList.py
@@ -12,7 +12,7 @@ def main(dateIni, dateEnd, delta):
       datestr  = date.strftime("%Y%m%d%H")
       print(datestr)
       date = date - timedelta(hours=int(delta))
-            
+
 if __name__ == '__main__': 
     dateIni = str(sys.argv[1])
     dateEnd = str(sys.argv[2])


### PR DESCRIPTION
### Description
Currently, GOMsaver and YDIAGsaver filters in UFO write observation feedback files for each processor. Although the `maxIODAPoolSize` parameter allows us to specify the maximum number of IO pool members in IODA writer class, this only works for the obsout diagnostics so far (up to my knowledge). This PR adds the capability to aggregate geoval and ydiags files for each processor using a python script. The file containing the aggregated data is named following the same convention (i.e. `<prefix>_<app>_<suffix>.nc4`) so no error occurs when doing the verification steps. All this is controlled by the variable `concatenateObsFeedback` which can be specified under `variational, hofx, or enkf` key values in the scenario YAML files, default is set to `False`. A new CYLC task was added, which runs after the execute step if the `concatenateObsFeedback` was set to `True`.

Note that the walltime can be adjusted depending on how many ObsSpace are with geoval and ydiags files. Here some info on the timing for reference, for example, concatenating all 256 geoval files for abi_g16 takes ~20s (ydiag files take longer). Using dask improves the timing significantly, but this package is not available in the python environment we are using (my-cylc8.2), which is why I added an environment file to activate NPL.
```
2024-03-15 10:51:17 - INFO - Working on: geoval abi_g16
2024-03-15 10:51:37 - INFO - Working on: geoval ahi_himawari8
2024-03-15 10:51:56 - INFO - Working on: geoval amsua-cld_aqua
...
2024-03-15 10:55:39 - INFO - Working on: ydiags abi_g16
2024-03-15 10:56:11 - INFO - Working on: ydiags ahi_himawari8
2024-03-15 10:56:45 - INFO - Working on: ydiags amsua-cld_aqua
...
```
This PR also changes the `maxIODAPoolSize` to 1, so only one obsout file is written by ObsSpace.

In addition, this PR updates the path for the `meanStateBuildDir` for a new compilation using spack-stack 1.6.0. The previous compilation using spack-stack 1.5 was failing after the update for the develop branch. 

The computational resources for the `3dhybrid-allsky` scenario are also updated.


### Issue closed
None

### Tests completed
#### Tier 1:
These were tested with and without the new option. The DA part was also tested by activating the GOMsaver and YDIAGsaver filters in the YAML files.
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Scenario (optional):
 - [x] 3dhybrid-allsky_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
