### PR TITLE
Using the generic model variable names in mpas-jedi

### DIFF
--- a/bin/RTPP.csh
+++ b/bin/RTPP.csh
@@ -190,11 +190,11 @@ set prevYAML = $thisYAML
 set AnalysisVariables = ( \
   $StandardAnalysisVariables \
   pressure_p \
-  pressure \
-  rho \
-  theta \
+  air_pressure \
+  dry_air_density \
+  air_potential_temperature \
   u \
-  qv \
+  water_vapor_mixing_ratio_wrt_dry_air \
 )
 foreach hydro ($MPASHydroIncrementVariables)
   set AnalysisVariables = ($AnalysisVariables $hydro)

--- a/bin/SACA.csh
+++ b/bin/SACA.csh
@@ -205,12 +205,6 @@ echo "  - xland"   >> keptvars.yaml
 echo "  - cldmask" >> keptvars.yaml
 echo "  - brtemp"  >> keptvars.yaml
 
-#-BJJ-TMP We may not need this anymore. This is already included in geovars.yaml
-#echo ""                               >> geovars.yaml
-#echo "  - field name: ni"             >> geovars.yaml
-#echo "    mpas template field: theta" >> geovars.yaml
-#echo "    mpas identity field: ni"    >> geovars.yaml
-
 # ======================
 # Link observations data
 # ======================

--- a/bin/SACA.csh
+++ b/bin/SACA.csh
@@ -205,10 +205,11 @@ echo "  - xland"   >> keptvars.yaml
 echo "  - cldmask" >> keptvars.yaml
 echo "  - brtemp"  >> keptvars.yaml
 
-echo ""                               >> geovars.yaml
-echo "  - field name: ni"             >> geovars.yaml
-echo "    mpas template field: theta" >> geovars.yaml
-echo "    mpas identity field: ni"    >> geovars.yaml
+#-BJJ-TMP We may not need this anymore. This is already included in geovars.yaml
+#echo ""                               >> geovars.yaml
+#echo "  - field name: ni"             >> geovars.yaml
+#echo "    mpas template field: theta" >> geovars.yaml
+#echo "    mpas identity field: ni"    >> geovars.yaml
 
 # ======================
 # Link observations data
@@ -302,7 +303,7 @@ end
 set VarSub = `echo "$VarSub" | sed 's/.$//'`
 # optional for diag and diag_cldfra
 if (${runSacaDiag} == True) then
-  set VarSub = $VarSub",uReconstructZonal,uReconstructMeridional"
+  set VarSub = $VarSub",eastward_wind,northward_wind"
   echo "uReconstructZonal"      >> stream_list.${MPASCore}.${AppName}_background
   echo "uReconstructMeridional" >> stream_list.${MPASCore}.${AppName}_background
   echo "uReconstructZonal"      >> stream_list.${MPASCore}.${AppName}_analysis

--- a/config/jedi/applications/3dhybrid-allsky.yaml
+++ b/config/jedi/applications/3dhybrid-allsky.yaml
@@ -78,13 +78,13 @@ cost function:
               read vertical balance: true
             vertical balance:
               vbal:
-              - balanced variable: velocity_potential
-                unbalanced variable: stream_function
+              - balanced variable: air_horizontal_velocity_potential
+                unbalanced variable: air_horizontal_streamfunction
                 diagonal regression: true
-              - balanced variable: temperature
-                unbalanced variable: stream_function
-              - balanced variable: surface_pressure
-                unbalanced variable: stream_function
+              - balanced variable: air_temperature
+                unbalanced variable: air_horizontal_streamfunction
+              - balanced variable: air_pressure_at_surface
+                unbalanced variable: air_horizontal_streamfunction
         linear variable change:
           linear variable change name: Control2Analysis
           input variables: *ctlvars

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -76,13 +76,13 @@ cost function:
               read vertical balance: true
             vertical balance:
               vbal:
-              - balanced variable: velocity_potential
-                unbalanced variable: stream_function
+              - balanced variable: air_horizontal_velocity_potential
+                unbalanced variable: air_horizontal_streamfunction
                 diagonal regression: true
