### PR TITLE
Adopt JEDI code sprint variable name changes

### DIFF
--- a/config/jedi/ObsPlugs/da/filters/abi-clr_g16.yaml
+++ b/config/jedi/ObsPlugs/da/filters/abi-clr_g16.yaml
@@ -28,9 +28,9 @@
       channels: *clrabi_channels
     - name: brightness_temperature_jacobian_air_temperature
       channels: *clrabi_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+    - name: brightness_temperature_jacobian_water_vapor_mixing_ratio_wrt_dry_air
       channels: *clrabi_channels
     - name: brightness_temperature_jacobian_surface_emissivity
       channels: *clrabi_channels
-    - name: brightness_temperature_jacobian_surface_temperature
+    - name: brightness_temperature_jacobian_skin_temperature_at_surface
       channels: *clrabi_channels

--- a/config/jedi/ObsPlugs/da/filters/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/da/filters/abi_g16.yaml
@@ -100,9 +100,9 @@
       channels: *abi_g16_channels
     - name: brightness_temperature_jacobian_air_temperature
       channels: *abi_g16_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+    - name: brightness_temperature_jacobian_water_vapor_mixing_ratio_wrt_dry_air
       channels: *abi_g16_channels
     - name: brightness_temperature_jacobian_surface_emissivity
       channels: *abi_g16_channels
-    - name: brightness_temperature_jacobian_surface_temperature
+    - name: brightness_temperature_jacobian_skin_temperature_at_surface
       channels: *abi_g16_channels

--- a/config/jedi/ObsPlugs/da/filters/ahi-clr_himawari8.yaml
+++ b/config/jedi/ObsPlugs/da/filters/ahi-clr_himawari8.yaml
@@ -25,9 +25,9 @@
       channels: *clrahi_channels
     - name: brightness_temperature_jacobian_air_temperature
       channels: *clrahi_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+    - name: brightness_temperature_jacobian_water_vapor_mixing_ratio_wrt_dry_air
       channels: *clrahi_channels
     - name: brightness_temperature_jacobian_surface_emissivity
       channels: *clrahi_channels
-    - name: brightness_temperature_jacobian_surface_temperature
+    - name: brightness_temperature_jacobian_skin_temperature_at_surface
       channels: *clrahi_channels

--- a/config/jedi/ObsPlugs/da/filters/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/da/filters/ahi_himawari8.yaml
@@ -68,9 +68,9 @@
       channels: *ahi_himawari8_channels
     - name: brightness_temperature_jacobian_air_temperature
       channels: *ahi_himawari8_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+    - name: brightness_temperature_jacobian_water_vapor_mixing_ratio_wrt_dry_air
       channels: *ahi_himawari8_channels
     - name: brightness_temperature_jacobian_surface_emissivity
       channels: *ahi_himawari8_channels
-    - name: brightness_temperature_jacobian_surface_temperature
+    - name: brightness_temperature_jacobian_skin_temperature_at_surface
       channels: *ahi_himawari8_channels

--- a/config/jedi/ObsPlugs/da/filters/sfc.yaml
+++ b/config/jedi/ObsPlugs/da/filters/sfc.yaml
@@ -3,7 +3,7 @@
     maxvalue: 3
   - filter: Difference Check
     reference: MetaData/stationElevation
-    value: GeoVaLs/surface_altitude
+    value: GeoVaLs/height_above_mean_sea_level_at_surface
     threshold: 200.0
   - filter: Background Check
     threshold: 3.0

--- a/config/jedi/ObsPlugs/hofx/filters/abi-clr_g16.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/abi-clr_g16.yaml
@@ -20,9 +20,9 @@
       channels: *clrabi_channels
     - name: brightness_temperature_jacobian_air_temperature
       channels: *clrabi_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+    - name: brightness_temperature_jacobian_water_vapor_mixing_ratio_wrt_dry_air
       channels: *clrabi_channels
     - name: brightness_temperature_jacobian_surface_emissivity
       channels: *clrabi_channels
-    - name: brightness_temperature_jacobian_surface_temperature
+    - name: brightness_temperature_jacobian_skin_temperature_at_surface
       channels: *clrabi_channels

