### PR TITLE
Clean-up and modify folder specification for external analyses and 1st bkg for 60-3km

### DIFF
--- a/initialize/suites/CloudDirectInsertion.py
+++ b/initialize/suites/CloudDirectInsertion.py
@@ -30,8 +30,6 @@ from initialize.post.Benchmark import Benchmark
 
 from initialize.suites.SuiteBase import SuiteBase
 
-from initialize.framework.Workflow import Workflow
-
 class CloudDirectInsertion(SuiteBase):
   def __init__(self, conf:Config):
     super().__init__(conf)
@@ -47,7 +45,7 @@ class CloudDirectInsertion(SuiteBase):
     self.c['externalanalyses'] = ExternalAnalyses(conf, self.c['hpc'], meshes)
     self.c['initic'] = InitIC(conf, self.c['hpc'], meshes, self.c['externalanalyses'])
 
-    self.c['saca'] = SACA(conf, self.c['hpc'], meshes['Outer'], self.c['worklow'])
+    self.c['saca'] = SACA(conf, self.c['hpc'], meshes['Outer'], self.c['workflow'])
 
     # Forecast object is only used to initialize parts of ExtendedForecast and ForecastSACA
     self.c['forecast'] = Forecast(conf, self.c['hpc'], meshes['Outer'], self.c['members'], self.c['model'], self.c['observations'],

--- a/scenarios/3dhybrid_O60-3kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid_O60-3kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -1,9 +1,6 @@
 # settings borrowed from /glade/work/liuz/pandac_hybrid/amsua_clrsky
 experiment:
-  name: '3dhybrid_O60-3kmIE60km_TEST_Modelv8.2.1_samePP'
-
-build:
-  mpas bundle: /glade/work/taosun/Derecho/JEDI/mpas-bundle-v8.2/build_sp
+  suffix: '_ensB-SE80+RTPP70_VarBC'
 
 firstbackground:
   resource: "PANDAC.GFS"
@@ -22,11 +19,7 @@ forecast:
 
 externalanalyses:
   resource: "GFS.PANDAC"
-  #resources:
-  #  GFS:
-  #    PANDAC: # only available 20180418T00-20180524T00
-  #      30km:
-  #        directory: /glade/derecho/scratch/ivette/pandac/GenerateGFSAnalyses_new/ExternalAnalyses/30km
+
 members:
   n: 1
 
@@ -34,20 +27,6 @@ model:
   outerMesh: 60-3km
   innerMesh: 60km
   ensembleMesh: 60km
-  resources:
-    60-3km:
-      RadiationLWInterval: 00:30:00
-      RadiationSWInterval: 00:30:00
-      PhysicsSuite: mesoscale_reference
-      Microphysics: mp_wsm6
-      Convection: cu_ntiedtke
-      PBL: bl_ysu
-      Gwdo: bl_ysu_gwdo
-      RadiationCloud: cld_fraction
-      RadiationLW: rrtmg_lw
-      RadiationSW: rrtmg_sw
-      SfcLayer: sf_monin_obukhov
-      LSM: sf_noah
 
 observations:
   resource: PANDACArchiveForVarBC
@@ -81,6 +60,6 @@ variational:
 workflow:
   first cycle point: 20180414T18
   #restart cycle point: 20180419T12
-  final cycle point: 20180514T18
+  final cycle point: 20180415T06
   #CyclingWindowHR: 24 # default is 6 for cycling DA
   #max active cycle points: 4 # used for independent 'extendedforecast'

--- a/scenarios/GenerateGFSAnalyses.yaml
+++ b/scenarios/GenerateGFSAnalyses.yaml
@@ -3,15 +3,12 @@ suite: GenerateExternalAnalyses
 externalanalyses:
   resource: "GFS.RDA"
 experiment:
-  name: 'GenerateGFSAnalyses_new2'
+  name: 'GenerateGFSAnalyses'
   prefix: ''
 hpc:
   CriticalQueue: economy
   NonCriticalQueue: economy
-model:
-  outerMesh: 30km
-  GraphInfoDir: /glade/campaign/mmm/parc/ivette/pandac/codeBuild/MPAS-Model_v8.1_files/init_files/30km
 workflow:
-  first cycle point: 20180414T12 #20180414T18
-  final cycle point: 20180414T18
-  max active cycle points: 20
+  first cycle point: 20220606T00
+  final cycle point: 20220608T00
+  max active cycle points: 60

--- a/scenarios/defaults/externalanalyses.yaml
+++ b/scenarios/defaults/externalanalyses.yaml
@@ -32,16 +32,13 @@ externalanalyses:
     GFS:
       PANDAC: # only available 20180415T00-20180525T00
         120km:
-          #directory: "/glade/campaign/mmm/parc/liuz/pandac_common/120km/120km_GFSANA"
           directory: "/glade/campaign/mmm/parc/taosun/pandac/120kmMeshGFS/MPAS_IC_NEW"
         60km:
           directory: "/glade/campaign/mmm/parc/taosun/pandac/60kmMeshGFS/MPAS_IC_NEW"
         30km:
-          #directory: "/glade/campaign/mmm/parc/liuz/pandac_common/30km/30km_GFSANA"
           directory: "/glade/campaign/mmm/parc/taosun/pandac/30kmMeshGFS/MPAS_IC_NEW"
         60-3km:
-          #directory: "/glade/campaign/mmm/parc/ivette/pandac/saca/60-3km/60-3km_GFSANA"
-          directory: "/glade/campaign/mmm/parc/taosun/pandac/60km3kmVMeshGFS/MPAS_IC"
+          directory: "/glade/campaign/mmm/parc/taosun/pandac/60km3kmVMeshGFS/MPAS_IC_NEW"
       RDA:
         common:
           PrepareExternalAnalysisTasks:

--- a/scenarios/defaults/firstbackground.yaml
+++ b/scenarios/defaults/firstbackground.yaml
@@ -34,11 +34,9 @@ firstbackground:
         60km: # only available 20180414T18, 20200723T18
           directory: "/glade/campaign/mmm/parc/taosun/pandac/60kmMeshGFS/FirstBackground_NEW/{{FirstCycleDate}}"
         30km: # only available 20180414T18
-          #directory: "/glade/campaign/mmm/parc/liuz/pandac_common/30km/30km_1stCycle_background_single/{{FirstCycleDate}}"
           directory: "/glade/campaign/mmm/parc/taosun/pandac/30kmMeshGFS/FirstBackground_NEW/{{FirstCycleDate}}"
         60-3km:
-          #directory: "/glade/campaign/mmm/parc/ivette/pandac/saca/60-3km/60-3km_1stCycle_background_single/{{FirstCycleDate}}"
-          directory: "/glade/campaign/mmm/parc/taosun/pandac/60km3kmVMeshGFS/FirstBackground/{{FirstCycleDate}}"
+          directory: "/glade/campaign/mmm/parc/taosun/pandac/60km3kmVMeshGFS/FirstBackground_Thompson_NEW/{{FirstCycleDate}}"
       LaggedGEFS:
         common:
           PrepareFirstBackground: "LinkWarmStartBackgrounds => ForecastFinished__"


### PR DESCRIPTION
### Description
This small PR is to adjust the folder specification for the external analyses and first background for the 60-3km variable mesh to use the ones created with new topography files and land use option. It also moves back some scenario yaml configurations and fixes a typo in the CloudDirectInsertion suite.

### Issue closed
None

### Tests completed
Files where updated and tested.
