### PR TITLE
Add support for log levels.

### DIFF
--- a/Run.py
+++ b/Run.py
@@ -44,9 +44,9 @@ def main():
   run.execute()
 
 
-class Run():
+class Run(Logger):
   def __init__(self):
-    self.logPrefix = self.__class__.__name__+': '
+    super().__init__()
 
     # Parse command line
     ap = argparse.ArgumentParser()
@@ -77,7 +77,7 @@ class Run():
       print("Running the scenario: "+scenarioFile)
       print("#########################################################################")
 
-      self.clean()
+      self.clean(self)
 
       scenario = Scenario(scenarioFile)
       scenario.initialize()
@@ -88,12 +88,11 @@ class Run():
       suite = SuiteLookup(suiteName, scenario.getConfig())
       suite.submit()
 
-    self.clean()
+    self.clean(self)
 
   @staticmethod
-  def clean():
-    logger = Logger()
-    logger.log('cleaning up auto-generated files...', level=logger.MSG_DEBUG)
+  def clean(self):
+    self.log('cleaning up auto-generated files...', level=self.MSG_DEBUG)
 
     for g in [
       "config/auto/*.csh",

--- a/Run.py
+++ b/Run.py
@@ -26,6 +26,7 @@ import subprocess
 
 # local modules
 from initialize.config.Config import Config
+from initialize.config.Logger import Logger
 from initialize.config.Scenario import Scenario
 from initialize.suites.SuiteBase import SuiteLookup
 
@@ -91,7 +92,8 @@ class Run():
 
   @staticmethod
   def clean():
-    print('cleaning up auto-generated files...')
+    logger = Logger()
+    logger.log('cleaning up auto-generated files...', level=logger.MSG_DEBUG)
 
     for g in [
       "config/auto/*.csh",

--- a/initialize/config/Component.py
+++ b/initialize/config/Component.py
@@ -9,17 +9,22 @@
 
 from collections.abc import Iterable
 
+from initialize.config.Logger import Logger
 from initialize.config.Config import Config
 from initialize.config.TaskFamily import CylcTaskFamily
 from initialize.config.SubConfig import SubConfig
 
-class Component():
+class Component(Logger):
+
   defaults = None
   workDir = None
   requiredVariables = {}
   optionalVariables = {}
   variablesWithDefaults = {}
   def __init__(self, config:Config):
+
+    super().__init__()
+
     self.base = self.__class__.__name__
     self.lower = self.__class__.__name__.lower()
     self.logPrefix = self.__class__.__name__+': '
@@ -83,9 +88,8 @@ class Component():
     self._exportVarsToCsh()
     return
 
-  def _msg(self, text):
-    print(self.logPrefix+text)
-    return
+  def _msg(self, text, *args, **kwargs):
+    self.log(text, *args, **kwargs)
 
   def __getitem__(self, key):
     '''

--- a/initialize/config/Config.py
+++ b/initialize/config/Config.py
@@ -12,13 +12,15 @@ from copy import deepcopy
 import yaml
 import sys
 import traceback
+from initialize.config.Logger import Logger
 
-class Config():
+class Config(Logger):
   def __init__(self,
       filename: str,
       defaultsFile:str = None,
     ):
 
+   super().__init__()
    with open(filename) as file:
      self._table = yaml.load(file, Loader=yaml.FullLoader)
 
@@ -124,7 +126,7 @@ class Config():
         # do we ever want to use the preempt queue? this could lead to starvation.
         #if queue == 'share':
           #newqueue = 'preempt'
-        print('Config converting queue:', queue, ' to:', newqueue)
+        self.log('Config converting queue:', queue, ' to:', newqueue, level=self.MSG_DEBUG)
         if subtable != None:
           self.__setitem2__(subtable, attrName, newqueue)
         else:
@@ -135,7 +137,7 @@ class Config():
         #print('job_priority:', self['job_priority'], ' ', self.has('hpc.job_priority'))
         if subtable == None and self.has('hpc.job_priority') == False and queue in ['economy', 'premium']:
           self.__setitem__('job_priority', queue)
-          print('Adding job_priority ', queue)
+          self.log('Adding job_priority ', queue, level=self.MSG_DEBUG)
 
         '''
         print('################################################################################')

--- a/initialize/config/Logger.py
+++ b/initialize/config/Logger.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+'''
+ (C) Copyright 2023 UCAR
+
+ This software is licensed under the terms of the Apache Licence Version 2.0
+ which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+'''
+
+import os
+
+'''
+class for logging statements conditionally, based on verbosity.
+the value of the CYLC_DEBUG environment variable will control output.
+if CYLC_DEBUG is not set, assume verbosity level 1 (some info, all errors)
+'''
+class Logger():
+
+  # values for passing to log e.g. log("text", level=self.MSG_DEBUG)
+  MSG_QUIET = 0 # always print
+  MSG_NORMAL = 1 # normal output, suppress if CYLC_DEBUG env var is 0
+  MSG_DEBUG = 2 # print if CYLC_DEBUG is >= 2
+  MSG_NOISY = 3 # print if CYLC_DEBUG is >= 3
+  _msg_level = 1
+
+  def __init__(self):
+
+    # set level for printing via self.log()
+    msg_env = os.getenv('CYLC_DEBUG')
+    if msg_env is None:
+      self._msg_level = 1
+    elif msg_env.isdigit():
+      self._msg_level = int(msg_env)
+
+    self.logPrefix = self.__class__.__name__+': '
+
+  def log(self, text, *args, **kwargs):
+    level = kwargs.get('level', 1)
+    if level <= self._msg_level:
+      print(self.logPrefix+text)
+    return
+

--- a/initialize/framework/Experiment.py
+++ b/initialize/framework/Experiment.py
@@ -87,7 +87,7 @@ class Experiment(Component):
     cylcWorkDir = hpc['top directory']+'/'+user+'/cylc-run'
     self._set('cylcWorkDir', cylcWorkDir)
     cmd = ['mkdir', '-p', cylcWorkDir]
-    self._msg(' '.join(cmd))
+    self._msg(' '.join(cmd), level=self.MSG_DEBUG)
     sub = subprocess.run(cmd)
 
     ## absolute experiment directory
@@ -98,23 +98,23 @@ class Experiment(Component):
     self._set('ModelConfigDir', self['mainScriptDir']+'/config/mpas')
     self._set('title', self.PackageBaseName+'--'+self['SuiteName'])
 
-    self._msg('')
+    self._msg('', level=self.MSG_DEBUG)
     self._msg('======================================================================')
     self._msg('Setting up a new suite')
     self._msg('  SuiteName: '+self['SuiteName'])
     self._msg('  mainScriptDir: '+self['mainScriptDir'])
     self._msg('  ExperimentDirectory: '+self['ExperimentDirectory'])
     self._msg('======================================================================')
-    self._msg('')
+    self._msg('', level=self.MSG_DEBUG)
 
     cmd = ['rm', '-rf', self['mainScriptDir']]
-    self._msg(' '.join(cmd))
+    self._msg(' '.join(cmd), level=self.MSG_DEBUG)
     sub = subprocess.run(cmd)
 
     cmd = ['mkdir', '-p', self['mainScriptDir']]
-    self._msg(' '.join(cmd))
+    self._msg(' '.join(cmd), level=self.MSG_DEBUG)
     sub = subprocess.run(cmd)
 
-    self._msg('')
+    self._msg('', level=self.MSG_DEBUG)
 
     self._cshVars = ['cylcWorkDir', 'SuiteName', 'ExperimentDirectory', 'mainScriptDir', 'ConfigDir', 'ModelConfigDir']

--- a/initialize/framework/HPC.py
+++ b/initialize/framework/HPC.py
@@ -72,16 +72,15 @@ class HPC(Component):
 
     self.variablesWithDefaults['top directory'] = [topdir, str]
     self.variablesWithDefaults['TMPDIR'] = [topdir + '/{{USER}}/temp', str]
-    self._msg('vars'+ str(self.variablesWithDefaults))
-    self._msg('init######################################################################')
-    #print('config:', dir(config))
-    #self._msg('table:'+ str(config._table))
     super().__init__(config)
+    self._msg('vars'+ str(self.variablesWithDefaults), level=self.MSG_DEBUG)
+    self._msg('config:', dir(config), level=self.MSG_NOISY)
+    self._msg('table:'+ str(config._table), level=self.MSG_NOISY)
 
     user = os.getenv('USER')
     TMPDIR = self['TMPDIR'].replace('{{USER}}', user)
     cmd = ['mkdir', '-p', TMPDIR]
-    print(' '.join(cmd))
+    self._msg(' '.join(cmd), level=self.MSG_DEBUG)
     sub = subprocess.run(cmd)
 
     # default multi-processor task
@@ -101,6 +100,7 @@ class HPC(Component):
     }
     singlejob = Resource(self._conf, attr, ('job', 'single proc'))
     self.singletask = TaskLookup[self.system](singlejob)
+    self._msg('init ######################################################################', level=self.MSG_DEBUG)
 
   def maxMemPerNode(self):
     return self.multitask.maxMemPerNode

--- a/initialize/suites/SuiteBase.py
+++ b/initialize/suites/SuiteBase.py
@@ -10,14 +10,16 @@
 import os
 import subprocess
 
+from initialize.config.Logger import Logger
 from initialize.config.Config import Config
 from initialize.config.TaskFamily import placeholdertask
 
 from initialize.framework.HPC import HPC
 from initialize.framework.Workflow import Workflow
 
-class SuiteBase():
+class SuiteBase(Logger):
   def __init__(self, conf:Config):
+    super().__init__()
     self.c = {}
     self.c['hpc'] = HPC(conf)
     self.c['workflow'] = Workflow(conf)
@@ -38,18 +40,18 @@ class SuiteBase():
     elif host == "cheyenne":
       self.suiteFileName = 'suite.rc'
 
-  def __msg(self, text):
-    print(self.logPrefix+text)
+  def __msg(self, text, *args, **kwargs):
+    self.log(text, *args, **kwargs)
     return
 
   def submit(self):
     scriptDir = self.c['experiment']['mainScriptDir']
     cmd = ['rm', '-rf', scriptDir]
-    self.__msg(' '.join(cmd))
+    self.__msg(' '.join(cmd), level=self.MSG_DEBUG)
     sub = subprocess.run(cmd)
 
     cmd = ['mkdir', '-p', scriptDir]
-    self.__msg(' '.join(cmd))
+    self.__msg(' '.join(cmd), level=self.MSG_DEBUG)
     sub = subprocess.run(cmd)
 
     host = os.getenv('NCAR_HOST')
@@ -133,11 +135,11 @@ conda activate """ + conda + """
     ]
     for spec in suiteSpec:
       cmd = ['cp', '-rP', spec, scriptDir+'/']
