### PR TITLE
Add MHS clear-sky assimilation using raw observations to replace the …

### DIFF
--- a/config/jedi/ObsPlugs/da/base/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_metop-a.yaml
@@ -12,7 +12,7 @@
     obsdatain: *{{ObsDataIn}}
     {{ObsDataOut}}
     simulated variables: [brightnessTemperature]
-    channels: &mhs_metop-a_channels 3-5
+    channels: &mhs_metop-a_channels 1-5
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc
   obs operator:

--- a/config/jedi/ObsPlugs/da/base/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_metop-b.yaml
@@ -12,7 +12,7 @@
     obsdatain: *{{ObsDataIn}}
     {{ObsDataOut}}
     simulated variables: [brightnessTemperature]
-    channels: &mhs_metop-b_channels 3-5
+    channels: &mhs_metop-b_channels 1-5
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc
   obs operator:

--- a/config/jedi/ObsPlugs/da/base/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_n18.yaml
@@ -12,7 +12,7 @@
     obsdatain: *{{ObsDataIn}}
     {{ObsDataOut}}
     simulated variables: [brightnessTemperature]
-    channels: &mhs_n18_channels 3-5
+    channels: &mhs_n18_channels 1-5
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc
   obs operator:

--- a/config/jedi/ObsPlugs/da/base/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_n19.yaml
@@ -12,7 +12,7 @@
     obsdatain: *{{ObsDataIn}}
     {{ObsDataOut}}
     simulated variables: [brightnessTemperature]
-    channels: &mhs_n19_channels 3-5
+    channels: &mhs_n19_channels 1-5
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc
   obs operator:

--- a/config/jedi/ObsPlugs/da/bias/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_metop-a.yaml
@@ -2,7 +2,7 @@
     input file: {{biasCorrectionDir}}/satbias_mhs_metop-a.h5
     output file: {{OutDBDir}}{{MemberDir}}/satbias_mhs_metop-a.h5
     variational bc:
-      predictors: &predictors1
+      predictors:
       - name: constant
       - name: lapseRate
         order: 2

--- a/config/jedi/ObsPlugs/da/bias/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_metop-b.yaml
@@ -2,7 +2,7 @@
     input file: {{biasCorrectionDir}}/satbias_mhs_metop-b.h5
     output file: {{OutDBDir}}{{MemberDir}}/satbias_mhs_metop-b.h5
     variational bc:
-      predictors: &predictors1
+      predictors:
       - name: constant
       - name: lapseRate
         order: 2

--- a/config/jedi/ObsPlugs/da/bias/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_n18.yaml
@@ -2,7 +2,7 @@
     input file: {{biasCorrectionDir}}/satbias_mhs_n18.h5
     output file: {{OutDBDir}}{{MemberDir}}/satbias_mhs_n18.h5
     variational bc:
-      predictors: &predictors1
+      predictors:
       - name: constant
       - name: lapseRate
         order: 2

--- a/config/jedi/ObsPlugs/da/bias/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/bias/mhs_n19.yaml
@@ -2,7 +2,7 @@
     input file: {{biasCorrectionDir}}/satbias_mhs_n19.h5
     output file: {{OutDBDir}}{{MemberDir}}/satbias_mhs_n19.h5
     variational bc:
-      predictors: &predictors1
+      predictors:
       - name: constant
       - name: lapseRate
         order: 2

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
@@ -81,6 +81,7 @@
         options:
           sensor: mhs_metop-a
           channels: *mhs_metop-a_channels
+    <<: *multiIterationFilter
 # Transmittnace Top Check
   - filter: BlackList
     filter variables:
@@ -93,6 +94,7 @@
         channels: *mhs_metop-a_channels
         options:
           channels: *mhs_metop-a_channels
+    <<: *multiIterationFilter
 
 # Background Check
   - filter: Background Check

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
@@ -58,8 +58,8 @@
     test variables:
     - name: ObsFunction/BennartzScatIndex
       options:
-        channel_89ghz: 1    # MHS 89.00 GHz channel
-        channel_150ghz: 2   # MHS 157.00 GHz channel
+        channel_89ghz: 1
+        channel_150ghz: 2
         bennartz_coeff_1: -39.2010
         bennartz_coeff_2: 0.1104
         apply_bias: ObsBiasData

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
@@ -1,8 +1,146 @@
   obs filters:
