### PR TITLE
Update bias correction yamls and coefficients file following naming convention

### DIFF
--- a/bin/PrepJEDI.csh
+++ b/bin/PrepJEDI.csh
@@ -333,6 +333,7 @@ foreach instrument ($observers)
       # if no obs file exists, link satbias file from the previous cycle
       if ( ! -f ${InDBDir}/${instrument}_obs_${thisValidDate}.h5 ) then
         ln -sf ${biasCorrectionDir}/satbias_${i}.h5 ${DAWorkDir}/${thisValidDate}/dbOut
+        ln -sf ${biasCorrectionDir}/satbias_cov_${i}.h5 ${DAWorkDir}/${thisValidDate}/dbOut
       endif
     endif
   end

--- a/config/jedi/ObsPlugs/da/bias/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/da/bias/abi_g16.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors:
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &abig16tlap {{fixedTlapmeanCov}}/abi_g16_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *abig16tlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/da/bias/ahi_himawari8.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors:
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &ahihimawari8tlap {{fixedTlapmeanCov}}/ahi_himawari8_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *ahihimawari8tlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/bias/amsua_aqua.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors5
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &amsuaaquatlap {{fixedTlapmeanCov}}/amsua_aqua_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *amsuaaquatlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/bias/amsua_metop-a.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors4
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &amsuametopatlap {{fixedTlapmeanCov}}/amsua_metop-a_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *amsuametopatlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/bias/amsua_metop-b.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors4
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &amsuametopbtlap {{fixedTlapmeanCov}}/amsua_metop-b_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *amsuametopbtlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/amsua_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/bias/amsua_metop-c.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors4
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &amsuametopctlap {{fixedTlapmeanCov}}/amsua_metop-c_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *amsuametopctlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/da/bias/amsua_n15.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors2
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &amsua15tlap {{fixedTlapmeanCov}}/amsua_n15_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *amsua15tlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/da/bias/amsua_n18.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors3
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &amsua18tlap {{fixedTlapmeanCov}}/amsua_n18_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *amsua18tlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/da/bias/amsua_n19.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors1
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &amsua19tlap {{fixedTlapmeanCov}}/amsua_n19_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *amsua19tlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/iasi_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/bias/iasi_metop-a.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors:
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &iasimetopatlap {{fixedTlapmeanCov}}/iasi_metop-a_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *iasimetopatlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/iasi_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/bias/iasi_metop-b.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors:
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &iasimetopbtlap {{fixedTlapmeanCov}}/iasi_metop-b_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *iasimetopbtlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/iasi_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/bias/iasi_metop-c.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors:
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &iasimetopctlap {{fixedTlapmeanCov}}/iasi_metop-c_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *iasimetopctlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_metop-a.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors1
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &mhsmetopatlap {{fixedTlapmeanCov}}/mhs_metop-a_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *mhsmetopatlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_metop-b.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors1
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &mhsmetopbtlap {{fixedTlapmeanCov}}/mhs_metop-b_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *mhsmetopbtlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_n18.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors1
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &mhs18tlap {{fixedTlapmeanCov}}/mhs_n18_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *mhs18tlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/config/jedi/ObsPlugs/da/bias/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_n19.yaml
@@ -4,19 +4,19 @@
     variational bc:
       predictors: &predictors1
       - name: constant
-      - name: lapse_rate
+      - name: lapseRate
         order: 2
         tlapse: &mhs19tlap {{fixedTlapmeanCov}}/mhs_n19_tlapmean.txt
-      - name: lapse_rate
+      - name: lapseRate
         tlapse: *mhs19tlap
-      - name: emissivity
-      - name: scan_angle
+      - name: emissivityJacobian
+      - name: sensorScanAngle
         order: 4
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 3
-      - name: scan_angle
+      - name: sensorScanAngle
         order: 2
-      - name: scan_angle
+      - name: sensorScanAngle
     covariance:
       minimal required obs number: 20
       variance range: [1.0e-6, 10.]

--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -85,9 +85,9 @@ class Observations(Component):
     'CRTMTABLES': ['/glade/work/nystrom/Code/JEDI/jcsda_internal/CRTM_V3_coeffs/', str],
 
     # static directories for bias correction files
