### PR TITLE
[Draft] Support using the public mpas-model release 8.2

### DIFF
--- a/config/mpas/forecast/streams.atmosphere
+++ b/config/mpas/forecast/streams.atmosphere
@@ -1,5 +1,5 @@
 <streams>
-<immutable_stream name="static"
+<immutable_stream name="invariant"
                   type="input"
                   precision="{{PRECISION}}"
                   filename_template="{{StaticFieldsPrefix}}.{{nCells}}.nc"

--- a/config/mpas/hofx/streams.atmosphere
+++ b/config/mpas/hofx/streams.atmosphere
@@ -1,5 +1,5 @@
 <streams>
-<immutable_stream name="static"
+<immutable_stream name="invariant"
                   type="input"
                   precision="{{PRECISION}}"
                   filename_template="{{StaticFieldsPrefix}}.{{nCells}}.nc"

--- a/config/mpas/rtpp/streams.atmosphere
+++ b/config/mpas/rtpp/streams.atmosphere
@@ -1,5 +1,5 @@
 <streams>
-<immutable_stream name="static"
+<immutable_stream name="invariant"
                   type="input"
                   precision="{{PRECISION}}"
                   filename_template="{{StaticFieldsPrefix}}.{{nCells}}.nc"

--- a/config/mpas/saca/streams.atmosphere
+++ b/config/mpas/saca/streams.atmosphere
@@ -1,5 +1,5 @@
 <streams>
-<immutable_stream name="static"
+<immutable_stream name="invariant"
                   type="input"
                   filename_template="{{StaticFieldsPrefix}}.{{nCells}}.nc"
                   precision="{{PRECISION}}"

--- a/config/mpas/variational/streams.atmosphere
+++ b/config/mpas/variational/streams.atmosphere
@@ -1,5 +1,5 @@
 <streams>
-<immutable_stream name="static"
+<immutable_stream name="invariant"
                   type="input"
                   precision="{{PRECISION}}"
                   filename_template="{{StaticFieldsPrefix}}.{{nCells}}.nc{{TemplateFieldsMember}}"

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -40,11 +40,9 @@ class Build(Component):
     # set system dependent defaults before invoking Component ctor
     system = os.getenv('NCAR_HOST')
     if system == 'derecho':
-      if config._bundle_dir != None:
-        self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
-      else:
-        self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_saca_dev_10Jun2024/build_SP', str]
+      self.variablesWithDefaults['mpas bundle'] = \
+        ['/glade/work/jwittig/repos1/mpas-bundle-model-8.1/build-gnu-1p', str]
+        #['/glade/u/home/taosun/work/Derecho/JEDI/mpas-bundle-dev/build', str]
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]
       self.variablesWithDefaults['forecast directory'] = ['bundle', str]

--- a/scenarios/defaults/model.yaml
+++ b/scenarios/defaults/model.yaml
@@ -36,7 +36,7 @@ model:
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
       SfcLayer: sf_mynn
-      LSM: noah
+      LSM: sf_noah
     30km:
       meshRatio: 1
       nCells: 655362
@@ -53,7 +53,7 @@ model:
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
       SfcLayer: sf_monin_obukhov
-      LSM: noah
+      LSM: sf_noah
     60km:
       meshRatio: 1
       nCells: 163842
@@ -70,7 +70,7 @@ model:
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
       SfcLayer: sf_monin_obukhov
-      LSM: noah
+      LSM: sf_noah
     120km:
       meshRatio: 1
       nCells: 40962
@@ -87,4 +87,4 @@ model:
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
       SfcLayer: sf_monin_obukhov
-      LSM: noah
+      LSM: sf_noah


### PR DESCRIPTION
This PR contains changes to switch from using the internal JCSDA mpas-model to the public mpas-model release 8.2.
It includes
 - Change stream names from "static" to "invariant".
 - Change lsm scheme name from "noah" to "sf_noah"

It is based on changes in https://github.com/NCAR/MPAS-Workflow/pull/313, authored by @mos3r3n.

### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