--- a/config/jedi/ObsPlugs/hofx/filters/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/abi_g16.yaml
@@ -76,9 +76,9 @@
       channels: *abi_channels
     - name: brightness_temperature_jacobian_air_temperature
       channels: *abi_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+    - name: brightness_temperature_jacobian_water_vapor_mixing_ratio_wrt_dry_air
       channels: *abi_channels
     - name: brightness_temperature_jacobian_surface_emissivity
       channels: *abi_channels
-    - name: brightness_temperature_jacobian_surface_temperature
+    - name: brightness_temperature_jacobian_skin_temperature_at_surface
       channels: *abi_channels

--- a/config/jedi/ObsPlugs/hofx/filters/ahi-clr_himawari8.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/ahi-clr_himawari8.yaml
@@ -20,9 +20,9 @@
       channels: *clrahi_channels
     - name: brightness_temperature_jacobian_air_temperature
       channels: *clrahi_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+    - name: brightness_temperature_jacobian_water_vapor_mixing_ratio_wrt_dry_air
       channels: *clrahi_channels
     - name: brightness_temperature_jacobian_surface_emissivity
       channels: *clrahi_channels
-    - name: brightness_temperature_jacobian_surface_temperature
+    - name: brightness_temperature_jacobian_skin_temperature_at_surface
       channels: *clrahi_channels

--- a/config/jedi/ObsPlugs/hofx/filters/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/ahi_himawari8.yaml
@@ -68,9 +68,9 @@
       channels: *ahi_channels
     - name: brightness_temperature_jacobian_air_temperature
       channels: *ahi_channels
-    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+    - name: brightness_temperature_jacobian_water_vapor_mixing_ratio_wrt_dry_air
       channels: *ahi_channels
     - name: brightness_temperature_jacobian_surface_emissivity
       channels: *ahi_channels
-    - name: brightness_temperature_jacobian_surface_temperature
+    - name: brightness_temperature_jacobian_skin_temperature_at_surface
       channels: *ahi_channels

--- a/config/jedi/ObsPlugs/hofx/filters/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/mhs_metop-a.yaml
@@ -10,11 +10,11 @@
 #      channels: *mhs_metop-a_channels
 #    - name: brightness_temperature_jacobian_air_temperature
 #      channels: *mhs_metop-a_channels
-#    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+#    - name: brightness_temperature_jacobian_water_vapor_mixing_ratio_wrt_dry_air
 #      channels: *mhs_metop-a_channels
 #    - name: brightness_temperature_jacobian_surface_emissivity
 #      channels: *mhs_metop-a_channels
-#    - name: brightness_temperature_jacobian_surface_temperature
+#    - name: brightness_temperature_jacobian_skin_temperature_at_surface
 #      channels: *mhs_metop-a_channels
 #    - name: weightingfunction_of_atmosphere_layer
 #      channels: *mhs_metop-a_channels

--- a/config/jedi/ObsPlugs/hofx/filters/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/mhs_n19.yaml
@@ -10,11 +10,11 @@
 #      channels: *mhs_n19_channels
 #    - name: brightness_temperature_jacobian_air_temperature
 #      channels: *mhs_n19_channels
-#    - name: brightness_temperature_jacobian_humidity_mixing_ratio
+#    - name: brightness_temperature_jacobian_water_vapor_mixing_ratio_wrt_dry_air
 #      channels: *mhs_n19_channels
 #    - name: brightness_temperature_jacobian_surface_emissivity
 #      channels: *mhs_n19_channels
-#    - name: brightness_temperature_jacobian_surface_temperature
+#    - name: brightness_temperature_jacobian_skin_temperature_at_surface
 #      channels: *mhs_n19_channels
 #    - name: weightingfunction_of_atmosphere_layer
 #      channels: *mhs_n19_channels

--- a/config/jedi/ObsPlugs/hofx/filters/sfc.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/sfc.yaml
@@ -3,5 +3,5 @@
     maxvalue: 3
   - filter: Difference Check
     reference: MetaData/stationElevation
-    value: GeoVaLs/surface_altitude
+    value: GeoVaLs/height_above_mean_sea_level_at_surface
     threshold: 200.0

--- a/config/mpas/geovars.yaml
+++ b/config/mpas/geovars.yaml
@@ -19,19 +19,16 @@ fields:
   - field name: upward_air_velocity
     mpas template field: theta
 
-  - field name: geometric_height
-    mpas template field: theta
-
   - field name: geopotential_height
     mpas template field: theta
 
   - field name: geopotential_height_levels
     mpas template field: w
 
-  - field name: surface_geopotential_height
+  - field name: geopotential_height_at_surface
     mpas template field: u10
 
-  - field name: height
+  - field name: height_above_mean_sea_level
     mpas template field: theta
 
   - field name: virtual_temperature
@@ -53,21 +50,25 @@ fields:
     mpas template field: theta
     mpas identity field: uReconstructMeridional
 
-  - field name: humidity_mixing_ratio
+  - field name: water_vapor_mixing_ratio_wrt_dry_air
     mpas template field: theta
 
   - field name: specific_humidity
     mpas template field: theta
     mpas identity field: spechum
 
-  - field name: surface_altitude
+  - field name: height_above_mean_sea_level_at_surface
     mpas template field: u10
 
   - field name: surface_pressure
     mpas template field: u10
     mpas identity field: surface_pressure
 
-  - field name: surface_temperature
+  - field name: air_pressure_at_surface
+    mpas template field: u10
+    mpas identity field: surface_pressure
+
+  - field name: air_temperature_at_2m
     mpas template field: u10
     mpas identity field: t2m
 
@@ -75,15 +76,15 @@ fields:
     mpas template field: u10
     mpas identity field: q2
 
-  - field name: uwind_at_10m
+  - field name: eastward_wind_at_10m
     mpas template field: u10
     mpas identity field: u10
 
-  - field name: vwind_at_10m
+  - field name: northward_wind_at_10m
     mpas template field: u10
     mpas identity field: v10
 
-  - field name: skin_temperature
+  - field name: skin_temperature_at_surface
     mpas template field: u10
     mpas identity field: skintemp
 
@@ -99,6 +100,81 @@ fields:
     mpas template field: theta
 
   - field name: mole_fraction_of_carbon_dioxide_in_air
+    mpas template field: theta
+
+  - field name: mixing_ratio_of_cloud_liquid_water
+    mpas template field: theta
+    mpas identity field: qc
+
+  - field name: mixing_ratio_of_cloud_ice
+    mpas template field: theta
+    mpas identity field: qi
+
+  - field name: mixing_ratio_of_rain
+    mpas template field: theta
+    mpas identity field: qr
+
+  - field name: mixing_ratio_of_snow
+    mpas template field: theta
+    mpas identity field: qs
+
+  - field name: mixing_ratio_of_graupel
+    mpas template field: theta
+    mpas identity field: qg
+
+  - field name: mixing_ratio_of_hail
+    mpas template field: theta
+    mpas identity field: qh
+
+  - field name: cloud_liquid_water
+    mpas template field: theta
+    mpas identity field: qc
+
+  - field name: cloud_liquid_ice
+    mpas template field: theta
+    mpas identity field: qi
+
+  - field name: rain_water
+    mpas template field: theta
+    mpas identity field: qr
+
+  - field name: snow_water
+    mpas template field: theta
+    mpas identity field: qs
+
+  - field name: graupel
+    mpas template field: theta
+    mpas identity field: qg
+
+  - field name: hail
+    mpas template field: theta
+    mpas identity field: qh
+
+  - field name: cloud_droplet_number_concentration
+    mpas template field: theta
+    mpas identity field: nc
+
+  - field name: cloud_ice_number_concentration
+    mpas template field: theta
+    mpas identity field: ni
+
+  - field name: rain_number_concentration
+    mpas template field: theta
+    mpas identity field: nr
+
+  - field name: snow_number_concentration
+    mpas template field: theta
+    mpas identity field: ns
+
+  - field name: graupel_number_concentration
+    mpas template field: theta
+    mpas identity field: ng
+
+  - field name: hail_number_concentration
+    mpas template field: theta
+    mpas identity field: nh
+
+  - field name: moist_air_density
     mpas template field: theta
 
   - field name: mass_content_of_cloud_liquid_water_in_atmosphere_layer
@@ -144,24 +220,28 @@ fields:
     mpas template field: u10
     mpas identity field: skintemp
 
-  - field name: surface_temperature_where_sea
+  - field name: skin_temperature_at_surface_where_sea
     mpas template field: u10
     mpas identity field: skintemp
 
-  - field name: surface_temperature_where_land
+  - field name: skin_temperature_at_surface_where_land
     mpas template field: u10
     mpas identity field: skintemp
 
