### PR TITLE
Fix the issue that first background files are in double precession while mpas-bundle in single-precession.

### DIFF
--- a/bin/LinkWarmStartBackgrounds.csh
+++ b/bin/LinkWarmStartBackgrounds.csh
@@ -28,23 +28,24 @@ while ( $member <= $nMembers )
       # Outer loop mesh
       set fcFile = $CyclingFCDirs[$member]/${FCFilePrefix}.${nextFirstFileDate}.nc
       set InitialMemberFC = "$firstbackground__directoryOuter"`${memberDir} 2 $member "${firstbackground__memberFormatOuter}"`
-      ln -sfv ${InitialMemberFC}/${firstbackground__filePrefixOuter}.*.nc ${fcFile}${OrigFileSuffix}
-      set varinfo = `ncdump -h ${fcFile}${OrigFileSuffix} | grep surface_pressure`
-      if ( "$varinfo" =~ "*double*" ) then
-         if ( "$bundlePrecision" == "single" ) then
-            ncpdq -5 --pck_map=dbl_flt ${fcFile}${OrigFileSuffix} ${fcFile}
-         else
-            mv ${fcFile}${OrigFileSuffix} ${fcFile}
-         endif
-      else if ( "$varinfo" =~ "*float*" ) then
-         if ( "$bundlePrecision" == "double" ) then
-            ncpdq -5 --pck_map=flt_dbl ${fcFile}${OrigFileSuffix} ${fcFile}
-         else
-            mv ${fcFile}${OrigFileSuffix} ${fcFile}
-         endif
-      else
-         echo "netCDF file Error: ${fcFile}${OrigFileSuffix}"
-      endif
+      ln -sfv ${InitialMemberFC}/${firstbackground__filePrefixOuter}.*.nc $CyclingFCDirs[$member]/.
+      # Handling double/single precision files
+      foreach file ($CyclingFCDirs[$member]/*.nc)
+        set varinfo = `ncdump -h ${file} | grep surface_pressure`
+        if ( "$varinfo" =~ "*double*" ) then
+           if ( "$bundlePrecision" == "single" ) then
+              mv ${file} ${file}${OrigFileSuffix}
+              ncpdq -5 --pck_map=dbl_flt ${file}${OrigFileSuffix} ${file}
+           endif
+        else if ( "$varinfo" =~ "*float*" ) then
+           if ( "$bundlePrecision" == "double" ) then
+              mv ${file} ${file}${OrigFileSuffix}
+              ncpdq -5 --pck_map=flt_dbl ${file}${OrigFileSuffix} ${file}
+           endif
+        else
+           echo "netCDF file Error: ${fcFile}${OrigFileSuffix}"
+        endif
+      end
 
       # Inner loop mesh
       if ($nCellsOuter != $nCellsInner) then

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -19,6 +19,8 @@ class Build(Component):
     # mpas-bundle build directory
     'mpas bundle': ['/replace/this/in/host/specific/code/below', str],
 
+    'bundle precision': ['single', str, ['single', 'double']],
+
     # optional double-precision build
     #'mpas bundle': ['/glade/work/guerrett/pandac/build/mpas-bundle_gnu-openmpi_22MAR2023', str],
 

--- a/initialize/suites/SuiteBase.py
+++ b/initialize/suites/SuiteBase.py
@@ -79,6 +79,7 @@ class SuiteBase():
     # load conda + activate """ + conda + """
     init-script = '''
 source """ + modScript + """
+module load nco
 module load conda//latest
 conda activate """ + conda + """
 
@@ -90,6 +91,7 @@ conda activate """ + conda + """
     # load conda + activate npl
     init-script = '''
 source """ + modScript + """
+module load nco
 module load conda/latest
 conda activate """ + conda + """
 '''

--- a/initialize/suites/SuiteBase.py
+++ b/initialize/suites/SuiteBase.py
@@ -80,7 +80,7 @@ class SuiteBase():
     init-script = '''
 source """ + modScript + """
 module load nco
-module load conda//latest
+module load conda/latest
 conda activate """ + conda + """
 
 '''


### PR DESCRIPTION
### Description
Our mpas-bundle is commonly built in single precession. However, the first background files are in double precession (i.e. ensemble background at 00Z 15 April 2018). In that case, the analysis output will report error information "ERROR: MPAS IO Error: Inconsistent redefinition of dimension" (@RGNystrom reported). To solve this issue, the NCO is employed to convert double (float) variables to float (double) variables when the mpas-bundle is built in single (double) precision.

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 4denvar_OIE120km_WarmStart
 - [x] letkf_OIE120km_WarmStart