### PR TITLE
[Draft] Updates for using the public MPAS-Dev/MPAS_Model in mpas-bundle.

### DIFF
--- a/bin/PrepJEDI.csh
+++ b/bin/PrepJEDI.csh
@@ -1162,8 +1162,8 @@ if ("$ArgAppType" == variational) then
     set an = $CyclingDAOutDirs[$member]
     mkdir -p ${an}
     set anFile = ${an}/${ANFilePrefix}.$thisMPASFileDate.nc
-    rm ${anFile}
-    cp -v ${bgFile} ${anFile}
+    rm ${anFile}*
+    cp -v ${bgFile} ${anFile}.bak
 
     @ member++
   end
@@ -1223,8 +1223,8 @@ else if ("$ArgAppType" == enkf) then
     set an = $CyclingDAOutDirs[$member]
     mkdir -p ${an}
     set anFile = ${an}/${ANFilePrefix}.$thisMPASFileDate.nc
-    rm ${anFile}
-    cp -v ${bgFile} ${anFile}
+    rm ${anFile}*
+    cp -v ${bgFile} ${anFile}.bak
 
     @ member++
   end

--- a/bin/Variational.csh
+++ b/bin/Variational.csh
@@ -115,6 +115,14 @@ if ( $status != 0 ) then
   exit 1
 endif
 
+# Update state variables of analysis
+set an = $CyclingDAOutDirs[$ArgMember]
+set anFile = ${ANFilePrefix}.$thisMPASFileDate.nc
+cd ${an}
+mv ${anFile} ${anFile}.new
+mv ${anFile}.bak ${anFile}
+$update_analysis_states -i ${anFile}.new -o ${anFile}
+
 # ================================================================================================
 
 # Remove obs-database output files

--- a/config/mpas/forecast/streams.atmosphere
+++ b/config/mpas/forecast/streams.atmosphere
@@ -1,5 +1,5 @@
 <streams>
-<immutable_stream name="static"
+<immutable_stream name="invariant"
                   type="input"
                   precision="{{PRECISION}}"
                   filename_template="{{StaticFieldsPrefix}}.{{nCells}}.nc"

--- a/config/mpas/hofx/streams.atmosphere
+++ b/config/mpas/hofx/streams.atmosphere
@@ -1,5 +1,5 @@
 <streams>
-<immutable_stream name="static"
+<immutable_stream name="invariant"
                   type="input"
                   precision="{{PRECISION}}"
                   filename_template="{{StaticFieldsPrefix}}.{{nCells}}.nc"

--- a/config/mpas/rtpp/streams.atmosphere
+++ b/config/mpas/rtpp/streams.atmosphere
@@ -1,5 +1,5 @@
 <streams>
-<immutable_stream name="static"
+<immutable_stream name="invariant"
                   type="input"
                   precision="{{PRECISION}}"
                   filename_template="{{StaticFieldsPrefix}}.{{nCells}}.nc"

--- a/config/mpas/saca/streams.atmosphere
+++ b/config/mpas/saca/streams.atmosphere
@@ -1,5 +1,5 @@
 <streams>
-<immutable_stream name="static"
+<immutable_stream name="invariant"
                   type="input"
                   filename_template="{{StaticFieldsPrefix}}.{{nCells}}.nc"
                   precision="{{PRECISION}}"

--- a/config/mpas/variational/streams.atmosphere
+++ b/config/mpas/variational/streams.atmosphere
@@ -1,5 +1,5 @@
 <streams>
-<immutable_stream name="static"
+<immutable_stream name="invariant"
                   type="input"
                   precision="{{PRECISION}}"
                   filename_template="{{StaticFieldsPrefix}}.{{nCells}}.nc{{TemplateFieldsMember}}"

--- a/config/tools.csh
+++ b/config/tools.csh
@@ -22,6 +22,7 @@ set pyTools = ( \
   update_sensorScanPosition \
   updateXTIME \
   concatenate \
+  update_analysis_states \
 )
 foreach tool ($pyTools)
   setenv ${tool} "python ${pyDir}/${tool}.py"

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -41,7 +41,7 @@ class Build(Component):
     system = os.getenv('NCAR_HOST')
     if system == 'derecho':
       self.variablesWithDefaults['mpas bundle'] = \
-        ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_saca_dev_10Jun2024/build_SP', str]
+        ['/glade/u/home/taosun/work/Derecho/JEDI/mpas-bundle-dev/build', str]
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]
       self.variablesWithDefaults['forecast directory'] = ['bundle', str]