-      self.__msg(' '.join(cmd))
+      self.__msg(' '.join(cmd), level=self.MSG_DEBUG)
       sub = subprocess.run(cmd)
 
     cmd = ['./submit.csh']
-    self.__msg(' '.join(cmd))
+    self.__msg(' '.join(cmd), level=self.MSG_DEBUG)
     sub = subprocess.run(cmd)
 
   def __export(self):

--- a/submit.csh
+++ b/submit.csh
@@ -13,7 +13,14 @@
 
 set workflow_dir="MPAS-Workflow"
 
-echo "$0 (INFO): Generating the scenario-specific ${workflow_dir} directory"
+# set up how much to log
+if (! $?CYLC_DEBUG) then
+   set CYLC_DEBUG=1
+endif
+
+if ( $CYLC_DEBUG > 1) then
+  echo "$0 (INFO): Generating the scenario-specific ${workflow_dir} directory"
+endif
 
 # Create/copy the task shell scripts
 
@@ -21,7 +28,9 @@ echo "$0 (INFO): Generating the scenario-specific ${workflow_dir} directory"
 source config/auto/experiment.csh
 
 ## Change to the cylc suite directory
-echo $0 cd ${mainScriptDir}
+if ( $CYLC_DEBUG > 1) then
+  echo $0 cd ${mainScriptDir}
+endif
 cd ${mainScriptDir}
 
 set NCARHOST=$NCAR_HOST