-  - field name: surface_temperature_where_ice
+  - field name: skin_temperature_at_surface_where_ice
     mpas template field: u10
     mpas identity field: skintemp
 
-  - field name: surface_temperature_where_snow
+  - field name: skin_temperature_at_surface_where_snow
     mpas template field: u10
     mpas identity field: skintemp
 
   - field name: surface_snow_thickness
     mpas template field: u10
+
+  - field name: surface_roughness_length
+    mpas template field: u10
+    mpas identity field: znt
 
   - field name: vegetation_area_fraction
     mpas template field: u10
@@ -188,15 +268,21 @@ fields:
   - field name: surface_snow_area_fraction
     mpas template field: u10
 
-  - field name: surface_eastward_wind
+  - field name: eastward_wind_at_surface
     mpas template field: u10
     mpas identity field: u10
 
-  - field name: surface_northward_wind
+  - field name: northward_wind_at_surface
     mpas template field: u10
     mpas identity field: v10
 
-  - field name: surface_wind_speed
+  - field name: wind_speed_at_surface
+    mpas template field: u10
+
+  - field name: observable_domain_mask
+    mpas template field: u10
+
+  - field name: wind_reduction_factor_at_10m
     mpas template field: u10
 
   - field name: land_type_index_USGS
@@ -213,6 +299,10 @@ fields:
 
   - field name: tropopause_pressure
     mpas template field: u10
+
+  - field name: qv
+    mpas template field: theta
+    mpas identity field: qv
 
   - field name: qc
     mpas template field: theta

--- a/config/mpas/geovars.yaml
+++ b/config/mpas/geovars.yaml
@@ -53,7 +53,7 @@ fields:
   - field name: water_vapor_mixing_ratio_wrt_dry_air
     mpas template field: theta
 
-  - field name: specific_humidity
+  - field name: water_vapor_mixing_ratio_wrt_moist_air
     mpas template field: theta
     mpas identity field: spechum
 
@@ -72,7 +72,7 @@ fields:
     mpas template field: u10
     mpas identity field: t2m
 
-  - field name: specific_humidity_at_two_meters_above_surface
+  - field name: water_vapor_mixing_ratio_wrt_moist_air_at_2m
     mpas template field: u10
     mpas identity field: q2
 

--- a/config/mpas/keptvars.yaml
+++ b/config/mpas/keptvars.yaml
@@ -6,8 +6,8 @@
 
 
 # This yaml will be exercised when "geometry.deallocate non-da fields" is true.
-# The variables included in "fields" will be kept in memory (mpas_domain) 
-# for a given mpas-jedi application, while other fields will be deallocated 
+# The variables included in "fields" will be kept in memory (mpas_domain)
+# for a given mpas-jedi application, while other fields will be deallocated
 # from mpas_domain to save the memory.
 
 fields:
@@ -37,6 +37,8 @@ fields:
   - landmask
   - xice
   - snowc
+  - znt
+  - t2m
   - skintemp
   - ivgtyp
   - isltyp

--- a/config/mpas/keptvars.yaml
+++ b/config/mpas/keptvars.yaml
@@ -38,7 +38,6 @@ fields:
   - xice
   - snowc
   - znt
-  - t2m
   - skintemp
   - ivgtyp
   - isltyp

--- a/config/mpas/obsop_name_map.yaml
+++ b/config/mpas/obsop_name_map.yaml
@@ -6,7 +6,7 @@ variable maps:
   - name: windNorthward
     alias: northward_wind
   - name: specificHumidity
-    alias: specific_humidity
+    alias: water_vapor_mixing_ratio_wrt_moist_air
   - name: relativeHumidity
     alias: relative_humidity
   - name: pressure

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -44,7 +44,7 @@ class Build(Component):
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
       else:
         self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_Oct142024_gnssro/build', str] ## dev
+          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_17Oct2024/build_SP', str] ## dev
 
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -44,7 +44,7 @@ class Build(Component):
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
       else:
         self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/campaign/mmm/parc/liuz/pandac_common/mpas-bundle-code-build/mpas_bundle_v3_internal_gnuSP/build', str] ## MPAS-JEDI 3.0.0 release with MPAS-A V8.2.1
+          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_Oct142024_gnssro/build', str] ## dev
 
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]

