### PR TITLE
Correct amsua-cld* input file name for hofx run.

### DIFF
--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_aqua.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_aqua.yaml
@@ -4,7 +4,7 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: {{InDBDir}}/amsua_aqua_obs_{{thisValidDate}}.h5
+        obsfile: {{InDBDir}}/amsua-cld_aqua_obs_{{thisValidDate}}.h5
     obsdataout:
       engine:
         type: H5File

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-a.yaml
@@ -4,7 +4,7 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: {{InDBDir}}/amsua_metop-a_obs_{{thisValidDate}}.h5
+        obsfile: {{InDBDir}}/amsua-cld_metop-a_obs_{{thisValidDate}}.h5
     obsdataout:
       engine:
         type: H5File

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-b.yaml
@@ -4,7 +4,7 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: {{InDBDir}}/amsua_metop-b_obs_{{thisValidDate}}.h5
+        obsfile: {{InDBDir}}/amsua-cld_metop-b_obs_{{thisValidDate}}.h5
     obsdataout:
       engine:
         type: H5File

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_n15.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_n15.yaml
@@ -4,7 +4,7 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: {{InDBDir}}/amsua_n15_obs_{{thisValidDate}}.h5
+        obsfile: {{InDBDir}}/amsua-cld_n15_obs_{{thisValidDate}}.h5
     obsdataout:
       engine:
         type: H5File

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_n18.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_n18.yaml
@@ -4,7 +4,7 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: {{InDBDir}}/amsua_n18_obs_{{thisValidDate}}.h5
+        obsfile: {{InDBDir}}/amsua-cld_n18_obs_{{thisValidDate}}.h5
     obsdataout:
       engine:
         type: H5File

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_n19.yaml
@@ -4,7 +4,7 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: {{InDBDir}}/amsua_n19_obs_{{thisValidDate}}.h5
+        obsfile: {{InDBDir}}/amsua-cld_n19_obs_{{thisValidDate}}.h5
     obsdataout:
       engine:
         type: H5File


### PR DESCRIPTION
### Description
When we run hofx for amsua-cld*, the obs input files show in the yamls are not consistent with what we linked in dbIn directory. The failure is detected when we only verify amsua-cld*. This PR corrects the obs file names in the yamls. 

### Files modified:
config/jedi/ObsPlugs/hofx/base/amsua-cld_aqua.yaml
config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-a.yaml
config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-b.yaml
config/jedi/ObsPlugs/hofx/base/amsua-cld_n15.yaml
config/jedi/ObsPlugs/hofx/base/amsua-cld_n18.yaml
config/jedi/ObsPlugs/hofx/base/amsua-cld_n19.yaml

### Tests completed

- scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml
