### PR TITLE
Adapting jcsda-internal/mpas-jedi#1011

### DIFF
--- a/config/mpas/geovars.yaml
+++ b/config/mpas/geovars.yaml
@@ -44,11 +44,11 @@ fields:
 
   - field name: eastward_wind
     mpas template field: theta
-    mpas identity field: uReconstructZonal
+    mpas identity field: eastward_wind
 
   - field name: northward_wind
     mpas template field: theta
-    mpas identity field: uReconstructMeridional
+    mpas identity field: northward_wind
 
   - field name: water_vapor_mixing_ratio_wrt_dry_air
     mpas template field: theta

--- a/config/mpas/variables.csh
+++ b/config/mpas/variables.csh
@@ -10,11 +10,15 @@ set StandardAnalysisVariables = ( \
   spechum \
   surface_pressure \
   temperature \
-  uReconstructMeridional \
-  uReconstructZonal \
+  eastward_wind \
+  northward_wind \
 )
 set StandardStateVariables = ( \
-  $StandardAnalysisVariables \
+  spechum \
+  surface_pressure \
+  temperature \
+  uReconstructMeridional \
+  uReconstructZonal \
   theta \
   rho \
   u \

--- a/config/mpas/variables.csh
+++ b/config/mpas/variables.csh
@@ -10,8 +10,8 @@ set StandardAnalysisVariables = ( \
   spechum \
   surface_pressure \
   temperature \
-  eastward_wind \
   northward_wind \
+  eastward_wind \
 )
 set StandardStateVariables = ( \
   spechum \

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -44,7 +44,7 @@ class Build(Component):
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
       else:
         self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_16Dec2024/build_SP', str] ## develop
+          ['/glade/derecho/scratch/bjung/panda-c/code_spectralWindNaming/mpas-bundle/build_single', str] ## develop
 
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]


### PR DESCRIPTION
### Description

This PR adapts the changes required for jcsda-internal/mpas-jedi#1011.

* This PR changes the **wind analysis variable names** (which were MPAS Model's name) to JEDI's generic names (which are ccpp names). 
  * `uReconstructZonal` --> `eastward_wind`
  * `uReconstructMeridional` --> `northward_wind`.
* Note that we keep using the MPAS wind variable names in **state variables**.
* Testing is under way (please see https://github.com/JCSDA-internal/mpas-jedi/pull/1037 ).

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
