### PR TITLE
Script to run cylc jobs and graph results.

### DIFF
--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -16,10 +16,8 @@
 # jobs which have finished are moved to either the "succeeded" directory of the "failed" directory.
 # See check_running_jobs for that logic.
 #
-# To generate graphs, the jobs in the "succeeded" and "processed" directories are examined to see
-# if the same workflow has run at least twice and at least one run hasn't been graphed.
-# If so, comparison graphs are made for each pair of successive runs; the older run is the baseline.
-# After jobs have been graphed they are moved to the "processed" directory.
+# To generate graphs, the provided workflow is graphed against the baseline run.
+# After the provided job has been graphed its run file is moved to the "processed" directory.
 # See make_graphs for details.
 
 readonly CRON_SUFFIX="_cron"  # append to workflow name to ID workflows run by this script
@@ -219,7 +217,7 @@ check_cylc_job()
   return 0
 }
 
-# create comparison graphs between the provided cylc experiment and the previous run
+# create comparison graphs between the provided cylc experiment and the baseline run
 make_graphs()
 {
   local readonly graphics_dir=$1 # where the mpas-bundle graphing code is
@@ -227,14 +225,17 @@ make_graphs()
   local readonly files_dir=$3  # root directory where job files are
   local readonly success_file=$4 # the workflow file to process.
 
-  # assume a name of <workflow>.<yy-mm-dd>*, use the <workflow> part to find all runs of the same workflow.
+  # assume a name of <workflow>.<yy-mm-dd>* for current runs, 
+  # assume a name of <workflow>.baseline* for the baseline run,
+  # use the <workflow> part to find baseline run of the same workflow.
   local readonly file_base=${success_file%.*}
   local readonly file_suffix=${success_file#*.} # used to create run specific graph directories
   local readonly pass_dir=$files_dir/$PASS_DIR  # where the passed workflows are
   local readonly graph_dir=$files_dir/$GRAPHED_DIR # where the graphed workflows are
   local readonly date="$(date +%F)"
-  local readonly model_graph_dir=$output_dir/$date/$file_suffix/model
-  local readonly obs_graph_dir=$output_dir/$date/$file_suffix/obs
+  # outut dirs for the graphs
+  local readonly model_out_dir=$output_dir/$date/$file_suffix/model
+  local readonly obs_out_dir=$output_dir/$date/$file_suffix/obs
   local base_run="" # the job to be used as the baseline for the graph
   local new_run="" # the job to be compared against the base
   # PBS directives
@@ -242,70 +243,58 @@ make_graphs()
   local readonly account="-a nmmm0043"
   local readonly memory="-m 12"
   # SpawnAnalyzeStats arguments
-  local readonly an_model_spaces=" -d mpas -p model -t forecast"
-  local readonly an_obs_spaces=" -d amsua_,sonde,airc,sfc,gnssrobndropp1d,satwind,mhs_as  -p obs -t omb/oma"
+  local readonly last_cycle="-l 20180421T18"
+  local readonly model_spaces=" -d mpas -p model -t forecast"
+  local readonly obs_spaces=" -d amsua_,sonde,airc,sfc,gnssrobndropp1d,satwind,mhs_as  -p obs -t omb/oma"
 
   if [ "$success_file" == "" ]; then
     log "no job file passed to make_graphs(), no graphs made"
     return
   fi
 
-  # find the passed workflows, oldest first
-  local readonly passed_files=($(ls ${pass_dir}/${file_base}*))
-  local readonly npassed_files=${#passed_files[@]} 
-
-  # find the most recent graphed workflow
-  local readonly graphed_files=($(ls -r ${graph_dir}/${file_base}*))
-  local readonly ngraphed_files=${#graphed_files[@]}
-  log "passed nfiles: ${npassed_files} graphed nfiles: $ngraphed_files"
-
-  if [ "${npassed_files}" -eq 0 ]; then
-    log "there aren't any new jobs to graph"
-    return
-  fi
-  if [ "${npassed_files}" -lt 2 ] && [ "${ngraphed_files}" -eq 0 ]; then
-    log "there aren't two successful cylc runs to compare"
+  # verify the provided job is in the "passed" directory
+  ls ${pass_dir}/${success_file}
+  if [ "$?" -ne 0 ]; then
+    log "the run $success_file is not in $pass_dir, no graphs made"
     return
   fi
 
-  if [ "${#graphed_files[@]}" -gt 0 ]; then
-    base_run=$(cat ${graphed_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
-    new_run=$(cat ${passed_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
-  else
-    base_run=$(cat ${passed_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
-    new_run=$(cat ${passed_files[1]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+  # find the baseline job
+  local readonly graphed_files=($(ls -r ${graph_dir}/${file_base}.baseline*))
+  if [ "${#graphed_files[@]}" -eq 0 ]; then 
+    log "the baseline run ${file_base}.baseline* isn't in $graph_dir, no graphs made"
+    return
   fi
 
+  base_run=$(cat ${graphed_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+  new_run=$(cat ${pass_dir}/${success_file} | sed 's/MPAS-Workflow//' | sed 's/\///g')
   log "newest run: $new_run"
   log "previous run: $base_run"
+
   local readonly exp_names="previous:$base_run,current:$new_run"
-  local readonly an_base_args=" -s $graphics_dir $queue $account -n 1 $memory -c previous -e $exp_names "
-  log "an_base_args=$an_base_args"
-  local readonly an_model_args=" $an_base_args $an_model_spaces"
-  local readonly an_obs_args=" $an_base_args $an_obs_spaces"
+  local readonly base_args=" -s $graphics_dir $last_cycle $queue $account -n 1 $memory -c previous -e $exp_names "
+  log "base_args=$base_args"
+  local readonly an_model_args=" $base_args $model_spaces"
+  local readonly an_obs_args=" $base_args $obs_spaces"
 
   # make forecast comparison graphs
-  mkdir -p $model_graph_dir || (log "failed to create $model_graph_dir" && exit 1)
-  cd $model_graph_dir
-  log "making graphs in $model_graph_dir"
+  mkdir -p $model_out_dir || (log "failed to create $model_out_dir" && exit 1)
+  cd $model_out_dir
+  log "making graphs in $model_out_dir"
   log "$graphics_dir/SpawnAnalyzeStats.py $an_model_args"
   $graphics_dir/SpawnAnalyzeStats.py $an_model_args
 
   # make omb/oma comparison graphs
-  mkdir -p $obs_graph_dir || (log "failed to create $obs_graph_dir" && exit 1)
-  cd $obs_graph_dir
-  log "making graphs in $obs_graph_dir"
+  mkdir -p $obs_out_dir || (log "failed to create $obs_out_dir" && exit 1)
+  cd $obs_out_dir
+  log "making graphs in $obs_out_dir"
   log "$graphics_dir/SpawnAnalyzeStats.py $an_obs_args"
   $graphics_dir/SpawnAnalyzeStats.py $an_obs_args
 
-  # move the graphed files to the "graphed" directory
+  # move the graphed file to the "graphed" directory
   mkdir -p $graph_dir || (log "failed to create $graph_dir" && exit 1)
-  log "mv ${passed_files[0]} $graph_dir"
-  mv ${passed_files[0]} $graph_dir
-  if [ "$ngraphed_files" -eq 0 ]; then
-    log "mv ${passed_files[1]} $graph_dir"
-    mv ${passed_files[1]} $graph_dir
-  fi
+  log "mv ${pass_dir}/${success_file} $graph_dir"
+  mv ${pass_dir}/${success_file} $graph_dir
 }
 
 main()

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
 # script to run a cylc scenario or post process the scenario's data after it completes.
-#   If a scenario doesn't need post processing (it hasn't been run, or it is still running,
+#   If no scenarios need post processing (haven't finished successfully
 #   or its data has already been processed) the script will do nothing.
 # This script must be run on derecho or casper (not the cron server).
 #
@@ -14,11 +14,11 @@
 # A subsequent call to create graphs from the workflow will check the jobs in the "running" files.
 # The "running" jobs are checked to see if they are still running, have failed, or succeeded,
 # jobs which have finished are moved to either the "succeeded" directory of the "failed" directory.
-# See check_cylc for that logic.
+# See check_running_jobs for that logic.
 #
-# To generate graphs, the jobs in the "succeeded" and "processed" directories are examined to see if the same workflow
-# has run at least twice.
-# If so, the most recent two runs are graphed; the older run is the baseline.
+# To generate graphs, the jobs in the "succeeded" and "processed" directories are examined to see
+# if the same workflow has run at least twice and at least one run hasn't been graphed.
+# If so, comparison graphs are made for each pair of successive runs; the older run is the baseline.
 # After jobs have been graphed they are moved to the "processed" directory.
 # See make_graphs for details.
 
@@ -130,10 +130,8 @@ run_cylc()
 }
 
 # check to see if any cylc jobs started with this script have completed successfully.
-# if a job which had been started by this script finished OK return 0.
-# if no cylc job had been started but not post processed return -1.
-# else return a code from the last job to be looked at, see check_cylc_job for specific codes.
-check_cylc()
+# completed jobs will be moved to the "success" or "failed" directories.
+check_running_jobs()
 {
   local files_dir=$1
   local run_dir=$files_dir/$RUN_DIR
@@ -141,13 +139,13 @@ check_cylc()
 
   if [ ! -d "${run_dir}" ]; then
     log "no $run_dir directory, nothing running"
-    return -1
+    return
   fi
 
   running_jobs=$(ls $run_dir)
   if [ "$running_jobs" == "" ]; then
     log "no files in $run_dir, nothing running"
-    return -1
+    return
   fi
 
   # check all the workflows which were started
@@ -158,12 +156,8 @@ check_cylc()
     retcode=$?
     if [ $retcode -eq 0 ]; then
       echo "$job_name completed successfully"
-      eval "$2=$job"
-      return 0
     fi
   done
-
-  return $retcode # status of the last processed job
 }
 
 # check to see if a cylc job started with this script has been started and not post processed.
@@ -225,79 +219,92 @@ check_cylc_job()
   return 0
 }
 
-# create comparison graphs between this cylc experiment and the previous run
+# create comparison graphs between the provided cylc experiment and the previous run
 make_graphs()
 {
-  local graphics_dir=$1 # where the mpas-bundle graphing code is
-  local output_dir=$2   # where to put the graphs
-  local files_dir=$3
-  local success_file=$4 # the workflow to process. assume a name of <workflow>.<date>_cron
+  local readonly graphics_dir=$1 # where the mpas-bundle graphing code is
+  local readonly output_dir=$2   # where to put the graphs
+  local readonly files_dir=$3  # root directory where job files are
+  local readonly success_file=$4 # the workflow file to process.
 
-  local success_job=${success_file%.*}
-  local pass_dir=$files_dir/$PASS_DIR  # where the passed workflow names are
-  local graph_dir=$files_dir/$GRAPHED_DIR # where the graphed workflows are
-  local date="$(date +%F)"
-  local queue="develop"
-  local account="nmmm0043"
-  echo "success_job: $success_job"
+  # assume a name of <workflow>.<yy-mm-dd>*, use the <workflow> part to find all runs of the same workflow.
+  local readonly file_base=${success_file%.*}
+  local readonly file_suffix=${success_file#*.} # used to create run specific graph directories
+  local readonly pass_dir=$files_dir/$PASS_DIR  # where the passed workflows are
+  local readonly graph_dir=$files_dir/$GRAPHED_DIR # where the graphed workflows are
+  local readonly date="$(date +%F)"
+  local readonly model_graph_dir=$output_dir/$date/$file_suffix/model
+  local readonly obs_graph_dir=$output_dir/$date/$file_suffix/obs
+  local base_run="" # the job to be used as the baseline for the graph
+  local new_run="" # the job to be compared against the base
+  # PBS directives
+  local readonly queue="-q develop"
+  local readonly account="-a nmmm0043"
+  local readonly memory="-m 12"
+  # SpawnAnalyzeStats arguments
+  local readonly an_model_spaces=" -d mpas -p model -t forecast"
+  local readonly an_obs_spaces=" -d amsua_,sonde,airc,sfc,gnssrobndropp1d,satwind,mhs_as  -p obs -t omb/oma"
 
-  # find the two most recent passed workflows
-  local passed_files=$(ls -r ${pass_dir}/${success_job}*)
-  passed_files_array=($passed_files)
-  local npassed_files=${#passed_files_array[@]} 
-  log "passed nfiles: ${npassed_files}"
+  if [ "$success_file" == "" ]; then
+    log "no job file passed to make_graphs(), no graphs made"
+    return
+  fi
+
+  # find the passed workflows, oldest first
+  local readonly passed_files=($(ls ${pass_dir}/${file_base}*))
+  local readonly npassed_files=${#passed_files[@]} 
+
+  # find the most recent graphed workflow
+  local readonly graphed_files=($(ls -r ${graph_dir}/${file_base}*))
+  local readonly ngraphed_files=${#graphed_files[@]}
+  log "passed nfiles: ${npassed_files} graphed nfiles: $ngraphed_files"
+
   if [ "${npassed_files}" -eq 0 ]; then
     log "there aren't any new jobs to graph"
     return
   fi
-
-  # find the most recent graphed workflow
-  local graphed_files=$(ls -r ${graph_dir}/${success_job}*)
-  graphed_files_array=($graphed_files)
-  log "graphed nfiles: ${#graphed_files_array[@]}"
-
-  if [ "${npassed_files}" -lt 2 ] && [ "${#graphed_files_array[@]}" -eq 0 ]; then
+  if [ "${npassed_files}" -lt 2 ] && [ "${ngraphed_files}" -eq 0 ]; then
     log "there aren't two successful cylc runs to compare"
     return
   fi
 
-  # the contents of the workflow files are the names of the workflows
-  # compare the newest run against the previous run
-  local new_run=$(cat ${passed_files_array[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
-  if [ "${#passed_files_array[@]}" -gt 1 ]; then
-    local base_run=$(cat ${passed_files_array[1]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+  if [ "${#graphed_files[@]}" -gt 0 ]; then
+    base_run=$(cat ${graphed_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+    new_run=$(cat ${passed_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
   else
-    local base_run=$(cat ${graphed_files_array[1]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+    base_run=$(cat ${passed_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+    new_run=$(cat ${passed_files[1]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
   fi
+
   log "newest run: $new_run"
   log "previous run: $base_run"
-  local exp_names="previous:$base_run,current:$new_run"
+  local readonly exp_names="previous:$base_run,current:$new_run"
+  local readonly an_base_args=" -s $graphics_dir $queue $account -n 1 $memory -c previous -e $exp_names "
+  log "an_base_args=$an_base_args"
+  local readonly an_model_args=" $an_base_args $an_model_spaces"
+  local readonly an_obs_args=" $an_base_args $an_obs_spaces"
 
   # make forecast comparison graphs
-  local target_dir=$output_dir/$date/model
-  mkdir -p $target_dir || (log "failed to create $target_dir" && exit 1)
-  cd $target_dir
-  log "making graphs in $target_dir"
-  local an_stats_args=" -s $graphics_dir -q $queue -a $account -n 1 -c previous -e $exp_names -d mpas -p model -t forecast"
-  log "$graphics_dir/SpawnAnalyzeStats.py -s $an_stats_args"
-  #$graphics_dir/SpawnAnalyzeStats.py $an_stats_args
+  mkdir -p $model_graph_dir || (log "failed to create $model_graph_dir" && exit 1)
+  cd $model_graph_dir
+  log "making graphs in $model_graph_dir"
+  log "$graphics_dir/SpawnAnalyzeStats.py $an_model_args"
+  $graphics_dir/SpawnAnalyzeStats.py $an_model_args
 
   # make omb/oma comparison graphs
-  local target_dir=$output_dir/$date/obs
-  mkdir -p $target_dir || (log "failed to create $target_dir" && exit 1)
-  cd $target_dir
-  log "making graphs in $target_dir"
-  local an_stats_args=" -s $graphics_dir -q $queue -a $account -n 1 -c previous -e $exp_names -d amsua_,sonde,airc,sfc,gnssrobndropp1d,satwind,mhs_as  -p obs -t omb/oma"
-  log "$graphics_dir/SpawnAnalyzeStats.py $an_stats_args"
-  #$graphics_dir/SpawnAnalyzeStats.py $an_stats_args
+  mkdir -p $obs_graph_dir || (log "failed to create $obs_graph_dir" && exit 1)
+  cd $obs_graph_dir
+  log "making graphs in $obs_graph_dir"
+  log "$graphics_dir/SpawnAnalyzeStats.py $an_obs_args"
+  $graphics_dir/SpawnAnalyzeStats.py $an_obs_args
 
-  # make sure the graphed files get moved to the "graphed" directory
+  # move the graphed files to the "graphed" directory
   mkdir -p $graph_dir || (log "failed to create $graph_dir" && exit 1)
-  log "mv ${passed_files_array[0]} $graph_dir"
-  mv ${passed_files_array[0]} $graph_dir
-  if [ "${#passed_files_array[@]}" -gt 1 ]; then
-    log "mv ${passed_files_array[1]} $graph_dir"
-    mv ${passed_files_array[1]} $graph_dir
+  log "mv ${passed_files[0]} $graph_dir"
+  mv ${passed_files[0]} $graph_dir
+  if [ "$ngraphed_files" -eq 0 ]; then
+    log "mv ${passed_files[1]} $graph_dir"
+    mv ${passed_files[1]} $graph_dir
   fi
 }
 
@@ -330,6 +337,8 @@ main()
   done
 
   init_logs $LOGDIR "cron"
+  log ""
+  log "`date`"
   log "commandline: $0 $*"
 
   if [ "$help" != "" ]; then
@@ -340,8 +349,6 @@ main()
     log "suffix (-x <suffix>) is required."
     usage
   fi
-  # FIXME is this needed?
-  #suffix=${suffix}
 
   check_exists "$workflow_dir" "workflow dir" "dir"
   # make sure Run.py is in the workflow directory
@@ -368,14 +375,12 @@ main()
 
     run_cylc $workflow_dir $scenario $suffix $LOGDIR $bundle_dir 
   else
-    local success_file=""
-
     check_exists "$output_dir" "output dir" "dir"
-    check_exists "$graphics_dir" "bundle dir" "dir"
+    check_exists "$graphics_dir" "graphics dir" "dir"
     check_exists "$graphics_dir/SpawnAnalyzeStats.py" "SpawnAnalyzeStats.py" "file"
 
-    # see if a cron cylc workflow needs post processing, success_file is returned if one does
-    check_cylc $LOGDIR success_file
+    # see if any cron cylc workflowS have finished
+    check_running_jobs $LOGDIR
     if [ "$?" -ne 0 ]; then
       log "there were no running jobs"
       #return 0
@@ -386,9 +391,13 @@ main()
     module load conda/latest
     conda activate npl-2023a
 
-    # make a graph comparing the 2 most recent workflows which passed
-    echo "make_graphs $graphics_dir $output_dir $LOGDIR $success_file"
-    make_graphs $graphics_dir $output_dir $LOGDIR $success_file
+    # process the files in the "succeeded" directory, from oldest to newest
+    local passed_jobs=$(ls $LOGDIR/$PASS_DIR)
+    for job in $passed_jobs ; do
+      # make a graph comparing the 2 oldest workflows which passed
+      log "make_graphs $graphics_dir $output_dir $LOGDIR $job"
+      make_graphs $graphics_dir $output_dir $LOGDIR $job
+    done
   fi
 }
 

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -422,7 +422,7 @@ main()
   local help=""
   local CYLC_ENV_SCRIPT="env-setup/machine.sh"
 
-# get comamnd line args
+# get command line args
   while getopts w:d:k:g:o:s:x:l:m:c:h flag
   do
     case "${flag}" in

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -274,7 +274,7 @@ make_graphs()
   fi
 
   # find the baseline job
-  local readonly baseline_files=($(ls -r ${graph_dir}/${file_base}.baseline*))
+  local readonly baseline_files=($(ls ${graph_dir}/${file_base}.base*))
   if [ "${#baseline_files[@]}" -eq 0 ]; then 
     log "the baseline run ${file_base}.baseline* isn't in $graph_dir, no graphs made"
     return
@@ -290,25 +290,31 @@ make_graphs()
   fi
 
   base_run=$(cat ${baseline_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+  local base_label=${base_run#*.}
+  base_label=${base_label//"_cron"/}
   new_run=$(cat ${pass_dir}/${success_file} | sed 's/MPAS-Workflow//' | sed 's/\///g')
-  log "newest run: $new_run in file:${pass_dir}/${success_file}"
-  log "previous run: $prev_run in file ${graphed_files[0]} "
-  log "base run: $base_run in file ${baseline_files[0]}"
+  local new_label=${new_run#*.}
+  new_label=${new_label//"_cron"/}
+  local prev_label=${prev_run#*.}
+  prev_label=${prev_label//"_cron"/}
+  log "newest run: $new_run label ${new_label} in file:${pass_dir}/${success_file}"
+  log "previous run: $prev_run label ${prev_label} in file ${graphed_files[0]} "
+  log "base run: $base_run label ${base_label} in file ${baseline_files[0]}"
 
   local readonly base_args=" -s $graphics_dir $last_cycle $queue $account -n 1 $memory"
 
   # make forecast comparison graphs against the baseline
-  gen_graphs "baseline" $base_run $new_run $model_out_dir $graphics_dir "$base_args $model_spaces"
+  gen_graphs $base_label $base_run $new_label $new_run $model_out_dir $graphics_dir "$base_args $model_spaces"
 
   # make omb/oma comparison graphs against the baseline
-  gen_graphs "baseline" $base_run $new_run $obs_out_dir $graphics_dir "$base_args $obs_spaces"
+  gen_graphs $base_label $base_run $new_label $new_run $obs_out_dir $graphics_dir "$base_args $obs_spaces"
 
   if [ "$prev_run" != "" ]; then
     # make forecast comparison graphs against the previous run
-    gen_graphs "previous" $prev_run $new_run $model_out_dir $graphics_dir "$base_args $model_spaces"
+    gen_graphs $prev_label $prev_run $new_label $new_run $model_out_dir $graphics_dir "$base_args $model_spaces"
 
     # make omb/oma comparison graphs against the previous run
-    gen_graphs "previous" $prev_run $new_run $obs_out_dir $graphics_dir "$base_args $obs_spaces"
+    gen_graphs $prev_label $prev_run $new_label $new_run $obs_out_dir $graphics_dir "$base_args $obs_spaces"
   fi
 
   # move the graphed file to the "graphed" directory
@@ -319,14 +325,15 @@ make_graphs()
 
 gen_graphs()
 {
-  local base_name=$1
-  local base_run=$2
-  local new_run=$3
-  local out_dir=$4
-  local script_dir=$5
-  local script_args=$6
+  local readonly base_name=$1
+  local readonly base_run=$2
+  local readonly new_name=$3
+  local readonly new_run=$4
+  local readonly out_dir=$5
+  local readonly script_dir=$6
+  local readonly script_args=$7
 
-  script_args="$script_args -c $base_name -e $base_name:$base_run,current:$new_run"
+  script_args="$script_args -c $base_name -e $base_name:$base_run,$new_name:$new_run"
   mkdir -p $out_dir/$base_name || (log "failed to create $out_dir/$base_name" && exit 1)
   cd $out_dir/$base_name
   log "making graphs in $out_dir/$base_name"

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -227,6 +227,29 @@ check_cylc_job()
   return 0
 }
 
+# wait for the provided job to either show in the queue ($2 is 1)
+# or for the job to leave the queue ($2 is 0)
+queue_wait()
+{
+  local job=$1
+  local pcode=$2
+  local secs=$3
+  local dir="enter"
+  if [ "$pcode" == 0 ]; then
+    dir="leave"
+  fi
+
+  log "waiting for $job to $dir queue, checking every $secs seconds"
+
+  qstat ${job} &> /dev/null
+  local rc=$?
+  while [ ${rc} == "${pcode}" ]; do
+    sleep ${secs}
+    qstat ${job} &> /dev/null
+    rc=$?
+  done
+}
+
 # create comparison graphs between the provided cylc experiment and
 #   1. the baseline run
 #   2. the previous run (if there is one)
@@ -306,20 +329,35 @@ make_graphs()
   log "base run: $base_run label ${base_label} in file ${baseline_files[0]}"
 
   local readonly base_args=" -s $graphics_dir $last_cycle $queue $account -n 1 $memory"
+  local model_base_sync_job=""
+  local model_prev_sync_job=""
+  local obs_base_sync_job=""
+  local obs_prev_sync_job=""
 
-  # make forecast comparison graphs against the baseline
-  gen_graphs $base_label $base_run $new_label $new_run $model_out_dir $graphics_dir "$base_args $model_spaces"
+  # make model comparison graphs against the baseline
+  gen_graphs $base_label $base_run $new_label $new_run $model_out_dir $graphics_dir "$base_args $model_spaces" model_base_sync_job
+  log "make_graphs sync job:$model_base_sync_job"
+  queue_wait ${model_base_sync_job} 1 5 # wait for the sync jobs to show up in the queue, check every 5 seconds
 
   # make omb/oma comparison graphs against the baseline
-  gen_graphs $base_label $base_run $new_label $new_run $obs_out_dir $graphics_dir "$base_args $obs_spaces"
+  gen_graphs $base_label $base_run $new_label $new_run $obs_out_dir $graphics_dir "$base_args $obs_spaces" obs_base_sync_job
+  queue_wait ${obs_base_sync_job} 1 5 # wait for the sync jobs to show up in the queue, check every 5 seconds
 
   if [ "$prev_run" != "" ]; then
     # make forecast comparison graphs against the previous run
-    gen_graphs $prev_label $prev_run $new_label $new_run $model_out_dir $graphics_dir "$base_args $model_spaces"
+    gen_graphs $prev_label $prev_run $new_label $new_run $model_out_dir $graphics_dir "$base_args $model_spaces" model_prev_sync_job
+    queue_wait ${model_prev_sync_job} 1 5 # wait for the sync jobs to show up in the queue, check every 5 seconds
 
     # make omb/oma comparison graphs against the previous run
-    gen_graphs $prev_label $prev_run $new_label $new_run $obs_out_dir $graphics_dir "$base_args $obs_spaces"
+    gen_graphs $prev_label $prev_run $new_label $new_run $obs_out_dir $graphics_dir "$base_args $obs_spaces" obs_prev_sync_job
+    queue_wait ${obs_prev_sync_job} 1 5 # wait for the sync jobs to show up in the queue, check every 5 seconds
   fi
+
+  # wait for the sync jobs to finish, check every 60 seconds
+  queue_wait ${model_base_sync_job} 0 60
+  queue_wait ${model_prev_sync_job} 0 60
+  queue_wait ${obs_base_sync_job} 0 60
+  queue_wait ${obs_prev_sync_job} 0 60
 
   # move the graphed file to the "graphed" directory
   mkdir -p $graph_dir || (log "failed to create $graph_dir" && exit 1)
@@ -341,8 +379,10 @@ gen_graphs()
   mkdir -p $out_dir/$base_name || (log "failed to create $out_dir/$base_name" && exit 1)
   cd $out_dir/$base_name
   log "making graphs in $out_dir/$base_name"
-  log "$script_dir/SpawnAnalyzeStats.py $script_args"
-  $script_dir/SpawnAnalyzeStats.py $script_args
+  log "$script_dir/SpawnAnalyzeStats.py $script_args -w"
+  local jobno=$($script_dir/SpawnAnalyzeStats.py $script_args -w 2>&1 > /dev/tty)
+  log "gen_graphs sync job is $jobno"
+  eval $8=$jobno
 }
 
 copy_graphs()
@@ -459,7 +499,7 @@ main()
     for job in $passed_jobs ; do
       # make a graph comparing the 2 oldest workflows which passed
       log "make_graphs $graphics_dir $output_dir $LOGDIR $job"
-      #make_graphs $graphics_dir $output_dir $LOGDIR $job
+      make_graphs $graphics_dir $output_dir $LOGDIR $job
     done
     if [ "$webserver" != "" ] && [ "$web_graphs_dir" != "" ]; then
       copy_graphs $output_dir $webserver $web_graphs_dir

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -281,7 +281,7 @@ make_graphs()
   local prev_run="" # the job run prior to the current run
   # PBS directives
   local readonly queue="-q develop"
-  local readonly account="-a nmmm0043"
+  local readonly account="-a nmmm0015"
   local readonly memory="-m 12"
   # SpawnAnalyzeStats arguments
   local readonly last_cycle="-l 20180421T18"

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -16,7 +16,9 @@
 # jobs which have finished are moved to either the "succeeded" directory of the "failed" directory.
 # See check_running_jobs for that logic.
 #
-# To generate graphs, the provided workflow is graphed against the baseline run.
+# To generate graphs, the provided workflow is graphed against
+#  1. the baseline run.
+#  2. the previous run
 # After the provided job has been graphed its run file is moved to the "processed" directory.
 # See make_graphs for details.
 
@@ -221,7 +223,9 @@ check_cylc_job()
   return 0
 }
 
-# create comparison graphs between the provided cylc experiment and the baseline run
+# create comparison graphs between the provided cylc experiment and
+#   1. the baseline run
+#   2. the previous run (if there is one)
 make_graphs()
 {
   local readonly graphics_dir=$1 # where the mpas-bundle graphing code is
@@ -236,12 +240,18 @@ make_graphs()
   local readonly file_suffix=${success_file#*.} # used to create run specific graph directories
   local readonly pass_dir=$files_dir/$PASS_DIR  # where the passed workflows are
   local readonly graph_dir=$files_dir/$GRAPHED_DIR # where the graphed workflows are
-  local readonly date="$(date +%F)"
+  local date="$(date +%F)"
   # outut dirs for the graphs
+  # extract yyyy-mm-dd from the current file name
+  local readonly pattern='([0-9]{4}-[0-9]{2}-[0-9]{2})'
+  if [[ $success_file =~ $pattern ]]; then
+    date=${BASH_REMATCH[0]}
+  fi
   local readonly model_out_dir=$output_dir/$date/$file_suffix/model
   local readonly obs_out_dir=$output_dir/$date/$file_suffix/obs
   local base_run="" # the job to be used as the baseline for the graph
-  local new_run="" # the job to be compared against the base
+  local new_run="" # the current job
+  local prev_run="" # the job run prior to the current run
   # PBS directives
   local readonly queue="-q develop"
   local readonly account="-a nmmm0043"
@@ -264,41 +274,64 @@ make_graphs()
   fi
 
   # find the baseline job
-  local readonly graphed_files=($(ls -r ${graph_dir}/${file_base}.baseline*))
-  if [ "${#graphed_files[@]}" -eq 0 ]; then 
+  local readonly baseline_files=($(ls -r ${graph_dir}/${file_base}.baseline*))
+  if [ "${#baseline_files[@]}" -eq 0 ]; then 
     log "the baseline run ${file_base}.baseline* isn't in $graph_dir, no graphs made"
     return
   fi
 
-  base_run=$(cat ${graphed_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+  # find the run prior to the current run,
+  # find the most recent graphed workflow (omitting the baseline run)
+  local readonly graphed_files=($(ls -r ${graph_dir}/${file_base}.2*))
+  if [ "${#graphed_files[@]}" -gt 0 ]; then
+    prev_run=$(cat ${graphed_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+  else
+    log "there is no previous run, only graphing against the baseline"
+  fi
+
+  base_run=$(cat ${baseline_files[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
   new_run=$(cat ${pass_dir}/${success_file} | sed 's/MPAS-Workflow//' | sed 's/\///g')
-  log "newest run: $new_run"
-  log "previous run: $base_run"
+  log "newest run: $new_run in file:${pass_dir}/${success_file}"
+  log "previous run: $prev_run in file ${graphed_files[0]} "
+  log "base run: $base_run in file ${baseline_files[0]}"
 
-  local readonly exp_names="previous:$base_run,current:$new_run"
-  local readonly base_args=" -s $graphics_dir $last_cycle $queue $account -n 1 $memory -c previous -e $exp_names "
-  log "base_args=$base_args"
-  local readonly an_model_args=" $base_args $model_spaces"
-  local readonly an_obs_args=" $base_args $obs_spaces"
+  local readonly base_args=" -s $graphics_dir $last_cycle $queue $account -n 1 $memory"
 
-  # make forecast comparison graphs
-  mkdir -p $model_out_dir || (log "failed to create $model_out_dir" && exit 1)
-  cd $model_out_dir
-  log "making graphs in $model_out_dir"
-  log "$graphics_dir/SpawnAnalyzeStats.py $an_model_args"
-  $graphics_dir/SpawnAnalyzeStats.py $an_model_args
+  # make forecast comparison graphs against the baseline
+  gen_graphs "baseline" $base_run $new_run $model_out_dir $graphics_dir "$base_args $model_spaces"
 
-  # make omb/oma comparison graphs
-  mkdir -p $obs_out_dir || (log "failed to create $obs_out_dir" && exit 1)
-  cd $obs_out_dir
-  log "making graphs in $obs_out_dir"
-  log "$graphics_dir/SpawnAnalyzeStats.py $an_obs_args"
-  $graphics_dir/SpawnAnalyzeStats.py $an_obs_args
+  # make omb/oma comparison graphs against the baseline
+  gen_graphs "baseline" $base_run $new_run $obs_out_dir $graphics_dir "$base_args $obs_spaces"
+
+  if [ "$prev_run" != "" ]; then
+    # make forecast comparison graphs against the previous run
+    gen_graphs "previous" $prev_run $new_run $model_out_dir $graphics_dir "$base_args $model_spaces"
+
+    # make omb/oma comparison graphs against the previous run
+    gen_graphs "previous" $prev_run $new_run $obs_out_dir $graphics_dir "$base_args $obs_spaces"
+  fi
 
   # move the graphed file to the "graphed" directory
   mkdir -p $graph_dir || (log "failed to create $graph_dir" && exit 1)
   log "mv ${pass_dir}/${success_file} $graph_dir"
   mv ${pass_dir}/${success_file} $graph_dir
+}
+
+gen_graphs()
+{
+  local base_name=$1
+  local base_run=$2
+  local new_run=$3
+  local out_dir=$4
+  local script_dir=$5
+  local script_args=$6
+
+  script_args="$script_args -c $base_name -e $base_name:$base_run,current:$new_run"
+  mkdir -p $out_dir/$base_name || (log "failed to create $out_dir/$base_name" && exit 1)
+  cd $out_dir/$base_name
+  log "making graphs in $out_dir/$base_name"
+  log "$script_dir/SpawnAnalyzeStats.py $script_args"
+  $script_dir/SpawnAnalyzeStats.py $script_args
 }
 
 main()

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -380,7 +380,8 @@ gen_graphs()
   cd $out_dir/$base_name
   log "making graphs in $out_dir/$base_name"
   log "$script_dir/SpawnAnalyzeStats.py $script_args -w"
-  local jobno=$($script_dir/SpawnAnalyzeStats.py $script_args -w 2>&1 > /dev/tty)
+  { jobno=$($script_dir/SpawnAnalyzeStats.py $script_args -w 2>&1 >&3 3>&-); } 3>&1
+
   log "gen_graphs sync job is $jobno"
   eval $8=$jobno
 }

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -58,10 +58,14 @@ usage()
   log "    -l <log_dir> where logs and data should be written, default $LOGDIR"
   log "    -h prints help and exits"
   log "to generate graphs"
-  log "  run_cylc.sh -w <workflow_dir> -g <graphics_dir> -o <output_dir> [-l log_dir] [-h] "
+  log "  run_cylc.sh -w <workflow_dir> -g <graphics_dir> -o <output_dir> [-m <mmm_webserver>] [-c <cylc_graph_dir>] [-l log_dir] [-h] "
   log "    -w <workflow_dir> the MPAS-Workflow location"
   log "    -g <graphics_dir> where the mpas-jedi graphics directory is"
   log "    -o <output_dir> where the comparison graphs should go"
+  log "    -m <mmm_webserver> the mmm web server content machine, e.g. whitedwarf.mmm.ucar.edu"
+  log "       if not provided the graphs won't get copied to the webserver"
+  log "    -c <cylc_graph_dir> where the cylc output graphs go on the mmm webserver, e.g. /web/htdocs/<graph-dir-path>"
+  log "       if not provided the graphs won't get copied to the webserver"
   log "    -l <log_dir> where logs and data should be written, default $LOGDIR"
   log "    -h prints help and exits"
   exit 1
@@ -341,6 +345,28 @@ gen_graphs()
   $script_dir/SpawnAnalyzeStats.py $script_args
 }
 
+copy_graphs()
+{
+  local readonly source_dir=$1
+  local readonly webserver=$2
+  local readonly web_graphs_dir=$3
+
+  log "copy_graphs: derecho graphs dir: $source_dir web server:$webserver web graph dir:$web_graphs_dir"
+
+  log "checking $source_dir" 
+  for dir in $(/bin/ls $source_dir); do
+    log "   dir to copy:$dir" 
+    log "   cd $source_dir && tar --remove-files -czf $dir.tgz $dir" 
+    cd $source_dir && tar --remove-files -czf $dir.tgz $dir
+    log "   scp $source_dir/$dir.tgz $webserver:$web_graphs_dir/" 
+    scp $source_dir/$dir.tgz $webserver:$web_graphs_dir/
+    log "   ssh $webserver cd $web_graphs_dir/ && tar -xzf $dir.tgz" 
+    ssh $webserver "cd $web_graphs_dir/ && tar -xzf $dir.tgz"
+    mv $source_dir/$dir.tgz $source_dir/../copied
+    log "   finished $dir" 
+  done
+}
+
 main()
 {
   local workflow_dir=""
@@ -350,11 +376,13 @@ main()
   local output_dir=""
   local scenario=""
   local suffix=""
+  local webserver=""
+  local web_graphs_dir=""
   local help=""
   local CYLC_ENV_SCRIPT="env-setup/machine.sh"
 
 # get comamnd line args
-  while getopts w:d:k:g:o:s:x:l:h flag
+  while getopts w:d:k:g:o:s:x:l:m:c:h flag
   do
     case "${flag}" in
       w) workflow_dir="${OPTARG}";;
@@ -365,6 +393,8 @@ main()
       s) scenario="${OPTARG}";;
       x) suffix="${OPTARG}";;
       l) LOGDIR=${OPTARG};;
+      m) webserver=${OPTARG};;
+      c) web_graphs_dir=${OPTARG};;
       h) help="help";;
     esac
   done
@@ -429,8 +459,11 @@ main()
     for job in $passed_jobs ; do
       # make a graph comparing the 2 oldest workflows which passed
       log "make_graphs $graphics_dir $output_dir $LOGDIR $job"
-      make_graphs $graphics_dir $output_dir $LOGDIR $job
+      #make_graphs $graphics_dir $output_dir $LOGDIR $job
     done
+    if [ "$webserver" != "" ] && [ "$web_graphs_dir" != "" ]; then
+      copy_graphs $output_dir $webserver $web_graphs_dir
+    fi
   fi
 }
 

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -1,0 +1,396 @@
+#!/bin/bash -l
+
+# script to run a cylc scenario or post process the scenario's data after it completes.
+#   If a scenario doesn't need post processing (it hasn't been run, or it is still running,
+#   or its data has already been processed) the script will do nothing.
+# This script must be run on derecho or casper (not the cron server).
+#
+# Jobs which have been started are placed in a "running" directory.
+# Jobs which have succeeded are placed in a "succeeded" directory.
+# Jobs which have failed are placed in a "failed" directory.
+# Jobs which have had graphs created for them are placed in a "processed" directory.
+#
+# When the script runs a cylc job it will put the name of the workflow into a "running" file.
+# A subsequent call to create graphs from the workflow will check the jobs in the "running" files.
+# The "running" jobs are checked to see if they are still running, have failed, or succeeded,
+# jobs which have finished are moved to either the "succeeded" directory of the "failed" directory.
+# See check_cylc for that logic.
+#
+# To generate graphs, the jobs in the "succeeded" and "processed" directories are examined to see if the same workflow
+# has run at least twice.
+# If so, the most recent two runs are graphed; the older run is the baseline.
+# After jobs have been graphed they are moved to the "processed" directory.
+# See make_graphs for details.
+
+readonly CRON_SUFFIX="_cron"  # append to workflow name to ID workflows run by this script
+readonly PASS_DIR="passed_workflows" # directory with workflows which passed
+readonly FAIL_DIR="failed_workflows" # directory with workflows which failed
+readonly RUN_DIR="running_workflows" # directory with workflows which are running
+readonly GRAPHED_DIR="processed_workflows" # directory with workflows that have been graphed.
+LOGDIR="${HOME}/my_cron_logs/cylc" # default base dir for PASS_DIR, FAIL_DIR, RUN_DIR, can be overwritten w/ -l
+
+# create the logging file (including its directory) and
+# create the directories to hold cylc processing files.
+init_logs()
+{
+  local cron_logdir="$1"
+  local suffix="$2"
+  local date="$(date +%F-%H)"
+
+  mkdir -p ${cron_logdir} || exit 1
+  mkdir -p "${cron_logdir}/logs" || exit 1
+  LOGFILE="${cron_logdir}/logs/run_cylc.${suffix}.${date}.log"
+}
+
+usage()
+{
+  echo""
+  log "usage:"
+  log "to run a cylc workflow"
+  log "  run_cylc.sh -w <workflow_dir> [-d <bundle_dir> [-k <lock_file>]] -s <scenario> -x <suffix> [-l log_dir] [-h] "
+  log "    -w <workflow_dir> the MPAS-Workflow location"
+  log "    -d <bundle_dir> where the mpas-bundle repo has been built"
+  log "        this will override the bundle set in the workflow's Build.py"
+  log "    -k <lock_file> the name of the lock file which exists while mpas-bundle is being built"
+  log "        if the mpas-bundle lock file exists, that will be logged and the workflow will not run"
+  log "    -s <scenario> a scenario to run (relative to workflow_dir)"
+  log "    -x <suffix> the suffix to append to the names of the workflows to run"
+  log "    -l <log_dir> where logs and data should be written, default $LOGDIR"
+  log "    -h prints help and exits"
+  log "to generate graphs"
+  log "  run_cylc.sh -w <workflow_dir> -g <graphics_dir> -o <output_dir> [-l log_dir] [-h] "
+  log "    -w <workflow_dir> the MPAS-Workflow location"
+  log "    -g <graphics_dir> where the mpas-jedi graphics directory is"
+  log "    -o <output_dir> where the comparison graphs should go"
+  log "    -l <log_dir> where logs and data should be written, default $LOGDIR"
+  log "    -h prints help and exits"
+  exit 1
+}
+
+log()
+{
+  echo -e "$1" | tee -a ${LOGFILE}
+}
+
+# check if the provided file/directory exists.
+# exit with usage message if file/dir doesn't exist.
+check_exists()
+{
+  local name=$1 # file/directory to check for existence
+  local msg=$2  # message to log if file/dir doesn't exist
+  local type=$3 # type of object to check for (file or directory)
+
+  if [ "$name" = "" ]; then
+    log "$msg is required"
+    usage
+  fi
+  if [ "$type" == "dir" ]; then
+    if [ ! -d "${name}" ]; then
+      log "$msg ${name} is not a directory"
+      usage
+    fi
+  else
+    if [ ! -f "${name}" ]; then
+      log "$msg ${name} is not a file"
+      usage
+    fi
+  fi
+}
+
+# run a cylc workflow.
+# creates a file with the name of the running scenario.
+run_cylc()
+{
+  log 'run_cylc'
+  local work_dir=$1 # location of the MPAS-Workflow cloned repo
+  local scenario=$2 # the workflow to run
+  local suffix=".$3${CRON_SUFFIX}"   # a string to append to the workflow names to uniquely identify them
+  local base_dir=$4 # base file directory
+  local bundle_dir=$5 # location of a mpas-bundle build (should be single precision)
+  local running_dir="$base_dir/$RUN_DIR"
+  local date="$(date +%F-%H-%M)"
+  
+
+  cd $work_dir
+  if [ "$bundle_dir" != "" ]; then
+    log "./Run.py $scenario -b $bundle_dir  -x $suffix"
+    $work_dir/Run.py $scenario -b $bundle_dir  -x $suffix  2>&1 | tee -a ${LOGFILE}
+  else
+    log "./Run.py $scenario -x $suffix"
+    $work_dir/Run.py $scenario -x $suffix  2>&1 | tee -a ${LOGFILE}
+  fi
+
+  # save the names of the running workflows to check for success later
+  mkdir -p $running_dir || (log "failed to create $running_dir" && exit 1)
+  workflow_name=$(cylc scan -t name | grep  "${suffix}$" )
+  workflow_file_name=$(echo $workflow_name | awk -F/ '{print $NF}')
+  log "workflow_name=$workflow_name"
+  log "echo $workflow_name > $running_dir/$workflow_file_name"
+  echo $workflow_name > $running_dir/$workflow_file_name
+}
+
+# check to see if any cylc jobs started with this script have completed successfully.
+# if a job which had been started by this script finished OK return 0.
+# if no cylc job had been started but not post processed return -1.
+# else return a code from the last job to be looked at, see check_cylc_job for specific codes.
+check_cylc()
+{
+  local files_dir=$1
+  local run_dir=$files_dir/$RUN_DIR
+  local retcode=0
+
+  if [ ! -d "${run_dir}" ]; then
+    log "no $run_dir directory, nothing running"
+    return -1
+  fi
+
+  running_jobs=$(ls $run_dir)
+  if [ "$running_jobs" == "" ]; then
+    log "no files in $run_dir, nothing running"
+    return -1
+  fi
+
+  # check all the workflows which were started
+  log "running_jobs=$running_jobs"
+  for job in $running_jobs ; do
+    job_name=$(cat $run_dir/$job)
+    check_cylc_job $job_name $run_dir/$job $files_dir
+    retcode=$?
+    if [ $retcode -eq 0 ]; then
+      echo "$job_name completed successfully"
+      eval "$2=$job"
+      return 0
+    fi
+  done
+
+  return $retcode # status of the last processed job
+}
+
+# check to see if a cylc job started with this script has been started and not post processed.
+# if a cylc job has been started check to see if it has finished.
+#   if it hasn't finished return -2
+# if a cylc job has finished, check for errors.
+#   if there were errors move the running file to "failed" directory and return -3
+#   if there were no errors move the running file to "passed" directory and return 0
+check_cylc_job()
+{
+  local job_name=$1
+  local job_file=$2 # file with the name of the running job (including absolute path)
+  local files_dir=$3  # base directory for the running/passed/failed jobs directories
+  local pass_dir=$files_dir/$PASS_DIR
+  local fail_dir=$files_dir/$FAIL_DIR
+  local retcode=0
+
+  # see if workflow which was started is still running
+  log "cylc ping ${job_name}"
+  cylc ping ${job_name} > /dev/null
+  retcode=$?
+  if [ $retcode -eq 0 ]; then
+    log "$job_name is running"
+    return -2
+  fi
+
+  # check to see if the job name is valid, a zero return code indicates the job name is valid
+  cylc workflow-state $job_name > /dev/null
+  if [[ $? -ne 0 ]]; then
+    log "$job_name cannot be found"
+    # FIXME remove the file, since we cannot tell if the job ever ran
+    mkdir -p $fail_dir || (log "failed to create $fail_dir" && exit 1)
+    mv $job_file $fail_dir
+    # if we got here the cycl workflow is unknown/deleted,
+    return -3
+  fi
+
+  # check the states of the finished tasks
+  # since the workflow is not running, if any step did not succeed the workflow failed.
+  local failed="${job_file}.failed"
+  cylc workflow-state $job_name | grep -v succeeded > $failed
+  retcode=$?
+  # FIXME put the failures from the failed file on the results website
+  if [ $retcode -eq 0 ]; then
+    log "$job_name failed"
+    mkdir -p $fail_dir || (log "failed to create $fail_dir" && exit 1)
+    mv $job_file $fail_dir
+    mv $failed $fail_dir
+    # if we got here a cycl workflow has finished with failures
+    return -3
+  fi
+
+  # if we got here a cycl workflow has finished without failures,
+  log "$job_name completed successfully"
+  mkdir -p $pass_dir || (log "failed to create $pass_dir" && exit 1)
+  log "mv $job_file $pass_dir"
+  mv $job_file $pass_dir
+  rm -f $failed
+  return 0
+}
+
+# create comparison graphs between this cylc experiment and the previous run
+make_graphs()
+{
+  local graphics_dir=$1 # where the mpas-bundle graphing code is
+  local output_dir=$2   # where to put the graphs
+  local files_dir=$3
+  local success_file=$4 # the workflow to process. assume a name of <workflow>.<date>_cron
+
+  local success_job=${success_file%.*}
+  local pass_dir=$files_dir/$PASS_DIR  # where the passed workflow names are
+  local graph_dir=$files_dir/$GRAPHED_DIR # where the graphed workflows are
+  local date="$(date +%F)"
+  local queue="develop"
+  local account="nmmm0043"
+  echo "success_job: $success_job"
+
+  # find the two most recent passed workflows
+  local passed_files=$(ls -r ${pass_dir}/${success_job}*)
+  passed_files_array=($passed_files)
+  local npassed_files=${#passed_files_array[@]} 
+  log "passed nfiles: ${npassed_files}"
+  if [ "${npassed_files}" -eq 0 ]; then
+    log "there aren't any new jobs to graph"
+    return
+  fi
+
+  # find the most recent graphed workflow
+  local graphed_files=$(ls -r ${graph_dir}/${success_job}*)
+  graphed_files_array=($graphed_files)
+  log "graphed nfiles: ${#graphed_files_array[@]}"
+
+  if [ "${npassed_files}" -lt 2 ] && [ "${#graphed_files_array[@]}" -eq 0 ]; then
+    log "there aren't two successful cylc runs to compare"
+    return
+  fi
+
+  # the contents of the workflow files are the names of the workflows
+  # compare the newest run against the previous run
+  local new_run=$(cat ${passed_files_array[0]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+  if [ "${#passed_files_array[@]}" -gt 1 ]; then
+    local base_run=$(cat ${passed_files_array[1]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+  else
+    local base_run=$(cat ${graphed_files_array[1]} | sed 's/MPAS-Workflow//' | sed 's/\///g')
+  fi
+  log "newest run: $new_run"
+  log "previous run: $base_run"
+  local exp_names="previous:$base_run,current:$new_run"
+
+  # make forecast comparison graphs
+  local target_dir=$output_dir/$date/model
+  mkdir -p $target_dir || (log "failed to create $target_dir" && exit 1)
+  cd $target_dir
+  log "making graphs in $target_dir"
+  local an_stats_args=" -s $graphics_dir -q $queue -a $account -n 1 -c previous -e $exp_names -d mpas -p model -t forecast"
+  log "$graphics_dir/SpawnAnalyzeStats.py -s $an_stats_args"
+  #$graphics_dir/SpawnAnalyzeStats.py $an_stats_args
+
+  # make omb/oma comparison graphs
+  local target_dir=$output_dir/$date/obs
+  mkdir -p $target_dir || (log "failed to create $target_dir" && exit 1)
+  cd $target_dir
+  log "making graphs in $target_dir"
+  local an_stats_args=" -s $graphics_dir -q $queue -a $account -n 1 -c previous -e $exp_names -d amsua_,sonde,airc,sfc,gnssrobndropp1d,satwind,mhs_as  -p obs -t omb/oma"
+  log "$graphics_dir/SpawnAnalyzeStats.py $an_stats_args"
+  #$graphics_dir/SpawnAnalyzeStats.py $an_stats_args
+
+  # make sure the graphed files get moved to the "graphed" directory
+  mkdir -p $graph_dir || (log "failed to create $graph_dir" && exit 1)
+  log "mv ${passed_files_array[0]} $graph_dir"
+  mv ${passed_files_array[0]} $graph_dir
+  if [ "${#passed_files_array[@]}" -gt 1 ]; then
+    log "mv ${passed_files_array[1]} $graph_dir"
+    mv ${passed_files_array[1]} $graph_dir
+  fi
+}
+
+main()
+{
+  local workflow_dir=""
+  local bundle_dir=""
+  local build_lock_file=""
+  local graphics_dir=""
+  local output_dir=""
+  local scenario=""
+  local suffix=""
+  local help=""
+  local CYLC_ENV_SCRIPT="env-setup/machine.sh"
+
+# get comamnd line args
+  while getopts w:d:k:g:o:s:x:l:h flag
+  do
+    case "${flag}" in
+      w) workflow_dir="${OPTARG}";;
+      d) bundle_dir="${OPTARG}";;
+      k) build_lock_file="${OPTARG}";;
+      g) graphics_dir="${OPTARG}";;
+      o) output_dir="${OPTARG}";;
+      s) scenario="${OPTARG}";;
+      x) suffix="${OPTARG}";;
+      l) LOGDIR=${OPTARG};;
+      h) help="help";;
+    esac
+  done
+
+  init_logs $LOGDIR "cron"
+  log "commandline: $0 $*"
+
+  if [ "$help" != "" ]; then
+    usage
+  fi
+
+  if [ "$suffix" == "" ] && [ "$graphics_dir" == "" ]; then
+    log "suffix (-x <suffix>) is required."
+    usage
+  fi
+  # FIXME is this needed?
+  #suffix=${suffix}
+
+  check_exists "$workflow_dir" "workflow dir" "dir"
+  # make sure Run.py is in the workflow directory
+  check_exists "$workflow_dir/Run.py" "file"
+  check_exists "$workflow_dir/$CYLC_ENV_SCRIPT" "file"
+
+  cd $workflow_dir
+  log "source $CYLC_ENV_SCRIPT"
+  source $CYLC_ENV_SCRIPT &> /dev/null
+
+  if [ "$graphics_dir" == "" ]; then
+    if [ "$bundle_dir" != "" ]; then
+      check_exists "$bundle_dir" "bundle dir" "dir"
+    fi
+    check_exists "$workflow_dir/$scenario" "scenario" "file"
+
+    # see if the mpas-bundle build lockfile exists, if so mpas-bundle is still compiling
+    if [ "$build_lock_file" != "" ]; then
+      if [ -e "$build_lock_file" ]; then
+        log "the mpas-bundle build is in progress, $build_lock_file exists"
+        exit 1
+      fi
+    fi
+
+    run_cylc $workflow_dir $scenario $suffix $LOGDIR $bundle_dir 
+  else
+    local success_file=""
+
+    check_exists "$output_dir" "output dir" "dir"
+    check_exists "$graphics_dir" "bundle dir" "dir"
+    check_exists "$graphics_dir/SpawnAnalyzeStats.py" "SpawnAnalyzeStats.py" "file"
+
+    # see if a cron cylc workflow needs post processing, success_file is returned if one does
+    check_cylc $LOGDIR success_file
+    if [ "$?" -ne 0 ]; then
+      log "there were no running jobs"
+      #return 0
+    fi
+
+    # set up python environment for the graphics tools
+    module reset 2> /dev/null
+    module load conda/latest
+    conda activate npl-2023a
+
+    # make a graph comparing the 2 most recent workflows which passed
+    echo "make_graphs $graphics_dir $output_dir $LOGDIR $success_file"
+    make_graphs $graphics_dir $output_dir $LOGDIR $success_file
+  fi
+}
+
+main "$@"
+

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -465,7 +465,18 @@ main()
 
   if [ "$graphics_dir" == "" ]; then
     if [ "$bundle_dir" != "" ]; then
-      check_exists "$bundle_dir" "bundle dir" "dir"
+      # if the bundle_dir doesn't exist, look for the newest dir w/
+      # the same root name, e.g. bundle_dir_<something>
+      if [ ! -d "${bundle_dir}" ]; then
+        local readonly b_dirs=($(ls -rd ${bundle_dir}*))
+        if [ "${#b_dirs[@]}" -gt 0 ]; then
+          log "setting bundle_dir=${b_dirs[0]}"
+          bundle_dir=${b_dirs[0]}
+        else
+          log "cannot find any build dirs at ${bundle_dir}"
+          usage
+        fi
+      fi
     fi
     check_exists "$workflow_dir/$scenario" "scenario" "file"
 

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -132,6 +132,7 @@ run_cylc()
 check_running_jobs()
 {
   local files_dir=$1
+  local output_dir=$2 # where results go, to be sent to web server
   local run_dir=$files_dir/$RUN_DIR
   local retcode=0
 
@@ -150,7 +151,7 @@ check_running_jobs()
   log "running_jobs=$running_jobs"
   for job in $running_jobs ; do
     job_name=$(cat $run_dir/$job)
-    check_cylc_job $job_name $run_dir/$job $files_dir
+    check_cylc_job $job_name $run_dir/$job $files_dir $output_dir
     retcode=$?
     if [ $retcode -eq 0 ]; then
       echo "$job_name completed successfully"
@@ -169,6 +170,7 @@ check_cylc_job()
   local job_name=$1
   local job_file=$2 # file with the name of the running job (including absolute path)
   local files_dir=$3  # base directory for the running/passed/failed jobs directories
+  local output_dir=$4 # directory to put results in, contents will get sent to the webserver
   local pass_dir=$files_dir/$PASS_DIR
   local fail_dir=$files_dir/$FAIL_DIR
   local retcode=0
@@ -198,12 +200,14 @@ check_cylc_job()
   local failed="${job_file}.failed"
   cylc workflow-state $job_name | grep -v succeeded > $failed
   retcode=$?
-  # FIXME put the failures from the failed file on the results website
   if [ $retcode -eq 0 ]; then
     log "$job_name failed"
-    mkdir -p $fail_dir || (log "failed to create $fail_dir" && exit 1)
+    local today=$(date +%F)
+    mkdir -p $fail_dir || (log "failed to create $fail_dir" && return -3)
     mv $job_file $fail_dir
-    mv $failed $fail_dir
+    cp $failed $fail_dir
+    mkdir -p $output_dir/$today || (log "failed to create $output_dir/$today" && return -3)
+    mv $failed $output_dir/$today
     # if we got here a cycl workflow has finished with failures
     return -3
   fi
@@ -369,7 +373,7 @@ main()
     check_exists "$graphics_dir/SpawnAnalyzeStats.py" "SpawnAnalyzeStats.py" "file"
 
     # see if any cron cylc workflowS have finished
-    check_running_jobs $LOGDIR
+    check_running_jobs $LOGDIR $output_dir
     if [ "$?" -ne 0 ]; then
       log "there were no running jobs"
       #return 0


### PR DESCRIPTION
### Description
This PR has a script which will run cylc jobs and graph the results.
It is intended to by run from cron, but can also be run manually.
Command line options control whether the script will run a cycl job, or look for results of previously started job.

Testing was done manually.

Note this relies on changes to the graphing code, including https://github.com/JCSDA-internal/mpas-jedi/pull/1022 (merged) 
and https://github.com/JCSDA-internal/mpas-jedi/pull/1027