### PR TITLE
Change tools/create_amb_in_nc.py to create cdf5 data files.

### DIFF
--- a/config/mpas/forecast/streams.atmosphere
+++ b/config/mpas/forecast/streams.atmosphere
@@ -28,7 +28,7 @@
                   filename_template="AmB.$Y-$M-$D_$h.$m.$s.nc"
                   filename_interval="none"
                   packages="iau"
-                  io_type="netcdf4"
+                  io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
 <stream name="output"

--- a/tools/create_amb_in_nc.py
+++ b/tools/create_amb_in_nc.py
@@ -43,7 +43,9 @@ def create_anal_incr_to_nc():
     file_a = 'an.%s.nc'%(tanl.strftime('%Y-%m-%d_%H.%M.%S'))	# Input analysis
     file_b = 'bg.%s.nc'%(tanl.strftime('%Y-%m-%d_%H.%M.%S'))	# Input background
     famb =  'AmB.%s.nc'%(tiau.strftime('%Y-%m-%d_%H.%M.%S')) 	# Output analysis increments
-    fout  = Dataset(famb, 'w')
+    fout  = Dataset(famb, 'w', format="NETCDF3_64BIT_DATA")
+    print('fout.data_model:', fout.data_model)
+    print('====================================')
 
     # Read input files - chunks can be adjusted to fit into the memory, if files are too large.
     #------------------------------------------
@@ -58,7 +60,7 @@ def create_anal_incr_to_nc():
     fout.input_xtime = tanl.strftime('%Y-%m-%d_%H:%M:%S') + ' UTC'
     fout.IAU_window_length_s = args.IAU_window_length_s
     fout.input_interval = "initial_only"
-    fout.io_type = "netcdf4"
+    fout.io_type = "NETCDF3_64BIT_DATA" #cdf5
 
     for name, dimension in fa.dimensions.items():
      if name == 'Time':


### PR DESCRIPTION
It currently creates netcdf4 files, which aren't readable by the SMIOL I/O library.

Change the io_type of the iau stream to be pnetcdf,cdf5 in config/mpas/forecast/streams.atmosphere.

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