-    'fixedCoeff': ['/glade/campaign/mmm/parc/jban/pandac/satbias_20240512', str],
-    'fixedTlapmeanCov': ['/glade/campaign/mmm/parc/jban/pandac/satbias_20240512/2023', str],
-    'initialVARBCcoeff': ['/glade/campaign/mmm/parc/jban/pandac/satbias_20240512/2023', str],
+    'fixedCoeff': ['/glade/campaign/mmm/parc/jban/pandac_common/obs/satbias', str],
+    'fixedTlapmeanCov': ['/glade/campaign/mmm/parc/jban/pandac_common/obs/satbias/2023', str],
+    'initialVARBCcoeff': ['/glade/campaign/mmm/parc/jban/pandac_common/obs/satbias/2023', str],
   }
 
   def __init__(self,

--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -85,9 +85,9 @@ class Observations(Component):
     'CRTMTABLES': ['/glade/work/nystrom/Code/JEDI/jcsda_internal/CRTM_V3_coeffs/', str],
 
     # static directories for bias correction files
-    'fixedCoeff': ['/glade/campaign/mmm/parc/liuz/pandac_common/obs/satbias', str],
-    'fixedTlapmeanCov': ['/glade/campaign/mmm/parc/liuz/pandac_common/obs/satbias/2018', str],
-    'initialVARBCcoeff': ['/glade/campaign/mmm/parc/liuz/pandac_common/obs/satbias/2018', str],
+    'fixedCoeff': ['/glade/campaign/mmm/parc/jban/pandac/satbias_20240512', str],
+    'fixedTlapmeanCov': ['/glade/campaign/mmm/parc/jban/pandac/satbias_20240512/2023', str],
+    'initialVARBCcoeff': ['/glade/campaign/mmm/parc/jban/pandac/satbias_20240512/2023', str],
   }
 
   def __init__(self,

--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -86,8 +86,8 @@ class Observations(Component):
 
     # static directories for bias correction files
     'fixedCoeff': ['/glade/campaign/mmm/parc/jban/pandac_common/obs/satbias', str],
-    'fixedTlapmeanCov': ['/glade/campaign/mmm/parc/jban/pandac_common/obs/satbias/2023', str],
-    'initialVARBCcoeff': ['/glade/campaign/mmm/parc/jban/pandac_common/obs/satbias/2023', str],
+    'fixedTlapmeanCov': ['/glade/campaign/mmm/parc/jban/pandac_common/obs/satbias/2018', str],
+    'initialVARBCcoeff': ['/glade/campaign/mmm/parc/jban/pandac_common/obs/satbias/2018', str],
   }
 
   def __init__(self,

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -41,7 +41,7 @@ class Build(Component):
     system = os.getenv('NCAR_HOST')
     if system == 'derecho':
       self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_dev_SP/mpas-bundle/build', str]
+          ['/glade/campaign/mmm/parc/jban/pandac/bundle/20240605/build_SP', str]
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]
       self.variablesWithDefaults['forecast directory'] = ['bundle', str]


### PR DESCRIPTION
### Description
This is a follow up PR for the naming convention in UFO and IODA (https://github.com/JCSDA-internal/ufo/pull/3015, https://github.com/JCSDA-internal/ioda/pull/1092). 
- Updated yamls (satellite bias part) for predictor name, 
- Updated static directories for bias correction files. 

And one bug fix for linking satbias_cov_* files if satellite obs file is missing (contributed by @mos3r3n ).

### Files modified
M       bin/PrepJEDI.csh
M       config/jedi/ObsPlugs/da/bias/abi_g16.yaml
M       config/jedi/ObsPlugs/da/bias/ahi_himawari8.yaml
M       config/jedi/ObsPlugs/da/bias/amsua_aqua.yaml
M       config/jedi/ObsPlugs/da/bias/amsua_metop-a.yaml
M       config/jedi/ObsPlugs/da/bias/amsua_metop-b.yaml
M       config/jedi/ObsPlugs/da/bias/amsua_metop-c.yaml
M       config/jedi/ObsPlugs/da/bias/amsua_n15.yaml
M       config/jedi/ObsPlugs/da/bias/amsua_n18.yaml
M       config/jedi/ObsPlugs/da/bias/amsua_n19.yaml
M       config/jedi/ObsPlugs/da/bias/iasi_metop-a.yaml
M       config/jedi/ObsPlugs/da/bias/iasi_metop-b.yaml
M       config/jedi/ObsPlugs/da/bias/iasi_metop-c.yaml
M       config/jedi/ObsPlugs/da/bias/mhs_metop-a.yaml
M       config/jedi/ObsPlugs/da/bias/mhs_metop-b.yaml
M       config/jedi/ObsPlugs/da/bias/mhs_n18.yaml
M       config/jedi/ObsPlugs/da/bias/mhs_n19.yaml
M       initialize/data/Observations.py
M       initialize/framework/Build.py

### Tests completed
#### Tier 1:
 - [x] 3denvar_OIE120km_WarmStart_VarBC


#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