--- a/scenarios/defaults/model.yaml
+++ b/scenarios/defaults/model.yaml
@@ -36,7 +36,7 @@ model:
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
       SfcLayer: sf_mynn
-      LSM: noah
+      LSM: sf_noah
     30km:
       meshRatio: 1
       nCells: 655362
@@ -53,7 +53,7 @@ model:
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
       SfcLayer: sf_monin_obukhov
-      LSM: noah
+      LSM: sf_noah
     60km:
       meshRatio: 1
       nCells: 163842
@@ -70,7 +70,7 @@ model:
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
       SfcLayer: sf_monin_obukhov
-      LSM: noah
+      LSM: sf_noah
     120km:
       meshRatio: 1
       nCells: 40962
@@ -87,4 +87,4 @@ model:
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
       SfcLayer: sf_monin_obukhov
-      LSM: noah
+      LSM: sf_noah

--- a/tools/update_analysis_states.py
+++ b/tools/update_analysis_states.py
@@ -1,0 +1,30 @@
+import argparse
+import netCDF4 as nc
+def update_variables(file1_path, file2_path):
+    # Open the netCDF files
+    nc1 = nc.Dataset(file1_path, 'r')
+    nc2 = nc.Dataset(file2_path, 'a')
+    # Get variables from both files
+    vars_file1 = list(nc1.variables.keys())
+    vars_file2 = list(nc2.variables.keys())
+    # Loop through variables in the second file
+    for var_name in vars_file2:
+        # Check if the variable is present in the first file
+        if var_name in vars_file1:
+            print("processing variable:", var_name)
+            # Get the variable object from both files
+            var1 = nc1.variables[var_name]
+            var2 = nc2.variables[var_name]
+            # Update values of the variable in the second file
+            var2[:] = var1[:]
+    # Close the netCDF files
+    nc1.close()
+    nc2.close()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='update analysis variables in the background file from the analysis file', formatter_class=argparse.Argum
+entDefaultsHelpFormatter)
+    parser.add_argument('-i', '--filein', help='analysis file', type=str, required=True)
+    parser.add_argument('-o', '--fileout', help='background file', type=str, required=True)
+    args = parser.parse_args()
+    update_variables(args.filein, args.fileout)

--- a/tools/update_analysis_states.py
+++ b/tools/update_analysis_states.py
@@ -1,12 +1,15 @@
 import argparse
 import netCDF4 as nc
+
 def update_variables(file1_path, file2_path):
     # Open the netCDF files
     nc1 = nc.Dataset(file1_path, 'r')
     nc2 = nc.Dataset(file2_path, 'a')
+
     # Get variables from both files
     vars_file1 = list(nc1.variables.keys())
     vars_file2 = list(nc2.variables.keys())
+
     # Loop through variables in the second file
     for var_name in vars_file2:
         # Check if the variable is present in the first file
@@ -15,16 +18,19 @@ def update_variables(file1_path, file2_path):
             # Get the variable object from both files
             var1 = nc1.variables[var_name]
             var2 = nc2.variables[var_name]
+
             # Update values of the variable in the second file
             var2[:] = var1[:]
+
     # Close the netCDF files
     nc1.close()
     nc2.close()
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='update analysis variables in the background file from the analysis file', formatter_class=argparse.Argum
-entDefaultsHelpFormatter)
+
+    parser = argparse.ArgumentParser(description='update analysis variables in the background file from the analysis file', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('-i', '--filein', help='analysis file', type=str, required=True)
     parser.add_argument('-o', '--fileout', help='background file', type=str, required=True)
     args = parser.parse_args()
+
     update_variables(args.filein, args.fileout)


### PR DESCRIPTION
### Description
This update is for implementing the public MPAS model in mpas-bundle. 

- Change static to invariant in two-stream files.
- Modify noah to sf_noah in model forecasting namelist.
- For DA, instead of copying the background file to the analysis file for overwriting, a new analysis file will be generated by the mpas-jedi. After DA, the analysis variables in the analysis file are overwritten to another existing mpasout file, copied from the background file. This treatment is due to the bug that the analysis variables cannot be directly written into an existing file in MPAS-JEDI. Now, only variational DA works. EnKF run mail fail. (This bug also appears in the variable-resolution mesh in JCSDA-internal MPAS).

### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
