### PR TITLE
Adapting jcsda-internal/mpas-jedi#1030

### DIFF
--- a/config/jedi/applications/3dhybrid-allsky.yaml
+++ b/config/jedi/applications/3dhybrid-allsky.yaml
@@ -85,10 +85,13 @@ cost function:
                 unbalanced variable: stream_function
               - balanced variable: surface_pressure
                 unbalanced variable: stream_function
-        linear variable change:
-          linear variable change name: Control2Analysis
-          input variables: *ctlvars
-          output variables: *incvars
+        model specific variable change:
+          inner variables: *ctlvars
+          outer variables: *incvars
+          linear variable change:
+            linear variable change name: Control2Analysis
+          variable change:
+            add vars and return: True
     - weight:
         date: *analysisDate
         stream name: control

--- a/config/jedi/applications/3dhybrid-allsky.yaml
+++ b/config/jedi/applications/3dhybrid-allsky.yaml
@@ -85,12 +85,12 @@ cost function:
                 unbalanced variable: stream_function
               - balanced variable: surface_pressure
                 unbalanced variable: stream_function
-        model specific variable change:
+        variable change:
           inner variables: *ctlvars
           outer variables: *incvars
           linear variable change:
             linear variable change name: Control2Analysis
-          variable change:
+          nonlinear variable change:
             add vars and return: True
     - weight:
         date: *analysisDate

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -83,12 +83,12 @@ cost function:
                 unbalanced variable: stream_function
               - balanced variable: surface_pressure
                 unbalanced variable: stream_function
-        model specific variable change:
+        variable change:
           inner variables: *ctlvars
           outer variables: *incvars
           linear variable change:
             linear variable change name: Control2Analysis
-          variable change:
+          nonlinear variable change:
             add vars and return: True
     - weight:
         value: {{ensembleCovarianceWeight}}

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -83,10 +83,13 @@ cost function:
                 unbalanced variable: stream_function
               - balanced variable: surface_pressure
                 unbalanced variable: stream_function
-        linear variable change:
-          linear variable change name: Control2Analysis
-          input variables: *ctlvars
-          output variables: *incvars
+        model specific variable change:
+          inner variables: *ctlvars
+          outer variables: *incvars
+          linear variable change:
+            linear variable change name: Control2Analysis
+          variable change:
+            add vars and return: True
     - weight:
         value: {{ensembleCovarianceWeight}}
       covariance:

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -66,10 +66,13 @@ cost function:
             unbalanced variable: stream_function
           - balanced variable: surface_pressure
             unbalanced variable: stream_function
-    linear variable change:
-      linear variable change name: Control2Analysis
-      input variables: *ctlvars
-      output variables: *incvars
+    model specific variable change:
+      inner variables: *ctlvars
+      outer variables: *incvars
+      linear variable change:
+        linear variable change name: Control2Analysis
+      variable change:
+        add vars and return: True
   observations:
     obs perturbations: {{ObsPerturbations}}
     observers:

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -66,12 +66,12 @@ cost function:
             unbalanced variable: stream_function
           - balanced variable: surface_pressure
             unbalanced variable: stream_function
-    model specific variable change:
+    variable change:
       inner variables: *ctlvars
       outer variables: *incvars
       linear variable change:
         linear variable change name: Control2Analysis
-      variable change:
+      nonlinear variable change:
         add vars and return: True
   observations:
     obs perturbations: {{ObsPerturbations}}

--- a/config/jedi/applications/4dhybrid.yaml
+++ b/config/jedi/applications/4dhybrid.yaml
@@ -120,10 +120,13 @@ cost function:
                 unbalanced variable: stream_function
               - balanced variable: surface_pressure
                 unbalanced variable: stream_function
-        linear variable change:
-          linear variable change name: Control2Analysis
-          input variables: *ctlvars
-          output variables: *incvars
+        model specific variable change:
+          inner variables: *ctlvars
+          outer variables: *incvars
+          linear variable change:
+            linear variable change name: Control2Analysis
+          variable change:
+            add vars and return: True
     - weight:
         value: {{ensembleCovarianceWeight}}
       covariance:

--- a/config/jedi/applications/4dhybrid.yaml
+++ b/config/jedi/applications/4dhybrid.yaml
@@ -120,12 +120,12 @@ cost function:
                 unbalanced variable: stream_function
               - balanced variable: surface_pressure
                 unbalanced variable: stream_function
-        model specific variable change:
+        variable change:
           inner variables: *ctlvars
           outer variables: *incvars
           linear variable change:
             linear variable change name: Control2Analysis
-          variable change:
+          nonlinear variable change:
             add vars and return: True
     - weight:
         value: {{ensembleCovarianceWeight}}

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -44,7 +44,7 @@ class Build(Component):
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
       else:
         self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_16Dec2024/build_SP', str] ## develop
+          ['/glade/derecho/scratch/bjung/panda-c/code_lvc_refactor/mpas-bundle/build_single', str] ## develop
 
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]


### PR DESCRIPTION
### Description

This PR adapts the changes required for jcsda-internal/mpas-jedi#1030.

* The yaml structure for `Control2Analysis` linear variable change, which is used for multivariate B, needs to be revised.


### Issue closed

Closes #341 

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [x] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
