### PR TITLE
Bug fix for surface obs generation.

### DIFF
--- a/bin/ObsToIODA.csh
+++ b/bin/ObsToIODA.csh
@@ -109,7 +109,7 @@ foreach gdasfile ( *"gdas."* )
      mkdir -p sfc
      cd sfc
      ln -sfv ${obs2iodaBuildDir}/${obs2iodaEXE} ./
-     ./${obs2iodaEXE} ${noGSIQCFilters} ../${gdasfile} >&! logs/log-converter_sfc
+     ./${obs2iodaEXE} ${noGSIQCFilters} ../${gdasfile} >&! ../logs/log-converter_sfc
      # replace surface obs file with file created without additional QC
      mv -f sfc_obs_${thisCycleDate}.h5 ../sfc_obs_${thisCycleDate}.h5
      cd ..


### PR DESCRIPTION
### Description
This PR is a bug fix for generating surface obs:

- For surface obs, our purpose is to use line 112 to generate surface obs with "-noqc" option to keep as more observation as possible,  and use this file (generated by line 112) to replace previous one which generated by line 107 without "-noqc" option.  

- While the command at line 112 is not executed because the log file is pointed to the wrong path.


### Issue closed

Closes #(if applicable)

### Tests completed
 - [x] GenerateObs
