### PR TITLE
Bugfix for handling the missing of last instrument in prepare initial yaml file.

### DIFF
--- a/bin/PrepJEDI.csh
+++ b/bin/PrepJEDI.csh
@@ -266,6 +266,9 @@ foreach instrument ($observers)
   date
 end
 
+# Need to go back to the working directory if the last instrument is missing
+cd ${WorkDir}
+
 # =========================
 # Satellite bias correction
 # =========================


### PR DESCRIPTION
### Description
In current PrepJEDI.csh, it will loop all the instruments. For each instrument, it will first come to the ${mainScriptDir} and then back to the ${WorkDir}. If one instrument is not available, it will skip to the next one without going back to the  ${WorkDir}. If the last instrument is not available, it will not go back to the ${WorkDir}. In that case, the orig.yaml will never be created under the ${WorkDir}. 
This PR fixes this bug.