### PR TITLE
Remove job specification for forecast entry in scenarios and verifyobs from default list in forecast post

### DIFF
--- a/initialize/applications/Forecast.py
+++ b/initialize/applications/Forecast.py
@@ -51,7 +51,8 @@ class Forecast(Component):
 
     ## post
     # list of tasks for Post
-    'post': [['verifyobs', 'verifymodel'], list]
+    # e.g.: ['verifyobs', 'verifymodel']
+    'post': [['verifymodel'], list]
   }
 
   def __init__(self,
@@ -235,7 +236,7 @@ class Forecast(Component):
       attr = {
         'seconds': {'def': 300},
         'nodes': {'def': 1, 'typ': int},
-        'PEPerNode': {'def': 36, 'typ': int},
+        'PEPerNode': {'def': 128, 'typ': int},
         'queue': {'def': self.hpc['NonCriticalQueue']},
         'account': {'def': self.hpc['NonCriticalAccount']},
       }

--- a/initialize/applications/ForecastSACA.py
+++ b/initialize/applications/ForecastSACA.py
@@ -53,7 +53,8 @@ class ForecastSACA(Component):
 
     ## post
     # list of tasks for Post
-    'post': [['verifyobs', 'verifymodel'], list],
+    # e.g.: ['verifyobs', 'verifymodel']
+    'post': [['verifymodel'], list],
   }
 
   def __init__(self,
@@ -243,7 +244,7 @@ class ForecastSACA(Component):
       attr = {
         'seconds': {'def': 300},
         'nodes': {'def': 1, 'typ': int},
-        'PEPerNode': {'def': 36, 'typ': int},
+        'PEPerNode': {'def': 128, 'typ': int},
         'queue': {'def': self.hpc['NonCriticalQueue']},
         'account': {'def': self.hpc['NonCriticalAccount']},
       }

--- a/scenarios/3denvar_O30kmIE60km_WarmStart_SpecifiedEnsemble.yaml
+++ b/scenarios/3denvar_O30kmIE60km_WarmStart_SpecifiedEnsemble.yaml
@@ -30,14 +30,6 @@ variational:
 experiment:
   suffix: '_B-SE80+RTPP70'
 
-forecast:
-  job:
-    30km:
-      # more efficient
-      nodes: 4
-      PEPerNode: 36
-      baseSeconds: 60
-      secondsPerForecastHR: 150
 observations:
   resource: PANDACArchive
   resources:

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -41,17 +41,6 @@ variational:
     forecasts:
       resource: "PANDAC.EDA"
 
-  # resource requirements
-  job:
-    30km:
-      60km:
-        3dhybrid:
-          nodes: 2
-          PEPerNode: 128
-          memory: 235GB
-          baseSeconds: 800
-          secondsPerEnVarMember: 9
-
   #execute: False # the default is True
   #post: [] # this turns off verifyobs
 

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_CloudInsertion.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_CloudInsertion.yaml
@@ -7,13 +7,6 @@ firstbackground:
   resource: "PANDAC.GFS"
 
 forecast:
-  job:
-    60-3km:
-      nodes: 4
-      PEPerNode: 128
-      baseSeconds: 60
-      secondsPerForecastHR: 300
-
   #execute: False # the default is True
   post: [] # use this when doing extended forecast
   #post: [verifymodel] # this turns off verifyobs

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_iasi.yaml
@@ -9,10 +9,7 @@ firstbackground:
 forecast:
   job:
     30km:
-      nodes: 2
-      PEPerNode: 128
-      baseSeconds: 60
-      secondsPerForecastHR: 240
+      secondsPerForecastHR: 20
 
   #execute: False # the default is True
   #post: [] # use this when doing extended forecast

--- a/scenarios/3dhybrid_O60-3kmIE60km_SpecifiedEnsemble_VarBC.yaml
+++ b/scenarios/3dhybrid_O60-3kmIE60km_SpecifiedEnsemble_VarBC.yaml
@@ -6,13 +6,6 @@ firstbackground:
   resource: "PANDAC.GFS"
 
 forecast:
-  job:
-    30km:
-      nodes: 2
-      PEPerNode: 128
-      baseSeconds: 60
-      secondsPerForecastHR: 240
-
   #execute: False # the default is True
   post: [] # use this when doing extended forecast
   #post: [verifymodel] # this turns off verifyobs
@@ -45,15 +38,6 @@ variational:
   job:
     defaults:
       retry: '3*PT30S'
-    60-3km:
-      60km:
-        3dhybrid:
-          nodes: 4
-          PEPerNode: 64
-          memory: 235GB
-          baseSeconds: 900
-          secondsPerEnVarMember: 10
-
   #execute: False # the default is True
   post: [] # this turns off verifyobs
 

--- a/scenarios/3dvar_O30kmIE60km_ColdStart.yaml
+++ b/scenarios/3dvar_O30kmIE60km_ColdStart.yaml
@@ -22,12 +22,6 @@ model:
 externalanalyses:
   resource: "GFS.RDA"
 forecast:
-  job:
-    30km:
-      nodes: 8
-      PEPerNode: 32 # the default is 36 now, but no partition file for 288 core in Duda's directory
-      baseSeconds: 60
-      secondsPerForecastHR: 120
   post: []
 variational:
   DAType: 3dvar

--- a/scenarios/3dvar_OIE120km_WarmStart_PostProcess.yaml
+++ b/scenarios/3dvar_OIE120km_WarmStart_PostProcess.yaml
@@ -18,7 +18,7 @@ firstbackground:
 
 forecast:
   execute: False
-  post: [verifyobs, verifymodel]
+  post: [verifymodel] #verifyobs
 
 members:
   n: 1

--- a/scenarios/4dhybrid_OIE120km_WarmStart.yaml
+++ b/scenarios/4dhybrid_OIE120km_WarmStart.yaml
@@ -6,7 +6,7 @@ firstbackground:
   resource: "PANDAC.GFS_4DEnVAR"
 forecast:
   FourD: True
-  post: [verifyobs, verifymodel]
+  post: [verifymodel] #verifyobs
 members:
   n: 1
 model:

--- a/scenarios/CloudDirectInsertion.yaml
+++ b/scenarios/CloudDirectInsertion.yaml
@@ -22,7 +22,7 @@ extendedforecast:
   DACycling: True
   updateSea: True
   #execute: False # uncomment if forecasts are already completed
-  post: [verifyobs] #verifyobs
+  post: [] #verifyobs
 
 forecastsaca:
   #execute: False

--- a/scenarios/IASI120km3denvar.yaml
+++ b/scenarios/IASI120km3denvar.yaml
@@ -49,21 +49,7 @@ variational:
     amsua_n19,
     iasi_metop-b,
   ]
-  # for a 6h obs file
-  job:
-    120km:
-      120km:
-        3denvar:
-          baseSeconds: 900
-          nodes: 8
-          PEPerNode: 16
-          memory: 109GB
-hpc:
-  CriticalQueue: premium
-  NonCriticalQueue: premium
+  # check job specification for Derecho
+
 verifyobs:
   script directory: /glade/campaign/mmm/parc/ivette/pandac/graphics
-hofx:
-  job:
-    120km:
-      seconds: 500

--- a/scenarios/IASI30kmIE60km3denvar.yaml
+++ b/scenarios/IASI30kmIE60km3denvar.yaml
@@ -66,16 +66,7 @@ variational:
     amsua_n19,
     iasi_metop-b,
   ]
-  job:
-    30km:
-      60km:
-        3denvar:
-          baseSeconds: 4500
-          nodes: 8
-          PEPerNode: 16
-          memory: 109GB
-hpc:
-  CriticalQueue: premium
-  NonCriticalQueue: premium
+  # check job specification for Derecho
+
 verifyobs:
   script directory: /glade/campaign/mmm/parc/ivette/pandac/graphics

--- a/scenarios/RealTime.yaml
+++ b/scenarios/RealTime.yaml
@@ -21,12 +21,3 @@ variational:
   DAType: 3dvar
   nInnerIterations: [60,]
   biasCorrection: True
-  job:
-    120km:
-      # Assuming 60 total inner iterations
-      120km:
-        3dvar:
-          baseSeconds: 400
-hpc:
-  CriticalQueue: premium
-  NonCriticalQueue: economy

--- a/scenarios/VerifyingGFSAnalysesFromRDA.yaml
+++ b/scenarios/VerifyingGFSAnalysesFromRDA.yaml
@@ -15,24 +15,9 @@ extendedforecast:
   # optionally turn on extended forecast verification
   post: []
 
-forecast:
-  job:
-    30km:
-      nodes: 4
-      PEPerNode: 32
-      baseSeconds: 60
-      secondsPerForecastHR: 150
-
 hpc:
   CriticalQueue: regular
   NonCriticalQueue: regular
-
-initic:
-  job:
-    30km:
-      seconds: 60
-      nodes: 4
-      PEPerNode: 32
 
 members:
   n: 1

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -232,8 +232,8 @@ variational:
           baseSeconds: 800
           secondsPerEnVarMember: 24
         3dhybrid:
-          nodes: 2
-          PEPerNode: 128
+          nodes: 4
+          PEPerNode: 64
           memory: 235GB
           baseSeconds: 500
           secondsPerEnVarMember: 9

--- a/scenarios/getkf_OIE60km_WarmStart.yaml
+++ b/scenarios/getkf_OIE60km_WarmStart.yaml
@@ -9,7 +9,7 @@ externalanalyses:
 firstbackground:
   resource: "PANDAC.LaggedGEFS"
 forecast:
-  post: [verifyobs, verifymodel]
+  post: [verifymodel] #verifyobs
 hofx:
   retainObsFeedback: False
 members:

--- a/scenarios/letkf2D_OIE60km_WarmStart.yaml
+++ b/scenarios/letkf2D_OIE60km_WarmStart.yaml
@@ -9,7 +9,7 @@ externalanalyses:
 firstbackground:
   resource: "PANDAC.LaggedGEFS"
 forecast:
-  post: [verifyobs, verifymodel]
+  post: [verifymodel] #verifyobs
 members:
   n: 20
 model:

--- a/scenarios/letkf_OIE60km_WarmStart.yaml
+++ b/scenarios/letkf_OIE60km_WarmStart.yaml
@@ -9,7 +9,7 @@ externalanalyses:
 firstbackground:
   resource: "PANDAC.LaggedGEFS"
 forecast:
-  post: [verifyobs, verifymodel]
+  post: [verifymodel] #verifyobs
 hofx:
   retainObsFeedback: False
 members:

--- a/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
+++ b/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
@@ -1,5 +1,5 @@
 experiment:
-  name: '3denvar_O30kmIE60km_WarmStart_TEST2'
+  name: '3denvar_O30kmIE60km_WarmStart_TEST'
 externalanalyses:
   resource: "GFS.PANDAC"
 forecast:

--- a/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
+++ b/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
@@ -1,5 +1,5 @@
 experiment:
-  name: '3denvar_O30kmIE60km_WarmStart_TEST'
+  name: '3denvar_O30kmIE60km_WarmStart_TEST2'
 externalanalyses:
   resource: "GFS.PANDAC"
 forecast:
@@ -40,11 +40,6 @@ variational:
   ensemble:
     forecasts:
       resource: "PANDAC.EDA"
-  job:
-    30km:
-      60km:
-        3denvar:
-          memory: 235GB
   post: [verifyobs]
   IRVISlandCoeff: IGBP
 hofx:

--- a/test/testinput/3dvar_O30kmIE60km_ColdStart.yaml
+++ b/test/testinput/3dvar_O30kmIE60km_ColdStart.yaml
@@ -3,12 +3,6 @@ externalanalyses:
 experiment:
   name: '3dvar_O30kmIE60km_ColdStart_TEST'
 forecast:
-  job:
-    30km:
-      nodes: 8
-      PEPerNode: 32 # the default is 36 now, but no partition file for 288 core in Duda's directory
-      baseSeconds: 60
-      secondsPerForecastHR: 120
   post: [verifyobs, verifymodel]
 hpc:
   CriticalQueue: economy
@@ -33,11 +27,6 @@ variational:
   DAType: 3dvar
   nInnerIterations: [30,]
   biasCorrection: True
-  job:
-    30km:
-      60km:
-        3dvar:
-          memory: 235GB
   post: [verifyobs]
 workflow:
   # test a recent date

--- a/test/testinput/ForecastFromGFSAnalysesMPT.yaml
+++ b/test/testinput/ForecastFromGFSAnalysesMPT.yaml
@@ -18,23 +18,9 @@ extendedforecast:
   # optionally turn on extended forecast post
   post: []
 
-forecast:
-  job:
-    30km:
-      # use 128 PE to match partition file in GraphInfoDir
-      nodes: 4
-      PEPerNode: 32
-
 hpc:
   CriticalQueue: economy
   NonCriticalQueue: economy
-
-initic:
-  job:
-    30km:
-      # use 128 PE to match partition file in GraphInfoDir
-      nodes: 4
-      PEPerNode: 32
 
 members:
   n: 1


### PR DESCRIPTION
### Description
This PR removes all jobs specification for the `forecast` entry in the scenario YAML files under the `scenarios` folder. It also removes some unnecessary specifications for the `variational` entry (adjusting the default value in the case for `3dhybrid`). In addition, it removes `verifyobs` from the default list in the `post` for forecast.

Scenarios with IASI seemed out-of-date. Job specification needs to be added in case differs from default.

### Issue closed
None

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