-  - filter: PreQC
-    maxvalue: 0
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-a.nc4
-  - filter: Background Check
-    threshold: 3.0
+
+  - filter: Domain Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: 5
+    where:
+    - variable:
+        name: MetaData/latitude
+      minvalue: -60.0
+      maxvalue: 60.0
     <<: *multiIterationFilter
+
+# obs prior filters:
+# Assign obs error for each channel
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-a_channels
+    action:
+      name: assign error
+      error parameter vector: [2.50, 2.50, 2.50, 2.00, 2.00]
+    <<: *multiIterationFilter
+
+# BennartzScatIndex check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-a_channels
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      maxvalue: 0.99
+    test variables:
+    - name: ObsFunction/BennartzScatIndex
+      options:
+        channel_89ghz: 1
+        channel_150ghz: 2
+        bennartz_coeff_1: 0.158
+        bennartz_coeff_2: 0.0163
+        apply_bias: ObsBiasData
+    maxvalue: -1.0
+    action:
+      name: reject
+    <<: *multiIterationFilter
+
+# BennartzScatIndex check over water
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-a_channels
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0
+    test variables:
+    - name: ObsFunction/BennartzScatIndex
+      options:
+        channel_89ghz: 1    # MHS 89.00 GHz channel
+        channel_150ghz: 2   # MHS 157.00 GHz channel
+        bennartz_coeff_1: -39.2010
+        bennartz_coeff_2: 0.1104
+        apply_bias: ObsBiasData
+    maxvalue: 10.0
+    action:
+      name: reject
+    <<: *multiIterationFilter
+
+# Topography check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-a_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
+        channels: *mhs_metop-a_channels
+        options:
+          sensor: mhs_metop-a
+          channels: *mhs_metop-a_channels
+# Transmittnace Top Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-a_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTransmitTopRad
+        channels: *mhs_metop-a_channels
+        options:
+          channels: *mhs_metop-a_channels
+
+# Background Check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-a_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundMW
+      channels: *mhs_metop-a_channels
+      options:
+        sensor: mhs_metop-a
+        channels: *mhs_metop-a_channels
+        threshold: 3.0
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [0.0, 1.0, 0.0, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *mhs_metop-a_channels
+          options:
+            channels: *mhs_metop-a_channels
+        obserr_bound_topo:
+          name: ObsFunction/ObsErrorFactorTopoRad
+          channels: *mhs_metop-a_channels
+          options:
+            channels: *mhs_metop-a_channels
+            sensor: mhs_metop-a
+        error parameter vector:
+                  [ 2.5, 2.5, 2.5, 2.0, 2.0]
+        obserr_bound_max: [5.0, 5.0, 10.0, 10.0, 10.0]
+    action:
+      name: reject
+    <<: *multiIterationFilter
+#  Useflag check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-a_channels
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *mhs_metop-a_channels
+      options:
+        channels: *mhs_metop-a_channels
+        use_flag: [ -1, -1, 1, 1,  1]
+    minvalue: 1.0e-12
+    action:
+      name: reject
+
+  - filter: Gaussian_Thinning
+    horizontal_mesh: {{RADTHINDISTANCE}}

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
@@ -81,6 +81,7 @@
         options:
           sensor: mhs_metop-b
           channels: *mhs_metop-b_channels
+    <<: *multiIterationFilter
 
 # Transmittnace Top Check
   - filter: BlackList
@@ -94,6 +95,7 @@
         channels: *mhs_metop-b_channels
         options:
           channels: *mhs_metop-b_channels
+    <<: *multiIterationFilter
 
 # Background Check
   - filter: Background Check

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
@@ -1,8 +1,147 @@
   obs filters:
-  - filter: PreQC
-    maxvalue: 0
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_metop-b.nc4
-  - filter: Background Check
-    threshold: 3.0
+
+  - filter: Domain Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: 5
+    where:
+    - variable:
+        name: MetaData/latitude
+      minvalue: -60.0
+      maxvalue: 60.0
     <<: *multiIterationFilter
+
+# obs prior filters:
+# Assign obs error for each channel
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-b_channels
+    action:
+      name: assign error
+      error parameter vector: [2.50, 2.50, 2.50, 2.00, 2.00]
+    <<: *multiIterationFilter
+
+# BennartzScatIndex check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-b_channels
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      maxvalue: 0.99
+    test variables:
+    - name: ObsFunction/BennartzScatIndex
+      options:
+        channel_89ghz: 1
+        channel_150ghz: 2
+        bennartz_coeff_1: 0.158
+        bennartz_coeff_2: 0.0163
+        apply_bias: ObsBiasData
+    maxvalue: -1.0
+    action:
+      name: reject
+    <<: *multiIterationFilter
+
+# BennartzScatIndex check over water
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-b_channels
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0
+    test variables:
+    - name: ObsFunction/BennartzScatIndex
+      options:
+        channel_89ghz: 1
+        channel_150ghz: 2
+        bennartz_coeff_1: -39.2010
+        bennartz_coeff_2: 0.1104
+        apply_bias: ObsBiasData
+    maxvalue: 10.0
+    action:
+      name: reject
+    <<: *multiIterationFilter
+
+# Topography check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-b_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
+        channels: *mhs_metop-b_channels
+        options:
+          sensor: mhs_metop-b
+          channels: *mhs_metop-b_channels
+
+# Transmittnace Top Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-b_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTransmitTopRad
+        channels: *mhs_metop-b_channels
+        options:
+          channels: *mhs_metop-b_channels
+
+# Background Check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-b_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundMW
+      channels: *mhs_metop-b_channels
+      options:
+        sensor: mhs_metop-b
+        channels: *mhs_metop-b_channels
+        threshold: 3.0
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [0.0, 1.0, 0.0, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *mhs_metop-b_channels
+          options:
+            channels: *mhs_metop-b_channels
+        obserr_bound_topo:
+          name: ObsFunction/ObsErrorFactorTopoRad
+          channels: *mhs_metop-b_channels
+          options:
+            channels: *mhs_metop-b_channels
+            sensor: mhs_metop-b
+        error parameter vector:
+                  [ 2.5, 2.5, 2.5, 2.0, 2.0]
+        obserr_bound_max: [5.0, 5.0, 10.0, 10.0, 10.0]
+    action:
+      name: reject
+    <<: *multiIterationFilter
+#  Useflag check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-b_channels
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *mhs_metop-b_channels
+      options:
+        channels: *mhs_metop-b_channels
+        use_flag: [ -1, -1, 1, 1,  1]
+    minvalue: 1.0e-12
+    action:
+      name: reject
+
+  - filter: Gaussian_Thinning
+    horizontal_mesh: {{RADTHINDISTANCE}}

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
@@ -1,8 +1,148 @@
   obs filters:
-  - filter: PreQC
-    maxvalue: 0
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n18.nc4
-  - filter: Background Check
-    threshold: 3.0
+
+  - filter: Domain Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: 5
+    where:
+    - variable:
+        name: MetaData/latitude
+      minvalue: -60.0
+      maxvalue: 60.0
     <<: *multiIterationFilter
+
+# obs prior filters:
+# Assign obs error for each channel
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n18_channels
+    action:
+      name: assign error
+      error parameter vector: [2.50, 2.50, 2.50, 2.00, 2.00]
+    <<: *multiIterationFilter
+
+# BennartzScatIndex check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n18_channels
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      maxvalue: 0.99
+    test variables:
+    - name: ObsFunction/BennartzScatIndex
+      options:
+        channel_89ghz: 1
+        channel_150ghz: 2
+        bennartz_coeff_1: 0.158
+        bennartz_coeff_2: 0.0163
+        apply_bias: ObsBiasData
+    maxvalue: -1.0
+    action:
+      name: reject
+    <<: *multiIterationFilter
+
+# BennartzScatIndex check over water
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n18_channels
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0
+    test variables:
+    - name: ObsFunction/BennartzScatIndex
+      options:
+        channel_89ghz: 1
+        channel_150ghz: 2
+        bennartz_coeff_1: -39.2010
+        bennartz_coeff_2: 0.1104
+        apply_bias: ObsBiasData
+    maxvalue: 10.0
+    action:
+      name: reject
+    <<: *multiIterationFilter
+
+# Topography check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n18_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
+        channels: *mhs_n18_channels
+        options:
+          sensor: mhs_n18
+          channels: *mhs_n18_channels
+
+# Transmittnace Top Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n18_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTransmitTopRad
+        channels: *mhs_n18_channels
+        options:
+          channels: *mhs_n18_channels
+
+# Background Check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n18_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundMW
+      channels: *mhs_n18_channels
+      options:
+        sensor: mhs_n18
+        channels: *mhs_n18_channels
+        threshold: 3.0
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [0.0, 1.0, 0.0, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *mhs_n18_channels
+          options:
+            channels: *mhs_n18_channels
+        obserr_bound_topo:
+          name: ObsFunction/ObsErrorFactorTopoRad
+          channels: *mhs_n18_channels
+          options:
+            channels: *mhs_n18_channels
+            sensor: mhs_n18
+        error parameter vector:
+                  [ 2.5, 2.5, 2.5, 2.0, 2.0]
+        obserr_bound_max: [5.0, 5.0, 10.0, 10.0, 10.0]
+    action:
+      name: reject
+    <<: *multiIterationFilter
+
+#  Useflag check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n18_channels
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *mhs_n18_channels
+      options:
+        channels: *mhs_n18_channels
+        use_flag: [ -1, -1, 1, 1,  1]
+    minvalue: 1.0e-12
+    action:
+      name: reject
+
+  - filter: Gaussian_Thinning
+    horizontal_mesh: {{RADTHINDISTANCE}}

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
@@ -81,6 +81,7 @@
         options:
           sensor: mhs_n18
           channels: *mhs_n18_channels
+    <<: *multiIterationFilter
 
 # Transmittnace Top Check
   - filter: BlackList
@@ -94,6 +95,7 @@
         channels: *mhs_n18_channels
         options:
           channels: *mhs_n18_channels
+    <<: *multiIterationFilter
 
 # Background Check
   - filter: Background Check

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
@@ -79,6 +79,7 @@
         options:
           sensor: mhs_n19
           channels: *mhs_n19_channels
+    <<: *multiIterationFilter
 
 # Transmittnace Top Check
   - filter: BlackList
@@ -92,6 +93,7 @@
         channels: *mhs_n19_channels
         options:
           channels: *mhs_n19_channels
+    <<: *multiIterationFilter
 
 # Background Check
   - filter: Background Check

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
@@ -1,8 +1,146 @@
   obs filters:
-  - filter: PreQC
-    maxvalue: 0
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_mhs_n19.nc4
-  - filter: Background Check
-    threshold: 3.0
+
+  - filter: Domain Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: 5
+    where:
+    - variable:
+        name: MetaData/latitude
+      minvalue: -60.0
+      maxvalue: 60.0
     <<: *multiIterationFilter
+
+# Assign obs error for each channel
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n19_channels
+    action:
+      name: assign error
+      error parameter vector: [2.50, 2.50, 3.00, 2.50, 2.50]
+    <<: *multiIterationFilter
+# BennartzScatIndex check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n19_channels
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      maxvalue: 0.99
+    test variables:
+    - name: ObsFunction/BennartzScatIndex
+      options:
+        channel_89ghz: 1
+        channel_150ghz: 2
+        bennartz_coeff_1: 0.158
+        bennartz_coeff_2: 0.0163
+        apply_bias: ObsBiasData
+    maxvalue: -1.0
+    action:
+      name: reject
+    <<: *multiIterationFilter
+
+# BennartzScatIndex check over water
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n19_channels
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0
+    test variables:
+    - name: ObsFunction/BennartzScatIndex
+      options:
+        channel_89ghz: 1
+        channel_150ghz: 2
+        bennartz_coeff_1: -39.2010
+        bennartz_coeff_2: 0.1104
+        apply_bias: ObsBiasData
+    maxvalue: 10.0
+    action:
+      name: reject
+    <<: *multiIterationFilter
+
+# Topography check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n19_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
+        channels: *mhs_n19_channels
+        options:
+          sensor: mhs_n19
+          channels: *mhs_n19_channels
+
+# Transmittnace Top Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n19_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTransmitTopRad
+        channels: *mhs_n19_channels
+        options:
+          channels: *mhs_n19_channels
+
+# Background Check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n19_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundMW
+      channels: *mhs_n19_channels
+      options:
+        sensor: mhs_n19
+        channels: *mhs_n19_channels
+        threshold: 3.0
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [0.0, 1.0, 0.0, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *mhs_n19_channels
+          options:
+            channels: *mhs_n19_channels
+        obserr_bound_topo:
+          name: ObsFunction/ObsErrorFactorTopoRad
+          channels: *mhs_n19_channels
+          options:
+            channels: *mhs_n19_channels
+            sensor: mhs_n19
+        error parameter vector:
+                  [ 2.5, 2.5, 3.0, 2.5, 2.5]
+        obserr_bound_max: [5.0, 5.0, 3.0, 5.0, 5.0]
+    action:
+      name: reject
+    <<: *multiIterationFilter
+
+#  Useflag check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n19_channels
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *mhs_n19_channels
+      options:
+        channels: *mhs_n19_channels
+        use_flag: [ -1, -1, -1, 1,  1]
+    minvalue: 1.0e-12
+    action:
+      name: reject
+
+  - filter: Gaussian_Thinning
+    horizontal_mesh: {{RADTHINDISTANCE}}

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -46,10 +46,10 @@ variational:
     30km:
       60km:
         3dhybrid:
-          nodes: 2
-          PEPerNode: 128
+          nodes: 4
+          PEPerNode: 64
           memory: 235GB
-          baseSeconds: 2000
+          baseSeconds: 800
           secondsPerEnVarMember: 9
 
   #execute: False # the default is True

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -49,7 +49,7 @@ variational:
           nodes: 2
           PEPerNode: 128
           memory: 235GB
-          baseSeconds: 800
+          baseSeconds: 2000
           secondsPerEnVarMember: 9
 
   #execute: False # the default is True

--- a/scenarios/defaults/observations.yaml
+++ b/scenarios/defaults/observations.yaml
@@ -267,10 +267,10 @@ observations:
           amsua-cld_n19: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/raw_obs
 
           ## mhs
-          mhs_metop-a: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/no_bias
-          mhs_metop-b: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/no_bias
-          mhs_n18: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/no_bias
-          mhs_n19: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/no_bias
+          mhs_metop-a: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/raw_obs
+          mhs_metop-b: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/raw_obs
+          mhs_n18: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/raw_obs
+          mhs_n19: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/raw_obs
 
           ## abi
           abi_g16: /glade/campaign/mmm/parc/jban/pandac/obsiodav3_intScanP_20230927/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct


### PR DESCRIPTION
This PR adds MHS clear-sky assimilation using raw observations to replace the ncdiag files. 

- Use BennartzScatIndex check:
   References: Bennartz, R., A. Thoss, A. Dybbroe, and D. B. Michelson, 2002: Precipitation analysis using the AdvancedMicrowave Sounding Unit in support of nowcasting applications. Meteorol. Appl., 9,177–189, doi:10.1017/S1350482702002037.
- Assimilate MHS Channel 5 within the range of 60S to 60N degrees. 
- Turn off MHS N19 Channel 3 due to poor quality.

Modified files:
config/jedi/ObsPlugs/da/base/mhs_metop-a.yaml	
config/jedi/ObsPlugs/da/base/mhs_metop-b.yaml	
config/jedi/ObsPlugs/da/base/mhs_n18.yaml	
config/jedi/ObsPlugs/da/base/mhs_n19.yaml	
config/jedi/ObsPlugs/da/bias/mhs_metop-a.yaml	
config/jedi/ObsPlugs/da/bias/mhs_metop-b.yaml	
config/jedi/ObsPlugs/da/bias/mhs_n18.yaml	
config/jedi/ObsPlugs/da/bias/mhs_n19.yaml	
config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml	
config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml	
config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml	
config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml	
scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
scenarios/defaults/observations.yaml


### Tests completed
#### Tier 1:
 - [x] 3dhybrid_O30kmIE60km  (conducted month-long cycling DA)
 - [x] 3denvar_OIE120km_WarmStart_VarBC (ran two cycles)