-              - balanced variable: temperature
-                unbalanced variable: stream_function
-              - balanced variable: surface_pressure
-                unbalanced variable: stream_function
+              - balanced variable: air_temperature
+                unbalanced variable: air_horizontal_streamfunction
+              - balanced variable: air_pressure_at_surface
+                unbalanced variable: air_horizontal_streamfunction
         linear variable change:
           linear variable change name: Control2Analysis
           input variables: *ctlvars

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -59,13 +59,13 @@ cost function:
           read vertical balance: true
         vertical balance:
           vbal:
-          - balanced variable: velocity_potential
-            unbalanced variable: stream_function
+          - balanced variable: air_horizontal_velocity_potential
+            unbalanced variable: air_horizontal_streamfunction
             diagonal regression: true
-          - balanced variable: temperature
-            unbalanced variable: stream_function
-          - balanced variable: surface_pressure
-            unbalanced variable: stream_function
+          - balanced variable: air_temperature
+            unbalanced variable: air_horizontal_streamfunction
+          - balanced variable: air_pressure_at_surface
+            unbalanced variable: air_horizontal_streamfunction
     linear variable change:
       linear variable change name: Control2Analysis
       input variables: *ctlvars

--- a/config/jedi/applications/4dhybrid.yaml
+++ b/config/jedi/applications/4dhybrid.yaml
@@ -113,13 +113,13 @@ cost function:
               read vertical balance: true
             vertical balance:
               vbal:
-              - balanced variable: velocity_potential
-                unbalanced variable: stream_function
+              - balanced variable: air_horizontal_velocity_potential
+                unbalanced variable: air_horizontal_streamfunction
                 diagonal regression: true
-              - balanced variable: temperature
-                unbalanced variable: stream_function
-              - balanced variable: surface_pressure
-                unbalanced variable: stream_function
+              - balanced variable: air_temperature
+                unbalanced variable: air_horizontal_streamfunction
+              - balanced variable: air_pressure_at_surface
+                unbalanced variable: air_horizontal_streamfunction
         linear variable change:
           linear variable change name: Control2Analysis
           input variables: *ctlvars

--- a/config/mpas/geovars.yaml
+++ b/config/mpas/geovars.yaml
@@ -8,6 +8,29 @@
 # Field definitions for the UFO observation operators
 # *** Do not add different FieldIONames or LongName, ufo only uses one name ***
 
+# ------------------------------------------------------------------------------
+# "field name" :
+#      JEDI's generic model variable name.
+# "mpas templated field" :
+#      MPAS variable name that has the same type & shape (dimension).
+#      This is used for templating the initial "subFields" pool from MPAS domain.
+#      See the "subroutine da_template_pool".
+# "mpas identity field" :
+#      JEDI's generic model variable name that is identical to a given "field name".
+#      This is used in "Model2GeoVars" NL, TL, AD routines.
+#      If "mpas identity field" is defined, xg is just copied from xm.
+#      If not, xg should go though the variable changes (NL, TL, AD) from xm.
+# "mpas io name" :
+#      MPAS variable name that is matching a given "field name" (If exist).
+#      This is used when interacting with MPAS I/O from mpas-jedi.
+#      See the "subroutine da_copy_all2sub_fields" (read) & "da_copy_sub2all_fields" (write).
+# "mpas io scaling factor" :
+#      This is used to scale the MPAS variable to JEDI's generic model variable.
+#      This factor is multipled to MPAS-io-name fields to match the unit of generic-name fields.
+#      This is only applicable for simple scaling.
+#      See the "subroutine da_copy_all2sub_fields" (scale) & "da_copy_sub2all_fields" (un-scale).
+# ------------------------------------------------------------------------------
+
 fields:
   - field name: air_pressure
     mpas template field: theta
@@ -41,14 +64,9 @@ fields:
     mpas io name: temperature
 
   - field name: eastward_wind
-    mpas template field: theta            # same type & shape. used for templating the initial "subFields" pool from MPAS domain
-                                          #                    "subroutine da_template_pool"
-    mpas identity field: eastward_wind    # used in "Model2GeoVars" NL, TL, AD routines
-                                          #   If there exist an identical variable from "subFields" pool.
-                                          #   If not, this field should go through a variable change.
-                                          #   This could be a logical key.
-    mpas io name: uReconstructZonal     # This is only applicable with "mpas identity field".
-    mpas io scaling factor: 1.0         # This is only applicable with "mpas identity field". TBD
+    mpas template field: theta
+    mpas identity field: eastward_wind
+    mpas io name: uReconstructZonal
 
   - field name: northward_wind
     mpas template field: theta
@@ -278,9 +296,13 @@ fields:
     mpas template field: u10
     mpas identity field: znt
 
+#NOTE: If users comment-out "mpas identity field" and "mpas io scaling factor" below,
+#      this will go through (NL) Variable Change.
   - field name: vegetation_area_fraction
     mpas template field: u10
-    mpas io name: vegfra     # need scaling
+#    mpas identity field: vegetation_area_fraction
+    mpas io name: vegfra # need scaling or Variable Change
+#    mpas io scaling factor: 0.01 # from MPAS unit [percent] to generic unit [unitless]
 
   - field name: leaf_area_index
     mpas template field: u10

--- a/config/mpas/geovars.yaml
+++ b/config/mpas/geovars.yaml
@@ -11,7 +11,8 @@
 fields:
   - field name: air_pressure
     mpas template field: theta
-    mpas identity field: pressure
+    mpas identity field: air_pressure
+    mpas io name: pressure
 
   - field name: air_pressure_levels
     mpas template field: w
@@ -36,57 +37,65 @@ fields:
 
   - field name: air_temperature
     mpas template field: theta
-    mpas identity field: temperature
-
-  - field name: temperature
-    mpas template field: theta
-    mpas identity field: temperature
+    mpas identity field: air_temperature
+    mpas io name: temperature
 
   - field name: eastward_wind
-    mpas template field: theta
-    mpas identity field: eastward_wind
+    mpas template field: theta            # same type & shape. used for templating the initial "subFields" pool from MPAS domain
+                                          #                    "subroutine da_template_pool"
+    mpas identity field: eastward_wind    # used in "Model2GeoVars" NL, TL, AD routines
+                                          #   If there exist an identical variable from "subFields" pool.
+                                          #   If not, this field should go through a variable change.
+                                          #   This could be a logical key.
+    mpas io name: uReconstructZonal     # This is only applicable with "mpas identity field".
+    mpas io scaling factor: 1.0         # This is only applicable with "mpas identity field". TBD
 
   - field name: northward_wind
     mpas template field: theta
     mpas identity field: northward_wind
+    mpas io name: uReconstructMeridional
 
   - field name: water_vapor_mixing_ratio_wrt_dry_air
     mpas template field: theta
+    mpas io name: qv
 
   - field name: water_vapor_mixing_ratio_wrt_moist_air
     mpas template field: theta
-    mpas identity field: spechum
+    mpas identity field: water_vapor_mixing_ratio_wrt_moist_air
+    mpas io name: spechum
 
   - field name: height_above_mean_sea_level_at_surface
     mpas template field: u10
 
-  - field name: surface_pressure
-    mpas template field: u10
-    mpas identity field: surface_pressure
-
   - field name: air_pressure_at_surface
     mpas template field: u10
-    mpas identity field: surface_pressure
+    mpas identity field: air_pressure_at_surface
+    mpas io name: surface_pressure
 
   - field name: air_temperature_at_2m
     mpas template field: u10
-    mpas identity field: t2m
+    mpas identity field: air_temperature_at_2m
+    mpas io name: t2m
 
   - field name: water_vapor_mixing_ratio_wrt_moist_air_at_2m
     mpas template field: u10
-    mpas identity field: q2
+    mpas identity field: water_vapor_mixing_ratio_wrt_moist_air_at_2m
+    mpas io name: q2
 
   - field name: eastward_wind_at_10m
     mpas template field: u10
-    mpas identity field: u10
+    mpas identity field: eastward_wind_at_10m
+    mpas io name: u10
 
   - field name: northward_wind_at_10m
     mpas template field: u10
-    mpas identity field: v10
+    mpas identity field: northward_wind_at_10m
+    mpas io name: v10
 
   - field name: skin_temperature_at_surface
     mpas template field: u10
-    mpas identity field: skintemp
+    mpas identity field: skin_temperature_at_surface
+    mpas io name: skintemp
 
   - field name: landmask
     mpas template field: ivgtyp
@@ -94,7 +103,8 @@ fields:
 
   - field name: seaice_fraction
     mpas template field: u10
-    mpas identity field: xice
+    mpas identity field: seaice_fraction
+    mpas io name: xice
 
   - field name: mole_fraction_of_ozone_in_air
     mpas template field: theta
@@ -102,77 +112,97 @@ fields:
   - field name: mole_fraction_of_carbon_dioxide_in_air
     mpas template field: theta
 
+#--- ???
   - field name: mixing_ratio_of_cloud_liquid_water
     mpas template field: theta
-    mpas identity field: qc
+    mpas identity field: mixing_ratio_of_cloud_liquid_water
+    mpas io name: qc
 
   - field name: mixing_ratio_of_cloud_ice
     mpas template field: theta
-    mpas identity field: qi
+    mpas identity field: mixing_ratio_of_cloud_ice
+    mpas io name: qi
 
   - field name: mixing_ratio_of_rain
     mpas template field: theta
-    mpas identity field: qr
+    mpas identity field: mixing_ratio_of_rain
+    mpas io name: qr
 
   - field name: mixing_ratio_of_snow
     mpas template field: theta
-    mpas identity field: qs
+    mpas identity field: mixing_ratio_of_snow
+    mpas io name: qs
 
   - field name: mixing_ratio_of_graupel
     mpas template field: theta
-    mpas identity field: qg
+    mpas identity field: mixing_ratio_of_graupel
+    mpas io name: qg
 
   - field name: mixing_ratio_of_hail
     mpas template field: theta
-    mpas identity field: qh
+    mpas identity field: mixing_ratio_of_hail
+    mpas io name: qh
+#--- ???
 
   - field name: cloud_liquid_water
     mpas template field: theta
-    mpas identity field: qc
+    mpas identity field: cloud_liquid_water
+    mpas io name: qc
 
   - field name: cloud_liquid_ice
     mpas template field: theta
-    mpas identity field: qi
+    mpas identity field: cloud_liquid_ice
+    mpas io name: qi
 
   - field name: rain_water
     mpas template field: theta
-    mpas identity field: qr
+    mpas identity field: rain_water
+    mpas io name: qr
 
   - field name: snow_water
     mpas template field: theta
-    mpas identity field: qs
+    mpas identity field: snow_water
+    mpas io name: qs
 
   - field name: graupel
     mpas template field: theta
-    mpas identity field: qg
-
+    mpas identity field: graupel
+    mpas io name: qg
+  
   - field name: hail
     mpas template field: theta
-    mpas identity field: qh
+    mpas identity field: hail
+    mpas io name: qh
 
   - field name: cloud_droplet_number_concentration
     mpas template field: theta
-    mpas identity field: nc
+    mpas identity field: cloud_droplet_number_concentration
+    mpas io name: nc
 
   - field name: cloud_ice_number_concentration
     mpas template field: theta
-    mpas identity field: ni
+    mpas identity field: cloud_ice_number_concentration
+    mpas io name: ni
 
   - field name: rain_number_concentration
     mpas template field: theta
-    mpas identity field: nr
+    mpas identity field: rain_number_concentration
+    mpas io name: nr
 
   - field name: snow_number_concentration
     mpas template field: theta
-    mpas identity field: ns
+    mpas identity field: snow_number_concentration
+    mpas io name: ns
 
   - field name: graupel_number_concentration
     mpas template field: theta
-    mpas identity field: ng
+    mpas identity field: graupel_number_concentration
+    mpas io name: ng
 
   - field name: hail_number_concentration
     mpas template field: theta
-    mpas identity field: nh
+    mpas identity field: hail_number_concentration
+    mpas io name: nh
 
   - field name: moist_air_density
     mpas template field: theta
@@ -218,23 +248,28 @@ fields:
 
   - field name: average_surface_temperature_within_field_of_view
     mpas template field: u10
-    mpas identity field: skintemp
+    mpas identity field: skin_temperature_at_surface #average_surface_temperature_within_field_of_view   # how to handle duplicated variable?? or just procedure ??
+    mpas io name: skintemp
 
   - field name: skin_temperature_at_surface_where_sea
     mpas template field: u10
-    mpas identity field: skintemp
+    mpas identity field: skin_temperature_at_surface #skin_temperature_at_surface_where_sea
+    mpas io name: skintemp
 
   - field name: skin_temperature_at_surface_where_land
     mpas template field: u10
-    mpas identity field: skintemp
+    mpas identity field: skin_temperature_at_surface #skin_temperature_at_surface_where_land
+    mpas io name: skintemp
 
   - field name: skin_temperature_at_surface_where_ice
     mpas template field: u10
-    mpas identity field: skintemp
+    mpas identity field: skin_temperature_at_surface #skin_temperature_at_surface_where_ice
+    mpas io name: skintemp
 
   - field name: skin_temperature_at_surface_where_snow
     mpas template field: u10
-    mpas identity field: skintemp
+    mpas identity field: skin_temperature_at_surface #skin_temperature_at_surface_where_snow
+    mpas io name: skintemp
 
   - field name: surface_snow_thickness
     mpas template field: u10
@@ -245,6 +280,7 @@ fields:
 
   - field name: vegetation_area_fraction
     mpas template field: u10
+    mpas io name: vegfra     # need scaling
 
   - field name: leaf_area_index
     mpas template field: u10
@@ -270,11 +306,13 @@ fields:
 
   - field name: eastward_wind_at_surface
     mpas template field: u10
-    mpas identity field: u10
+    mpas identity field: eastward_wind_at_10m #we are doing this... for CRTM #eastward_wind_at_surface
+    mpas io name: u10
 
   - field name: northward_wind_at_surface
     mpas template field: u10
-    mpas identity field: v10
+    mpas identity field: northward_wind_at_10m #we are doing this... for CRTM #northward_wind_at_surface
+    mpas io name: v10
 
   - field name: wind_speed_at_surface
     mpas template field: u10
@@ -284,7 +322,7 @@ fields:
 
   - field name: wind_reduction_factor_at_10m
     mpas template field: u10
-
+    
   - field name: land_type_index_USGS
     mpas template field: ivgtyp
 
@@ -300,26 +338,51 @@ fields:
   - field name: tropopause_pressure
     mpas template field: u10
 
-  - field name: qv
-    mpas template field: theta
-    mpas identity field: qv
+#  - field name: qv
+#    mpas template field: theta
+#    mpas identity field: qv
+#
+#  - field name: qc
+#    mpas template field: theta
+#    mpas identity field: qc
+#
+#  - field name: qi
+#    mpas template field: theta
+#    mpas identity field: qi
+#
+#  - field name: qr
+#    mpas template field: theta
+#    mpas identity field: qr
+#
+#  - field name: qs
+#    mpas template field: theta
+#    mpas identity field: qs
+#
+#  - field name: qg
+#    mpas template field: theta
+#    mpas identity field: qg
 
-  - field name: qc
+  - field name: dry_air_density   # for increment.yaml ?
     mpas template field: theta
-    mpas identity field: qc
+    mpas identity field: dry_air_density
+    mpas io name: rho
 
-  - field name: qi
+  - field name: air_potential_temperature   # for increment.yaml ?
     mpas template field: theta
-    mpas identity field: qi
+    mpas identity field: air_potential_temperature
+    mpas io name: theta
 
-  - field name: qr
+  - field name: air_horizontal_streamfunction
     mpas template field: theta
-    mpas identity field: qr
+    mpas identity field: air_horizontal_streamfunction
+    mpas io name: stream_function
 
-  - field name: qs
+  - field name: air_horizontal_velocity_potential
     mpas template field: theta
-    mpas identity field: qs
+    mpas identity field: air_horizontal_velocity_potential
+    mpas io name: velocity_potential
 
-  - field name: qg
+  - field name: relative_humidity
     mpas template field: theta
-    mpas identity field: qg
+    mpas identity field: relative_humidity
+    mpas io name: relhum

--- a/config/mpas/geovars.yaml
+++ b/config/mpas/geovars.yaml
@@ -44,11 +44,11 @@ fields:
 
   - field name: eastward_wind
     mpas template field: theta
-    mpas identity field: uReconstructZonal
+    mpas identity field: eastward_wind
 
   - field name: northward_wind
     mpas template field: theta
-    mpas identity field: uReconstructMeridional
+    mpas identity field: northward_wind
 
   - field name: water_vapor_mixing_ratio_wrt_dry_air
     mpas template field: theta

--- a/config/mpas/obsop_name_map.yaml
+++ b/config/mpas/obsop_name_map.yaml
@@ -14,13 +14,13 @@ variable maps:
   - name: virtualTemperature
     alias: virtual_temperature
   - name: stationPressure
-    alias: surface_pressure
+    alias: air_pressure_at_surface
   - name: depthBelowWaterSurface
     alias: ocean_depth
   - name: waterTemperature
     alias: ocean_temperature
   - name: surfacePressure
-    alias: surface_pressure
+    alias: air_pressure_at_surface
   - name: seaSurfaceTemperature
     alias: sea_surface_temperature
   - name: equivalentReflectivityFactor

--- a/config/mpas/variables.csh
+++ b/config/mpas/variables.csh
@@ -10,11 +10,15 @@ set StandardAnalysisVariables = ( \
   spechum \
   surface_pressure \
   temperature \
-  uReconstructMeridional \
-  uReconstructZonal \
+  eastward_wind \
+  northward_wind \
 )
 set StandardStateVariables = ( \
-  $StandardAnalysisVariables \
+  spechum \
+  surface_pressure \
+  temperature \
+  uReconstructMeridional \
+  uReconstructZonal \
   theta \
   rho \
   u \

--- a/config/mpas/variables.csh
+++ b/config/mpas/variables.csh
@@ -4,10 +4,10 @@
 ## workflow-relevant state variables
 ####################################
 set MPASHydroIncrementVariables = ( \
-  cloud_liquid_water
-  cloud_liquid_ice
-  graupel
-  rain_water
+  cloud_liquid_water \
+  cloud_liquid_ice \
+  graupel \
+  rain_water \
   snow_water \
 )
 set MPASHydroStateVariables = (${MPASHydroIncrementVariables} cldfrac)

--- a/config/mpas/variables.csh
+++ b/config/mpas/variables.csh
@@ -14,11 +14,7 @@ set StandardAnalysisVariables = ( \
   eastward_wind \
 )
 set StandardStateVariables = ( \
-  water_vapor_mixing_ratio_wrt_moist_air \
-  air_pressure_at_surface \
-  air_temperature \
-  northward_wind \
-  eastward_wind \
+  $StandardAnalysisVariables \
   air_potential_temperature \
   dry_air_density \
   u \

--- a/config/mpas/variables.csh
+++ b/config/mpas/variables.csh
@@ -3,37 +3,37 @@
 ####################################
 ## workflow-relevant state variables
 ####################################
-set MPASHydroIncrementVariables = (qc qi qg qr qs)
+set MPASHydroIncrementVariables = (cloud_liquid_water cloud_liquid_ice graupel rain_water snow_water)
 set MPASHydroStateVariables = (${MPASHydroIncrementVariables} cldfrac)
 
 set StandardAnalysisVariables = ( \
-  spechum \
-  surface_pressure \
-  temperature \
+  water_vapor_mixing_ratio_wrt_moist_air \
+  air_pressure_at_surface \
+  air_temperature \
   northward_wind \
   eastward_wind \
 )
 set StandardStateVariables = ( \
-  spechum \
-  surface_pressure \
-  temperature \
-  uReconstructMeridional \
-  uReconstructZonal \
-  theta \
-  rho \
+  water_vapor_mixing_ratio_wrt_moist_air \
+  air_pressure_at_surface \
+  air_temperature \
+  northward_wind \
+  eastward_wind \
+  air_potential_temperature \
+  dry_air_density \
   u \
-  qv \
-  pressure \
+  water_vapor_mixing_ratio_wrt_dry_air \
+  air_pressure \
   landmask \
-  xice \
+  seaice_fraction \
   snowc \
-  skintemp \
+  skin_temperature_at_surface \
   ivgtyp \
   isltyp \
   snowh \
-  vegfra \
-  u10 \
-  v10 \
+  vegetation_area_fraction \
+  eastward_wind_at_10m \
+  northward_wind_at_10m \
   lai \
   smois \
   tslb \
@@ -47,19 +47,19 @@ set MPASJEDIVariablesFiles = (\
 )
 
 set SACAStateVariables = ( \
-  temperature \
-  spechum \
-  theta \
+  air_temperature \
+  water_vapor_mixing_ratio_wrt_moist_air \
+  air_potential_temperature \
   u \
-  rho \
-  qv \
-  qc \
-  qi \
-  qs \
-  ni \
+  dry_air_density \
+  water_vapor_mixing_ratio_wrt_dry_air \
+  cloud_liquid_water \
+  cloud_liquid_ice \
+  snow_water \
+  cloud_ice_number_concentration \
   cldfrac \
   xland \
-  pressure \
+  air_pressure \
   pressure_p \
-  surface_pressure \
+  air_pressure_at_surface \
 )

--- a/config/mpas/variables.csh
+++ b/config/mpas/variables.csh
@@ -10,8 +10,8 @@ set StandardAnalysisVariables = ( \
   spechum \
   surface_pressure \
   temperature \
-  eastward_wind \
   northward_wind \
+  eastward_wind \
 )
 set StandardStateVariables = ( \
   spechum \

--- a/config/mpas/variables.csh
+++ b/config/mpas/variables.csh
@@ -3,7 +3,13 @@
 ####################################
 ## workflow-relevant state variables
 ####################################
-set MPASHydroIncrementVariables = (cloud_liquid_water cloud_liquid_ice graupel rain_water snow_water)
+set MPASHydroIncrementVariables = ( \
+  cloud_liquid_water
+  cloud_liquid_ice
+  graupel
+  rain_water
+  snow_water \
+)
 set MPASHydroStateVariables = (${MPASHydroIncrementVariables} cldfrac)
 
 set StandardAnalysisVariables = ( \

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -44,7 +44,7 @@ class Build(Component):
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
       else:
         self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_16Dec2024/build_SP', str] ## develop
+          ['/glade/derecho/scratch/bjung/panda-c/code_spectralWindNaming/mpas-bundle/build_single', str] ## develop
 
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -44,7 +44,7 @@ class Build(Component):
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
       else:
         self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/derecho/scratch/bjung/panda-c/code_spectralWindNaming/mpas-bundle/build_single', str] ## develop
+          ['/glade/derecho/scratch/bjung/panda-c/code_generic_names/mpas-bundle/build_single', str] ## develop
 
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -44,7 +44,7 @@ class Build(Component):
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
       else:
         self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/derecho/scratch/bjung/panda-c/code_generic_names/mpas-bundle/build_single', str] ## develop
+          ['/glade/work/bjung/panda-c/build/mpas-bundle_20250218/build_single', str] ## develop
 
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_allConfig.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_allConfig.yaml
@@ -177,11 +177,11 @@ variational:
           bumpLocDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.bumploc.duplicated.limited.1200km6km
   covariance:
     bumpCovControlVariables:
-    - stream_function
-    - velocity_potential
-    - temperature
-    - spechum
-    - surface_pressure
+    - air_horizontal_streamfunction
+    - air_horizontal_velocity_potential
+    - air_temperature
+    - water_vapor_mixing_ratio_wrt_moist_air
+    - air_pressure_at_surface
     bumpCovPrefix: mpas_parametersbump_cov
     bumpCovVBalPrefix: mpas_vbal
     60km:

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_allConfig.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_allConfig.yaml
@@ -186,9 +186,9 @@ variational:
     bumpCovVBalPrefix: mpas_vbal
     60km:
       hybridCoefficientsDir: /glade/campaign/mmm/parc/liuz/pandac_hybrid/60km.allsky_hybrid
-      bumpCovDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.NICAS_00global
-      bumpCovStdDevFile: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.VBAL_00       
+      bumpCovDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.NICAS_00global
+      bumpCovStdDevFile: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovVBalDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.VBAL_00
   job:
     30km:
       60km:

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -130,11 +130,11 @@ variational:
   # externally-produced background covariance files (var or hybrid)
   covariance:
     bumpCovControlVariables:
-    - stream_function
-    - velocity_potential
-    - temperature
-    - spechum
-    - surface_pressure
+    - air_horizontal_streamfunction
+    - air_horizontal_velocity_potential
+    - air_temperature
+    - water_vapor_mixing_ratio_wrt_moist_air
+    - air_pressure_at_surface
     bumpCovPrefix: mpas_parametersbump_cov
     bumpCovVBalPrefix: mpas_vbal
     #{{innerMesh}}:

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -150,11 +150,11 @@ variational:
     60km:
       hybridCoefficientsDir: /glade/campaign/mmm/parc/liuz/pandac_hybrid/60km.allsky_hybrid
       bumpCovDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.NICAS_00global
-      bumpCovStdDevFile: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovStdDevFile: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
       bumpCovVBalDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.VBAL_00
     120km:
       bumpCovDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/120km.NICAS_00
-      bumpCovStdDevFile: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
+      bumpCovStdDevFile: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/120km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
       bumpCovVBalDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/120km.VBAL_00
       hybridCoefficientsDir: /glade/campaign/mmm/parc/liuz/pandac_hybrid/120km.allsky_hybrid
 

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -149,13 +149,13 @@ variational:
       hybridCoefficientsDir: None
     60km:
       hybridCoefficientsDir: /glade/campaign/mmm/parc/liuz/pandac_hybrid/60km.allsky_hybrid
-      bumpCovDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.NICAS_00global
+      bumpCovDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.NICAS_00global
       bumpCovStdDevFile: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/derecho_2.1/60km.VBAL_00
+      bumpCovVBalDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.VBAL_00
     120km:
-      bumpCovDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.NICAS_00
+      bumpCovDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/120km.NICAS_00
       bumpCovStdDevFile: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/campaign/mmm/parc/liuz/pandac_common/BUMP_files/20230522_yr5/120km.VBAL_00
+      bumpCovVBalDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/120km.VBAL_00
       hybridCoefficientsDir: /glade/campaign/mmm/parc/liuz/pandac_hybrid/120km.allsky_hybrid
 
   # resource requirements


### PR DESCRIPTION
### Description
This PR adapts the changes required for jcsda-internal/mpas-jedi#1040.

* In the yamls, generic model variable names are used.
* Major changes can be seen in `config/mpas/variables.csh`, `config/mpas/geovars.yaml`, and `config/mpas/obsop_name_map.yaml`. Latter two are direct copies from the corresponding mpas-jedi repository.
* BUMP yaml sections for multivariate B also have corresponding changes.
* The variable names (or NetCDF group names) in the existing multivariate B BUMP files should be modified with generic names (or re-generated with corresponding mpas-jedi).

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