--- a/initialize/framework/HPC.py
+++ b/initialize/framework/HPC.py
@@ -37,7 +37,7 @@ class HPC(Component):
     'CriticalQueue': ['economy', str, ['economy', 'regular', 'premium']],
 
     # NonCritical*: used non-critical path jobs, single or multi-node, multi-processor only
-    'NonCriticalAccount': ['NMMM0015', str],
+    'NonCriticalAccount': ['NMMM0043', str],
     # override this below based on host
     'NonCriticalQueue': ['economy', str, ['economy', 'regular', 'premium']],
 

--- a/scenarios/3denvar_O30kmIE60km_WarmStart.yaml
+++ b/scenarios/3denvar_O30kmIE60km_WarmStart.yaml
@@ -13,22 +13,22 @@ variational:
   nInnerIterations: [60,60,]
   ensemble:
     forecasts:
-      resource: "PANDAC.GEFS"
+      resource: "PANDAC.EDA"
 observations:
   resource: PANDACArchive
   resources:
     PANDACArchive:
       IODADirectory:
         da:
-          abi_g16: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          ahi_himawari8: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
-          ahi-clr_himawari8: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
+          abi_g16: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          abi-clr_g16: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          ahi_himawari8: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
+          ahi-clr_himawari8: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
         hofx:
-          abi_g16: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          ahi_himawari8: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
-          ahi-clr_himawari8: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
+          abi_g16: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          abi-clr_g16: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
+          ahi_himawari8: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
+          ahi-clr_himawari8: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
       IODASuperObGrid:
         abi_g16: 15X15
         ahi_himawari8: 15X15

--- a/scenarios/defaults/enkf.yaml
+++ b/scenarios/defaults/enkf.yaml
@@ -110,8 +110,8 @@ enkf:
           nodes: 2
           PEPerNode: 128
           memory: 235GB
-          baseSeconds: 750
-          secondsPerMember: 45
+          baseSeconds: 800
+          secondsPerMember: 50
         solver:
           # cost for record (5 members, PBS JOB email)
           # 4 x 32 PE : ?.? min., ?? GB (single precision)

--- a/scenarios/defaults/forecast.yaml
+++ b/scenarios/defaults/forecast.yaml
@@ -53,4 +53,4 @@ forecast:
       nodes: 1
       PEPerNode: 128
       baseSeconds: 60
-      secondsPerForecastHR: 20
+      secondsPerForecastHR: 30

--- a/scenarios/defaults/initic.yaml
+++ b/scenarios/defaults/initic.yaml
@@ -27,6 +27,6 @@ initic:
       nodes: 1
       PEPerNode: 128
     120km:
-      seconds: 80
+      seconds: 120
       nodes: 1
       PEPerNode: 128

--- a/scenarios/defaults/rtpp.yaml
+++ b/scenarios/defaults/rtpp.yaml
@@ -26,7 +26,7 @@ rtpp:
       memory: 235GB
     120km:
       baseSeconds: 30
-      secondsPerMember: 15
+      secondsPerMember: 20
       nodes: 1
       PEPerNode: 128
       memory: 235GB

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -371,13 +371,13 @@ variational:
           nodes: 7 #7 subwindow slots
           PEPerNode: 128
           memory: 235GB
-          baseSeconds: 600
+          baseSeconds: 700
           secondsPerEnVarMember: 10
         4dhybrid:
           nodes: 7 #7 subwindow slots
           PEPerNode: 128
           memory: 235GB
-          baseSeconds: 600
+          baseSeconds: 700
           secondsPerEnVarMember: 10
         ensemble:
           3denvar:


### PR DESCRIPTION
### Description
This PRs makes the workflow compliant with latest variable change in JEDI to adopt CCPP names across the different components. This PR is related to PRs #[1017](https://github.com/JCSDA-internal/mpas-jedi/pull/1017), [1018](https://github.com/JCSDA-internal/mpas-jedi/pull/1018), [1019](https://github.com/JCSDA-internal/mpas-jedi/pull/1019), [1020](https://github.com/JCSDA-internal/mpas-jedi/pull/1020), and [1021](https://github.com/JCSDA-internal/mpas-jedi/pull/1021) in mpas-jedi repository.

The scenario `3denvar_O30kmIE60km_WarmStart` is also fixed and the walltime for EnKF Observer task is adjusted. The default account is temporarily changed to NMMM0043. A new build is provided.

### Issue closed
None

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2:
 - [x] 3denvar_O30kmIE60km_WarmStart
