### PR TITLE
Remove interpolation type

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -48,17 +48,17 @@ ecbuild_bundle( PROJECT ropp-ufo  GIT "https://github.com/JCSDA-internal/ropp-te
 option(BUNDLE_SKIP_RTTOV "Don't build rttov"  "ON") # Skip rttov build unless user passes -DBUNDLE_SKIP_RTTOV=OFF
 ecbuild_bundle( PROJECT rttov     GIT "https://github.com/JCSDA-internal/rttov.git"       BRANCH develop UPDATE )
 
-ecbuild_bundle( PROJECT oops      GIT "https://github.com/JCSDA-internal/oops.git"        TAG 463e67a5 )
-ecbuild_bundle( PROJECT vader     GIT "https://github.com/JCSDA-internal/vader.git"       TAG 14e8bce  )
-ecbuild_bundle( PROJECT saber     GIT "https://github.com/JCSDA-internal/saber.git"       TAG 48c0f95b )
-ecbuild_bundle( PROJECT crtm      GIT "https://github.com/JCSDA/CRTMv3.git"               TAG 0eff2d1  )
+ecbuild_bundle( PROJECT oops      GIT "https://github.com/JCSDA-internal/oops.git"        TAG 58b06876 )
+ecbuild_bundle( PROJECT vader     GIT "https://github.com/JCSDA-internal/vader.git"       TAG 0792f69  )
+ecbuild_bundle( PROJECT saber     GIT "https://github.com/JCSDA-internal/saber.git"       TAG 04087e60 )
+ecbuild_bundle( PROJECT crtm      GIT "https://github.com/JCSDA/CRTMv3.git"               TAG cda06c9  )
 
 option(ENABLE_IODA_DATA "Obtain ioda test data from ioda-data repository (vs tarball)" ON)
-ecbuild_bundle( PROJECT ioda-data GIT "https://github.com/JCSDA-internal/ioda-data.git"   TAG c6e3a8b  )
-ecbuild_bundle( PROJECT ioda      GIT "https://github.com/JCSDA-internal/ioda.git"        TAG 4fbcc851 )
+ecbuild_bundle( PROJECT ioda-data GIT "https://github.com/JCSDA-internal/ioda-data.git"   TAG 47b232c  )
+ecbuild_bundle( PROJECT ioda      GIT "https://github.com/JCSDA-internal/ioda.git"        TAG 7f0c6c05 )
 option(ENABLE_UFO_DATA "Obtain ufo test data from ufo-data repository (vs tarball)" ON)
-ecbuild_bundle( PROJECT ufo-data  GIT "https://github.com/JCSDA-internal/ufo-data.git"    TAG b003752  )
-ecbuild_bundle( PROJECT ufo       GIT "https://github.com/JCSDA-internal/ufo.git"         TAG b076df47 )
+ecbuild_bundle( PROJECT ufo-data  GIT "https://github.com/JCSDA-internal/ufo-data.git"    TAG c15e9c5  )
+ecbuild_bundle( PROJECT ufo       GIT "https://github.com/JCSDA-internal/ufo.git"         TAG 7da3e540 )
 
 
 # Find external ESMF for mpas-model (optional)
@@ -70,7 +70,7 @@ set(MPAS_CORES init_atmosphere atmosphere CACHE STRING "MPAS-Model: cores to bui
 ecbuild_bundle( PROJECT MPAS      GIT "https://github.com/MPAS-Dev/MPAS-Model" TAG 41e9a3fb8 )
 option(ENABLE_MPAS_JEDI_DATA "Obtain mpas-jedi test data from mpas-jedi-data repository (vs tarball)" ON)
 ecbuild_bundle( PROJECT mpas-jedi-data  GIT "https://github.com/JCSDA-internal/mpas-jedi-data.git"  TAG 12cdc56 )
-ecbuild_bundle( PROJECT mpas-jedi GIT "https://github.com/JCSDA-internal/mpas-jedi"      TAG 50cf13c )
+ecbuild_bundle( PROJECT mpas-jedi GIT "https://github.com/JCSDA-internal/mpas-jedi"      TAG 61ec4f9 )
 
 # Set GIT_BRANCH_FUNC to MPAS-JEDI's current branch so that it can be used for mpas-jedi-data
 find_branch_name(REPO_DIR_NAME mpas-jedi)

--- a/config/jedi/ObsPlugs/da/base/abi-clr_g16.yaml
+++ b/config/jedi/ObsPlugs/da/base/abi-clr_g16.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: abi_g16
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/da/base/abi_g16.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: abi_g16
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/ahi-clr_himawari8.yaml
+++ b/config/jedi/ObsPlugs/da/base/ahi-clr_himawari8.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: ahi_himawari8
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/da/base/ahi_himawari8.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: ahi_himawari8
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/aircraft.yaml
+++ b/config/jedi/ObsPlugs/da/base/aircraft.yaml
@@ -17,5 +17,3 @@
   <<: *heightAndHorizObsLoc
   obs operator:
     name: VertInterp
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_aqua.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_aqua
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_metop-a.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_metop-a
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_metop-b.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_metop-b
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_n15.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_n15.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n15
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_n18.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_n18.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n18
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_n19.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_n19.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n19
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_aqua.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_aqua
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_metop-a.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_metop-a
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_metop-b.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_metop-b
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_metop-c.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_metop-c
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_n15.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n15
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_n18.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n18
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_n19.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n19
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/gnssrobndmo-nopseudo.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrobndmo-nopseudo.yaml
@@ -22,5 +22,3 @@
     vert_interp_ops: false
     pseudo_ops: false
     min_temp_grad: 1.0e-6
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/gnssrobndmo.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrobndmo.yaml
@@ -22,5 +22,3 @@
     vert_interp_ops: true
     pseudo_ops: true
     min_temp_grad: 1.0e-6
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/gnssrobndnbam.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrobndnbam.yaml
@@ -26,5 +26,3 @@
       #sr_steps: 2 # same as default, super-refraction steps
       vertlayer: mass # or full, type of vertical layers for pressure and geopotential height
       #super_ref_qc: NBAM # same as default, or ECMWF
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/gnssrobndropp1d.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrobndropp1d.yaml
@@ -21,5 +21,3 @@
   <<: *heightAndHorizObsLoc
   obs operator:
     name: GnssroBndROPP1D
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/gnssrorefncep.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrorefncep.yaml
@@ -18,5 +18,3 @@
     name: GnssroRefNCEP
     obs options:
       use_compress: 0
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/gnssrorefncep_tunedErrors.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrorefncep_tunedErrors.yaml
@@ -18,5 +18,3 @@
     name: GnssroRefNCEP
     obs options:
       use_compress: 0
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/iasi_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/iasi_metop-a.yaml
@@ -26,5 +26,4 @@
       <<: *CRTMObsOptions
       Sensor_ID: iasi_metop-a
   get values:
-    <<: *GetValues
     tropopause pressure method: {{tropprsMethod}}

--- a/config/jedi/ObsPlugs/da/base/iasi_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/iasi_metop-b.yaml
@@ -26,5 +26,4 @@
       <<: *CRTMObsOptions
       Sensor_ID: iasi_metop-b
   get values:
-    <<: *GetValues
     tropopause pressure method: {{tropprsMethod}}

--- a/config/jedi/ObsPlugs/da/base/iasi_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/base/iasi_metop-c.yaml
@@ -26,5 +26,4 @@
       <<: *CRTMObsOptions
       Sensor_ID: iasi_metop-c
   get values:
-    <<: *GetValues
     tropopause pressure method: {{tropprsMethod}}

--- a/config/jedi/ObsPlugs/da/base/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_metop-a.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: mhs_metop-a
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_metop-b.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: mhs_metop-b
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_n18.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: mhs_n18
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_n19.yaml
@@ -20,5 +20,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: mhs_n19
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/satwind.yaml
+++ b/config/jedi/ObsPlugs/da/base/satwind.yaml
@@ -18,5 +18,3 @@
   obs operator:
     name: VertInterp
     observation alias file: obsop_name_map.yaml
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/satwnd.yaml
+++ b/config/jedi/ObsPlugs/da/base/satwnd.yaml
@@ -18,5 +18,3 @@
   obs operator:
     name: VertInterp
     observation alias file: obsop_name_map.yaml
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/sfc.yaml
+++ b/config/jedi/ObsPlugs/da/base/sfc.yaml
@@ -20,5 +20,3 @@
   linear obs operator:
     name: Identity
     observation alias file: obsop_name_map.yaml
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/sondes-2018043006.yaml
+++ b/config/jedi/ObsPlugs/da/base/sondes-2018043006.yaml
@@ -17,5 +17,3 @@
   obs operator:
     name: VertInterp
     observation alias file: obsop_name_map.yaml
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/da/base/sondes.yaml
+++ b/config/jedi/ObsPlugs/da/base/sondes.yaml
@@ -17,5 +17,3 @@
   obs operator:
     name: VertInterp
     observation alias file: obsop_name_map.yaml
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/enkf/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/enkf/ObsAnchors.yaml
@@ -68,8 +68,5 @@ _cloudy crtm: &cloudyCRTMObsOperator
   obs options:
     <<: *CRTMObsOptions
 
-_get values: &GetValues
-  nnearest: 3
-
 _multi iteration filter: &multiIterationFilter
   _blank: null

--- a/config/jedi/ObsPlugs/hofx/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/hofx/ObsAnchors.yaml
@@ -23,7 +23,5 @@ _cloudy crtm: &cloudyCRTMObsOperator
   Cloud_Seeding: true
   obs options:
     <<: *CRTMObsOptions
-_get values: &GetValues
-  nnearest: 3
 _multi iteration filter: &multiIterationFilter
   _blank: null

--- a/config/jedi/ObsPlugs/hofx/base/abi-clr_g16.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/abi-clr_g16.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: abi_g16
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/abi_g16.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: abi_g16
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/ahi-clr_himawari8.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/ahi-clr_himawari8.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: ahi_himawari8
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/ahi_himawari8.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: ahi_himawari8
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/aircraft.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/aircraft.yaml
@@ -14,5 +14,3 @@
   obs operator:
     name: VertInterp
     observation alias file: obsop_name_map.yaml
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_aqua.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_aqua.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_aqua
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-a.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_metop-a
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-b.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_metop-b
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_n15.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_n15.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n15
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_n18.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_n18.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n18
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_n19.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n19
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_aqua.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_aqua
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_metop-a.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_metop-a
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_metop-b.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_metop-b
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua_metop-c.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_metop-c.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_metop-c
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_n15.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n15
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_n18.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n18
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_n19.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: amsua_n19
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/gnssrobndmo-nopseudo.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrobndmo-nopseudo.yaml
@@ -18,5 +18,3 @@
     vert_interp_ops: false
     pseudo_ops: false
     min_temp_grad: 1.0e-6
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/gnssrobndmo.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrobndmo.yaml
@@ -18,5 +18,3 @@
     vert_interp_ops: true
     pseudo_ops: true
     min_temp_grad: 1.0e-6
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/gnssrobndnbam.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrobndnbam.yaml
@@ -22,5 +22,3 @@
       #sr_steps: 2 # same as default, super-refraction steps
       vertlayer: mass # or full, type of vertical layers for pressure and geopotential height
       #super_ref_qc: NBAM # same as default, or ECMWF
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/gnssrobndropp1d.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrobndropp1d.yaml
@@ -17,5 +17,3 @@
   obs error: *ObsErrorDiagonal
   obs operator:
     name: GnssroBndROPP1D
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/gnssrorefncep.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrorefncep.yaml
@@ -15,5 +15,3 @@
     name: GnssroRefNCEP
     obs options:
       use_compress: 0
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/gnssrorefncep_tunedErrors.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrorefncep_tunedErrors.yaml
@@ -15,5 +15,3 @@
     name: GnssroRefNCEP
     obs options:
       use_compress: 0
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/iasi_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/iasi_metop-a.yaml
@@ -21,5 +21,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: iasi_metop-a
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/iasi_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/iasi_metop-b.yaml
@@ -21,5 +21,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: iasi_metop-b
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/iasi_metop-c.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/iasi_metop-c.yaml
@@ -21,5 +21,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: iasi_metop-c
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/mhs_metop-a.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: mhs_metop-a
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/mhs_metop-b.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: mhs_metop-b
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/mhs_n18.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: mhs_n18
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/mhs_n19.yaml
@@ -17,5 +17,3 @@
     obs options:
       <<: *CRTMObsOptions
       Sensor_ID: mhs_n19
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/satwind.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/satwind.yaml
@@ -14,5 +14,3 @@
   obs operator:
     name: VertInterp
     observation alias file: obsop_name_map.yaml
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/satwnd.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/satwnd.yaml
@@ -14,5 +14,3 @@
   obs operator:
     name: VertInterp
     observation alias file: obsop_name_map.yaml
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/sfc.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/sfc.yaml
@@ -14,5 +14,3 @@
   obs operator:
     name: SfcPCorrected
     da_psfc_scheme: UKMO   # or WRFDA
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/sondes-2018043006.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/sondes-2018043006.yaml
@@ -14,5 +14,3 @@
   obs operator:
     name: VertInterp
     observation alias file: obsop_name_map.yaml
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/base/sondes.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/sondes.yaml
@@ -14,5 +14,3 @@
   obs operator:
     name: VertInterp
     observation alias file: obsop_name_map.yaml
-  get values:
-    <<: *GetValues

--- a/config/jedi/ObsPlugs/hofx/filters/sondes-2018043006.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/sondes-2018043006.yaml
@@ -1,5 +1,3 @@
-  get values:
-    <<: *GetValues
   obs filters:
   - filter: PreQC
     maxvalue: 3

--- a/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
@@ -42,8 +42,5 @@ _cloudy crtm: &cloudyCRTMObsOperator
   obs options:
     <<: *CRTMObsOptions
 
-_get values: &GetValues
-  nnearest: 3
-
 _multi iteration filter: &multiIterationFilter
   apply at iterations: 0,1,2,3,4,5

--- a/config/jedi/applications/3denvar-crossed.yaml
+++ b/config/jedi/applications/3denvar-crossed.yaml
@@ -4,7 +4,6 @@ _iteration: &iterationConfig
     nml_file: {{InnerNamelistFile}}
     streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   gradient norm reduction: 1e-3
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
@@ -38,7 +37,6 @@ cost function:
     nml_file: {{OuterNamelistFile}}
     streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   analysis variables: *incvars
   background:
     state variables: [{{StateVariables}}]

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -4,7 +4,6 @@ _iteration: &iterationConfig
     nml_file: {{InnerNamelistFile}}
     streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   gradient norm reduction: 1e-3
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
@@ -38,7 +37,6 @@ cost function:
     nml_file: {{OuterNamelistFile}}
     streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   analysis variables: *incvars
   background:
     state variables: [{{StateVariables}}]

--- a/config/jedi/applications/3dhybrid-allsky.yaml
+++ b/config/jedi/applications/3dhybrid-allsky.yaml
@@ -4,7 +4,6 @@ _iteration: &iterationConfig
     nml_file: {{InnerNamelistFile}}
     streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   gradient norm reduction: 1e-3
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
@@ -38,7 +37,6 @@ cost function:
     nml_file: {{OuterNamelistFile}}
     streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   analysis variables: *incvars
   background:
     state variables: [{{StateVariables}}]

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -4,7 +4,6 @@ _iteration: &iterationConfig
     nml_file: {{InnerNamelistFile}}
     streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   gradient norm reduction: 1e-3
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
@@ -38,7 +37,6 @@ cost function:
     nml_file: {{OuterNamelistFile}}
     streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   analysis variables: *incvars
   background:
     state variables: [{{StateVariables}}]

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -4,7 +4,6 @@ _iteration: &iterationConfig
     nml_file: {{InnerNamelistFile}}
     streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   gradient norm reduction: 1e-3
 output:
   filename: {{anStateDir}}{{MemberDir}}/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
@@ -26,7 +25,6 @@ cost function:
     nml_file: {{OuterNamelistFile}}
     streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   analysis variables: &incvars [{{AnalysisVariables}}]
   background:
     state variables: [{{StateVariables}}]

--- a/config/jedi/applications/4denvar_3slots.yaml
+++ b/config/jedi/applications/4denvar_3slots.yaml
@@ -4,7 +4,6 @@ _iteration: &iterationConfig
     nml_file: {{InnerNamelistFile}}
     streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   gradient norm reduction: 1e-3
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
@@ -45,7 +44,6 @@ cost function:
     nml_file: {{OuterNamelistFile}}
     streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   analysis variables: *incvars
   background:
     states:

--- a/config/jedi/applications/4denvar_7slots.yaml
+++ b/config/jedi/applications/4denvar_7slots.yaml
@@ -4,7 +4,6 @@ _iteration: &iterationConfig
     nml_file: {{InnerNamelistFile}}
     streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   gradient norm reduction: 1e-3
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
@@ -57,7 +56,6 @@ cost function:
     nml_file: {{OuterNamelistFile}}
     streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   analysis variables: *incvars
   background:
     states:

--- a/config/jedi/applications/4dhybrid.yaml
+++ b/config/jedi/applications/4dhybrid.yaml
@@ -4,7 +4,6 @@ _iteration: &iterationConfig
     nml_file: {{InnerNamelistFile}}
     streams_file: {{InnerStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   gradient norm reduction: 1e-3
   #Several 'online diagnostics' are useful for checking the H correctness and Hessian symmetry
 #  online diagnostics:
@@ -57,7 +56,6 @@ cost function:
     nml_file: {{OuterNamelistFile}}
     streams_file: {{OuterStreamsFile}}{{StreamsFileMember}}
     deallocate non-da fields: true
-    interpolation type: unstructured
   analysis variables: *incvars
   background:
     states:

--- a/config/jedi/applications/enkf.yaml
+++ b/config/jedi/applications/enkf.yaml
@@ -29,7 +29,6 @@ geometry:
   nml_file: {{EnKFNamelistFile}}
   streams_file: {{EnKFStreamsFile}}
   deallocate non-da fields: true
-  #interpolation type: unstructured # no Increment/State interp in enkf
 
 time window:
   begin: {{windowBegin}}

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -44,7 +44,7 @@ class Build(Component):
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
       else:
         self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_25Nov2024/build_SP', str] ## develop
+          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_16Dec2024/build_SP', str] ## develop
 
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]


### PR DESCRIPTION
### Description
This PR removes the `interpolation type` key work from the geometry section in each DA application, following recent changes in [PR#1002](https://github.com/JCSDA-internal/mpas-jedi/pull/1002) to use a generic interpolator for resolution changes.  The build is updated for this new change in mpas-jedi. Here, the `&GetValues` anchors and references (`*GetValues`) in the observation yaml files for the unstructured interpolation type with `nnereast: 3`( for the 3 nearest cells) is also removed. This was removed long time ago  in [PR#877](https://github.com/JCSDA-internal/mpas-jedi/pull/877).

### Issue closed
Closes #334 

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
