### PR TITLE
Only remove output files for the current member in Variational.csh

### DIFF
--- a/bin/EnKF.csh
+++ b/bin/EnKF.csh
@@ -82,14 +82,14 @@ endif
 # Remove obs-database output files
 # ================================
 if ("$retainObsFeedback" != True) then
-  set member = 1
-  while ( $member <= ${nMembers} )
-    set memDir = `${memberDir} $nMembers $member`
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${obsPrefix}*.h5
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${geoPrefix}*.nc4
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${diagPrefix}*.nc4
-    @ member++
-  end
+  echo " ls ${self_WorkDir}/${OutDBDir}/"
+  ls ${self_WorkDir}/${OutDBDir}/
+  echo "rm ${self_WorkDir}/${OutDBDir}/${obsPrefix}*.h5"
+  rm ${self_WorkDir}/${OutDBDir}/${obsPrefix}*.h5
+  echo "rm ${self_WorkDir}/${OutDBDir}/${geoPrefix}*.nc4"
+  rm ${self_WorkDir}/${OutDBDir}/${geoPrefix}*.nc4
+  echo "rm ${self_WorkDir}/${OutDBDir}/${diagPrefix}*.nc4"
+  rm ${self_WorkDir}/${OutDBDir}/${diagPrefix}*.nc4
 endif
 
 # Remove netcdf lock files

--- a/bin/Variational.csh
+++ b/bin/Variational.csh
@@ -120,14 +120,15 @@ endif
 # Remove obs-database output files
 # ================================
 if ("$retainObsFeedback" != True) then
-  set member = 1
-  while ( $member <= ${nMembers} )
-    set memDir = `${memberDir} $nMembers $member`
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${obsPrefix}*.h5
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${geoPrefix}*.nc4
-    rm ${self_WorkDir}/${OutDBDir}${memDir}/${diagPrefix}*.nc4
-    @ member++
-  end
+  set memDir = `${memberDir} $nMembers $ArgMember`
+  echo "ls ${self_WorkDir}/${OutDBDir}${memDir}/"
+  ls ${self_WorkDir}/${OutDBDir}${memDir}/
+  echo "rm ${self_WorkDir}/${OutDBDir}${memDir}/${obsPrefix}*.h5"
+  rm ${self_WorkDir}/${OutDBDir}${memDir}/${obsPrefix}*.h5
+  echo "rm ${self_WorkDir}/${OutDBDir}${memDir}/${geoPrefix}*.nc4"
+  rm ${self_WorkDir}/${OutDBDir}${memDir}/${geoPrefix}*.nc4
+  echo "rm ${self_WorkDir}/${OutDBDir}${memDir}/${diagPrefix}*.nc4"
+  rm ${self_WorkDir}/${OutDBDir}${memDir}/${diagPrefix}*.nc4
 endif
 
 # Remove netcdf lock files
@@ -136,6 +137,7 @@ rm */*.nc*.lock
 
 # Remove copies of templated fields files for inner loop
 if ("${TemplateFieldsFileInner}" != "${TemplateFieldsFileOuter}") then
+  echo "rm ${TemplateFieldsFileInner}*"
   rm ${TemplateFieldsFileInner}*
 endif
 


### PR DESCRIPTION
Also remove output files from the dbOut directory in EnKF.csh

### Description

### Issue closed

Closes #(if applicable)

### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart (this tested the changes to Variational.csh)
 - [x] getkf_OIE120km_WarmStart (this tested the changes to EnKF,csh)
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
