### PR TITLE
Fix concat task dependencies for Variational and EnKF

### DIFF
--- a/initialize/applications/EnKF.py
+++ b/initialize/applications/EnKF.py
@@ -261,7 +261,7 @@ class EnKF(Component):
     script = $origin/bin/ConcatenateObsFeedback.csh '''+concatArgs+'''
 '''+concattask.job()+concattask.directives()]
       self._dependencies += ['''
-        EnKF => ConcatEnKF''']
+        EnKF => ConcatEnKF => '''+self.tf.finished]
 
     self._dependencies += ['''
 

--- a/initialize/applications/EnKF.py
+++ b/initialize/applications/EnKF.py
@@ -261,7 +261,7 @@ class EnKF(Component):
     script = $origin/bin/ConcatenateObsFeedback.csh '''+concatArgs+'''
 '''+concattask.job()+concattask.directives()]
       self._dependencies += ['''
-        EnKF => ConcatEnKF => '''+self.tf.finished]
+        EnKF => ConcatEnKF => '''+self.tf.post]
 
     self._dependencies += ['''
 

--- a/initialize/applications/HofX.py
+++ b/initialize/applications/HofX.py
@@ -261,7 +261,7 @@ class HofX(Component):
     script = $origin/bin/ConcatenateObsFeedback.csh '''+concatArgs+'''
 '''+concattask.job()+concattask.directives()]
         self._dependencies += ['''
-        '''+execute+''' => '''+concat+''' => '''+self.tf.finished]
+        '''+execute+''' => '''+concat+''' => '''+self.tf.post]
 
     #########
     # outputs

--- a/initialize/applications/Variational.py
+++ b/initialize/applications/Variational.py
@@ -376,7 +376,7 @@ class Variational(Component):
     script = $origin/bin/ConcatenateObsFeedback.csh '''+concatArgs+'''
 '''+concattask.job()+concattask.directives()]
             self._dependencies += ['''
-        '''+self.base+str(mm)+''' => '''+concat]
+        '''+self.base+str(mm)+''' => '''+concat+''' => '''+self.tf.finished]
 
       else:
         # single instance or ensemble of EnsembleOfVariational(s)
@@ -400,7 +400,7 @@ class Variational(Component):
     script = $origin/bin/ConcatenateObsFeedback.csh '''+concatArgs+'''
 '''+concattask.job()+concattask.directives()]
             self._dependencies += ['''
-        EDA'''+str(instance)+''' => '''+concat]
+        EDA'''+str(instance)+''' => '''+concat+''' => '''+self.tf.finished]
 
     # TODO: make ABEI consistent with external class design
     # GenerateABEInflation

--- a/initialize/applications/Variational.py
+++ b/initialize/applications/Variational.py
@@ -376,7 +376,7 @@ class Variational(Component):
     script = $origin/bin/ConcatenateObsFeedback.csh '''+concatArgs+'''
 '''+concattask.job()+concattask.directives()]
             self._dependencies += ['''
-        '''+self.base+str(mm)+''' => '''+concat+''' => '''+self.tf.finished]
+        '''+self.base+str(mm)+''' => '''+concat+''' => '''+self.tf.post]
 
       else:
         # single instance or ensemble of EnsembleOfVariational(s)
@@ -400,7 +400,7 @@ class Variational(Component):
     script = $origin/bin/ConcatenateObsFeedback.csh '''+concatArgs+'''
 '''+concattask.job()+concattask.directives()]
             self._dependencies += ['''
-        EDA'''+str(instance)+''' => '''+concat+''' => '''+self.tf.finished]
+        EDA'''+str(instance)+''' => '''+concat+''' => '''+self.tf.post]
 
     # TODO: make ABEI consistent with external class design
     # GenerateABEInflation


### PR DESCRIPTION
### Description
This PR fixes the dependency for the `concat` task in the `Variational` and `EnKF` applications. The `HofX` was fixed some time ago but I missed fixing these two as well.

### Issue closed
None

### Tests completed
#### Tier 1:
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
