### PR TITLE
Use 48h late prepbufr file as default

### DIFF
--- a/bin/GetObs.csh
+++ b/bin/GetObs.csh
@@ -77,15 +77,15 @@ foreach inst ( ${convertToIODAObservations} )
        endif
     # for prepbufr observations
     else if ( ${inst} == prepbufr ) then
-       setenv THIS_FILE prepbufr.gdas.${thisValidDate}.nr
+       setenv THIS_FILE prepbufr.gdas.${ccyymmdd}.t${hh}z.nr.48h
        if ( ! -e ${THIS_FILE}) then
-          if ( -e ${PrepBUFRDirectory}/prepnr/${ccyy}/${THIS_FILE} ) then
-             echo "Source file: ${PrepBUFRDirectory}/prepnr/${ccyy}/${THIS_FILE}"
-             cp -p ${PrepBUFRDirectory}/prepnr/${ccyy}/${THIS_FILE} .
-          else
-             setenv THIS_FILE prepbufr.gdas.${ccyymmdd}.t${hh}z.nr.48h
+          if ( -e ${PrepBUFRDirectory}/prep48h/${ccyy}/${THIS_FILE} ) then
              echo "Source file: ${PrepBUFRDirectory}/prep48h/${ccyy}/${THIS_FILE}"
              cp -p ${PrepBUFRDirectory}/prep48h/${ccyy}/${THIS_FILE} .
+          else
+             setenv THIS_FILE prepbufr.gdas.${thisValidDate}.nr
+             echo "Source file: ${PrepBUFRDirectory}/prepnr/${ccyy}/${THIS_FILE}"
+             cp -p ${PrepBUFRDirectory}/prepnr/${ccyy}/${THIS_FILE} .
           endif
        endif
        # use obs errors embedded in prepbufr file


### PR DESCRIPTION
### Description
@liujake noticed the obs number of aircraft is very low when we use observation from `prepnr` directory.
This PR uses the prepbufr file with 48h time lag as default (in RDA `prep48h` directory). If the file does not exist in `prep48` directory, we will use prepbufr file from `prepnr` directory.

### Files modified:
M   bin/GetObs.csh
### Tests completed
 - [x] GenerateObs