@@ -31,8 +40,10 @@ if ( "$NCARHOST" == "derecho" ) then
     setenv CYLC_ENV /glade/work/jwittig/conda-envs/my-cylc8.2
   endif
 
-  echo $0 conda activate $CYLC_ENV
-  conda activate $CYLC_ENV
+  if ( $CYLC_DEBUG > 1) then
+    echo $0 conda activate $CYLC_ENV
+  endif
+  conda activate $CYLC_ENV >& /dev/null
   #set cylc_timeout="--comms-timeout=10"
 else if ( "$NCARHOST" == "cheyenne" ) then
   module purge
@@ -57,8 +68,10 @@ if ( "$NCARHOST" == "derecho" ) then
     cylc stop --kill ${workflow_dir}/$SuiteName
     sleep 5
   else
-    echo "$0 (INFO): confirmed that a cylc suite named $SuiteName is not already running"
-    echo "$0 (INFO): starting a new suite..."
+    if ( $CYLC_DEBUG > 1) then
+      echo "$0 (INFO): confirmed that a cylc suite named $SuiteName is not already running"
+      echo "$0 (INFO): starting a new suite..."
+    endif
   endif
 else if ( "$NCARHOST" == "cheyenne" ) then
   echo $0 cylc poll $SuiteName 
@@ -74,22 +87,30 @@ else if ( "$NCARHOST" == "cheyenne" ) then
   endif
 endif
 
