### PR TITLE
Modify for suite GenerateExternalAnalyses

### DIFF
--- a/initialize/suites/GenerateExternalAnalyses.py
+++ b/initialize/suites/GenerateExternalAnalyses.py
@@ -15,6 +15,7 @@ from initialize.config.Config import Config
 
 from initialize.data.ExternalAnalyses import ExternalAnalyses
 from initialize.data.Model import Model
+from initialize.data.InvariantStream import InvariantStream
 
 from initialize.framework.Build import Build
 from initialize.framework.Experiment import Experiment
@@ -27,10 +28,12 @@ class GenerateExternalAnalyses(SuiteBase):
     super().__init__(conf)
 
     self.c['model'] = Model(conf)
+    meshes = self.c['model'].getMeshes()
     self.c['build'] = Build(conf, self.c['model'])
     self.c['externalanalyses'] = ExternalAnalyses(conf, self.c['hpc'], self.c['model'].getMeshes())
     self.c['initic'] = InitIC(conf, self.c['hpc'], self.c['model'].getMeshes(), self.c['externalanalyses'])
     self.c['experiment'] = Experiment(conf, self.c['hpc'])
+    self.c['ss'] = InvariantStream(conf, meshes, self.c['workflow']['FirstCycleDate'], self.c['externalanalyses'], self.c['experiment'])
     self.c['naming'] = Naming(conf, self.c['experiment'])
 
     # TODO: make members optional, modify getCycleVars

--- a/scenarios/GenerateGFSAnalyses.yaml
+++ b/scenarios/GenerateGFSAnalyses.yaml
@@ -2,12 +2,15 @@ suite: GenerateExternalAnalyses
 
 externalanalyses:
   resource: "GFS.RDA"
+  #resource: "GFS.NCEPFTP"
 experiment:
   name: 'GenerateGFSAnalyses'
   prefix: ''
+model:
+  outerMesh: 120km
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalQueue: main
+  NonCriticalQueue: main
 workflow:
   first cycle point: 20220606T00
   final cycle point: 20220608T00

--- a/scenarios/GenerateGFSAnalyses.yaml
+++ b/scenarios/GenerateGFSAnalyses.yaml
@@ -9,8 +9,10 @@ experiment:
 model:
   outerMesh: 120km
 hpc:
-  CriticalQueue: main
-  NonCriticalQueue: main
+  CriticalQueue: economy
+  NonCriticalQueue: economy
+  #CriticalQueue: main
+  #NonCriticalQueue: main
 workflow:
   first cycle point: 20220606T00
   final cycle point: 20220608T00


### PR DESCRIPTION
This PR addresses the GenerateGFSAnalyses scenario for MPAS-Workflow version 3.0 and later, which uses MPAS model version 8.2 and replaces static files with the Invariant file. Therefore, InvariantStream information needs to be added to the GenerateExternalAnalyses suite file.

Files modified: initialize/suites/GenerateExternalAnalyses.py
                          scenarios/GenerateGFSAnalyses.yaml
                         

### Tests completed

 
#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 
