### PR TITLE
Add run time command switch to specify the mpas-bundle build directory

### DIFF
--- a/Run.py
+++ b/Run.py
@@ -51,11 +51,13 @@ class Run():
     ap = argparse.ArgumentParser()
     ap.add_argument('config', type=str,
                     help='configuration file; e.g., runs/test.yaml, scenarios/{{scenarioName}}.yaml')
+    ap.add_argument('-b', '--bundle_dir', help='mpas bundle directory')
+    ap.add_argument('-x', '--suffix', help='experiment name suffix')
     args = ap.parse_args()
     assert Path(args.config).is_file(), (self.logPrefix+'config ('+args.config+') does not exist')
 
     self.__configFile = args.config
-    self.__config = Config(args.config)
+    self.__config = Config(args.config, args.bundle_dir, args.suffix)
 
   def execute(self):
     '''
@@ -78,7 +80,7 @@ class Run():
 
       self.clean()
 
-      scenario = Scenario(scenarioFile)
+      scenario = Scenario(scenarioFile, self.__config._bundle_dir, self.__config._suffix)
       scenario.initialize()
 
       # suite name (defaults to Cycle)

--- a/initialize/config/Config.py
+++ b/initialize/config/Config.py
@@ -16,17 +16,26 @@ import traceback
 class Config():
   def __init__(self,
       filename: str,
+      bundle_dir: str,
+      suffix: str,
       defaultsFile:str = None,
     ):
 
    with open(filename) as file:
      self._table = yaml.load(file, Loader=yaml.FullLoader)
 
+   self._bundle_dir = bundle_dir
+   self._suffix = suffix
    if defaultsFile is not None:
      with open(defaultsFile) as file:
        self._defaults = yaml.load(file, Loader=yaml.FullLoader)
    else:
      self._defaults = {}
+
+  def __str__(self):
+    bd =  (self._bundle_dir if self._bundle_dir != None else 'None')
+    suffix =  (self._suffix if self._suffix != None else 'None')
+    return 'bundle_dir:' + bd + ' suffix:' + suffix
 
   def extract(self, subKey: str, defaultsFile:str = None):
     tab = deepcopy(self._table.get(subKey, {}))

--- a/initialize/config/Scenario.py
+++ b/initialize/config/Scenario.py
@@ -10,8 +10,8 @@
 from initialize.config.Config import Config
 
 class Scenario():
-  def __init__(self, file):
-    self.__conf = Config(file)
+  def __init__(self, file, bundle, suffix):
+    self.__conf = Config(file, bundle, suffix)
     self.__script = [
 '''#!/bin/csh -f
 

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -40,7 +40,10 @@ class Build(Component):
     # set system dependent defaults before invoking Component ctor
     system = os.getenv('NCAR_HOST')
     if system == 'derecho':
-      self.variablesWithDefaults['mpas bundle'] = \
+      if config._bundle_dir != None:
+        self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
+      else:
+        self.variablesWithDefaults['mpas bundle'] = \
           ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_dev_SP/mpas-bundle/build', str]
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]

--- a/initialize/framework/Experiment.py
+++ b/initialize/framework/Experiment.py
@@ -78,6 +78,11 @@ class Experiment(Component):
     if self['prefix'] is None:
       self._set('prefix', user+'_')
 
+    # if config has a suffix, use it
+    if config._suffix != None:
+      suffix = self['suffix'] if self['suffix'] != None else ''
+      self._set('suffix', suffix + config._suffix)
+
     ParentDirectory = hpc['top directory']+'/'+self['user directory']+'/'+self['user directory child']
 
     expName = self['prefix']+suiteName+self['suffix']


### PR DESCRIPTION
Add run time command switch to specify the mpas-bundle build directory.
Also add a run time switch to specify a scenario name suffix

Output of running `./Run.py -h`:
```
usage: Run.py [-h] [-b BUNDLE_DIR] [-x SUFFIX] config

positional arguments:
  config                configuration file; e.g., runs/test.yaml, scenarios/{{scenarioName}}.yaml

options:
  -h, --help            show this help message and exit
  -b BUNDLE_DIR, --bundle_dir BUNDLE_DIR
                        mpas bundle directory
  -x SUFFIX, --suffix SUFFIX
                        experiment name suffix
```
Note this change is backward compatible, `Run.py <config>` works as it used to.

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart_

The following tests failed when specifying an mpas-bundle build of the develop branch:
  - 3dvar_O30kmIE60km_ColdStart
  - 3dvar_OIE120km_ColdStart
  
#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
