### PR TITLE
Update obs2ioda executable using cmake build and NCEP-bufr libs

### DIFF
--- a/bin/ObsToIODA.csh
+++ b/bin/ObsToIODA.csh
@@ -27,6 +27,7 @@ date
 
 # Setup environment
 # =================
+source config/environmentJEDI.csh
 source config/auto/build.csh
 source config/auto/experiment.csh
 source config/auto/observations.csh
@@ -130,11 +131,6 @@ foreach gdasfile ( *"gdas."* )
   rm -rf $gdasfile
 
 end # gdasfile loop
-
-# need to change to mainScriptDir in order for environmentJEDI.csh to be sourced
-cd ${mainScriptDir}
-source config/environmentJEDI.csh
-cd -
 
 # upgrade from IODA v1 to v2 (convert char to string for /MetaData/stationIdentification & /MetaData/variable_names)
 

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -155,8 +155,8 @@ class Build(Component):
 
     # Obs2IODA-v2
     # -----------
-    self._set('obs2iodaEXE', 'obs2ioda-v2.x')
-    self._set('obs2iodaBuildDir', '/glade/campaign/mmm/parc/ivette/pandac/fork_obs2ioda/obs2ioda/obs2ioda-v2/src')
+    self._set('obs2iodaEXE', 'obs2ioda_v2')
+    self._set('obs2iodaBuildDir', '/glade/campaign/mmm/parc/ivette/pandac/codeBuild/obs2ioda_cmake/build/bin')
     self._set('iodaUpgradeEXE1', 'ioda-upgrade-v1-to-v2.x')
     self._set('iodaUpgradeEXE2', 'ioda-upgrade-v2-to-v3.x')
     self._set('iodaUpgradeBuildDir', self['mpas bundle']+'/bin')


### PR DESCRIPTION
### Description
This PR updates the obs2ioda executable (and directory path) to use a recent compilation using cmake and NCEP-bufr libs. This follows Andy's recent developments in obs2ioda repository. The script `ObsToIODA` is also updated to source same environment file as for other JEDI applications.

### Issue closed
None

### Tests completed
 - [x] GenerateObs