-echo $0 cylcWorkDir  ${cylcWorkDir}
-echo $0 SuiteName ${SuiteName}
-echo $0 mainScriptDir ${mainScriptDir}
+if ( $CYLC_DEBUG > 1) then
+  echo $0 cylcWorkDir  ${cylcWorkDir}
+  echo $0 SuiteName ${SuiteName}
+  echo $0 mainScriptDir ${mainScriptDir}
+endif
 rm -rf ${cylcWorkDir}/${SuiteName}
 
 if ( "$NCARHOST" == "derecho" ) then
   if ( -e ~/cylc-run/${workflow_dir}/${SuiteName} ) then
-    echo $0 cylc clean ${workflow_dir}/${SuiteName}
-    cylc clean ${workflow_dir}/${SuiteName}
+    if ( $CYLC_DEBUG > 1) then
+      echo $0 cylc clean ${workflow_dir}/${SuiteName}
+    endif
+    cylc clean ${workflow_dir}/${SuiteName} >& /dev/null
   #  echo "Already has this suite, replay it"
   endif
   echo $0 cylc install --run-name=${SuiteName}
-  cylc install --run-name=${SuiteName}
-  echo $0  cylc validate ${workflow_dir}/${SuiteName}
+  cylc install --run-name=${SuiteName} >& /dev/null
+  if ( $CYLC_DEBUG > 1) then
+    echo $0  cylc validate ${workflow_dir}/${SuiteName}
+  endif
   cylc validate ${workflow_dir}/${SuiteName}
-  echo $0 cylc play ${workflow_dir}/${SuiteName}
+  if ( $CYLC_DEBUG > 1) then
+    echo $0 cylc play ${workflow_dir}/${SuiteName}
+  endif
   cylc play ${workflow_dir}/${SuiteName}
 else if ( "$NCARHOST" == "cheyenne" ) then
   echo "$0 (INFO): register, validate, and run the suite:", ${SuiteName}


### PR DESCRIPTION
### Description
Different log levels will result in more or fewer log messages.
The level is controlled by the CYLC_DEBUG environment variable.
A value of 0 has the fewest messages, a value of 3 is the most verbose.
Default value (if CYLC_DEBUG is not set) is level 1.

To set the logging verbosity, before invoking Run.py or test.csh set CYLC_DEBUG
bash: `export CYLC_DEBUG=0`
tcsh: `setenv CYLC_DEBUG 0`

level 1 will show 
```
#########################################################################
Running the scenario: test/testinput/3dvar_OIE120km_WarmStart.yaml
#########################################################################
Experiment: ======================================================================
Experiment: Setting up a new suite
Experiment:   SuiteName: jwittig_3dvar_OIE120km_WarmStart_TEST
Experiment:   mainScriptDir: /glade/derecho/scratch/jwittig/pandac/jwittig_3dvar_OIE120km_WarmStart_TEST/MPAS-Workflow
Experiment:   ExperimentDirectory: /glade/derecho/scratch/jwittig/pandac/jwittig_3dvar_OIE120km_WarmStart_TEST
Experiment: ======================================================================
./submit.csh cylc version: 8.2.2
./submit.csh (INFO): checking if a suite with the same name is already running
./submit.csh cylc install --run-name=jwittig_3dvar_OIE120km_WarmStart_TEST
Valid for cylc-8.2.2

 ▪ ■  Cylc Workflow Engine 8.2.2
 ██   Copyright (C) 2008-2023 NIWA
▝▘    & British Crown (Met Office) & Contributors
```

level 0 will show the same, excluding the `Experiment` lines
level 2 will show similar output you see before this PR.
level 3 will show a little more than level 2.

### Issue closed

Closes #(if applicable)

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT 
    - This failed due to missing data files for the ExtendedMeanFC steps. File `x1.655362.graph.info.part.128` is missing.

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
