### PR TITLE
Add "reduce obs space" in thinning to reduce memory usage.

### DIFF
--- a/config/jedi/ObsPlugs/da/filters/abi-clr_g16.yaml
+++ b/config/jedi/ObsPlugs/da/filters/abi-clr_g16.yaml
@@ -12,6 +12,8 @@
 #      minvalue: 1.0
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/abi_g16_harnish.yaml_window
+++ b/config/jedi/ObsPlugs/da/filters/abi_g16_harnish.yaml_window
@@ -4,9 +4,11 @@
     - variable:
         name: MetaData/sensorZenithAngle
       maxvalue: 60.0
-
+     
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 
   - filter: Domain Check
     filter variables:

--- a/config/jedi/ObsPlugs/da/filters/abi_g16_harnish.yaml_wv
+++ b/config/jedi/ObsPlugs/da/filters/abi_g16_harnish.yaml_wv
@@ -7,6 +7,8 @@
 
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 
 # Assign obsError.
   - filter: Perform Action

--- a/config/jedi/ObsPlugs/da/filters/abi_g16_okamoto.yaml
+++ b/config/jedi/ObsPlugs/da/filters/abi_g16_okamoto.yaml
@@ -6,6 +6,8 @@
       maxvalue: 60.0
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 # Assign obsError.
   - filter: Perform Action
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/ahi-clr_himawari8.yaml
+++ b/config/jedi/ObsPlugs/da/filters/ahi-clr_himawari8.yaml
@@ -9,6 +9,8 @@
       maxvalue: 0.05
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/ahi_himawari8_harnish.yaml_window
+++ b/config/jedi/ObsPlugs/da/filters/ahi_himawari8_harnish.yaml_window
@@ -7,6 +7,8 @@
 
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 
   - filter: Domain Check
     filter variables:

--- a/config/jedi/ObsPlugs/da/filters/ahi_himawari8_harnish.yaml_wv
+++ b/config/jedi/ObsPlugs/da/filters/ahi_himawari8_harnish.yaml_wv
@@ -7,6 +7,8 @@
 
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 
 # Assign obsError.
   - filter: Perform Action

--- a/config/jedi/ObsPlugs/da/filters/ahi_himawari8_okamoto.yaml
+++ b/config/jedi/ObsPlugs/da/filters/ahi_himawari8_okamoto.yaml
@@ -6,6 +6,8 @@
       maxvalue: 60.0
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 # Assign obsError.
   - filter: Perform Action
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/amsua-cld_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua-cld_aqua.yaml
@@ -6,5 +6,7 @@
     <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}}
+#    action:
+#      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_aqua.nc4

--- a/config/jedi/ObsPlugs/da/filters/amsua-cld_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua-cld_metop-a.yaml
@@ -6,5 +6,7 @@
     <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}}
+#    action:
+#      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_metop-a.nc4

--- a/config/jedi/ObsPlugs/da/filters/amsua-cld_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua-cld_metop-b.yaml
@@ -6,5 +6,7 @@
     <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}}
+#    action:
+#      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_metop-b.nc4

--- a/config/jedi/ObsPlugs/da/filters/amsua-cld_n15.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua-cld_n15.yaml
@@ -6,5 +6,7 @@
     <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}}
+#    action:
+#      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_n15.nc4

--- a/config/jedi/ObsPlugs/da/filters/amsua-cld_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua-cld_n18.yaml
@@ -6,5 +6,7 @@
     <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}}
+#    action:
+#      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_n18.nc4

--- a/config/jedi/ObsPlugs/da/filters/amsua-cld_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filters/amsua-cld_n19.yaml
@@ -6,5 +6,7 @@
     <<: *multiIterationFilter
 #  - filter: Gaussian Thinning
 #    horizontal_mesh: {{RADTHINDISTANCE}}
+#    action:
+#      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua-cld_n19.nc4

--- a/config/jedi/ObsPlugs/da/filters/satwind.yaml
+++ b/config/jedi/ObsPlugs/da/filters/satwind.yaml
@@ -26,6 +26,8 @@
     maxvalue: 200.0
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filters/satwnd.yaml
+++ b/config/jedi/ObsPlugs/da/filters/satwnd.yaml
@@ -27,6 +27,8 @@
       name: reject
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
   - filter: Background Check
     threshold: 3.0
     <<: *multiIterationFilter

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua.yaml
@@ -208,5 +208,7 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_aqua.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a.yaml
@@ -208,5 +208,7 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-a.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b.yaml
@@ -208,5 +208,7 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-b.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-c.yaml
@@ -208,5 +208,7 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_metop-c.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15.yaml
@@ -208,5 +208,7 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n15.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18.yaml
@@ -208,5 +208,7 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n18.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19.yaml
@@ -208,5 +208,7 @@
       name: reject
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}{{MemberDir}}/{{geoPrefix}}_amsua_n19.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml
@@ -161,5 +161,7 @@
       name: reject
 #  - filter: Gaussian_Thinning # input already thinned IASI data
 #    horizontal_mesh: {{RADTHINDISTANCE}}
+#    action:
+#      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}/{{geoPrefix}}_iasi_metop-a.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml
@@ -161,5 +161,7 @@
       name: reject
 #  - filter: Gaussian_Thinning # assimilate already thinned iasi data
 #    horizontal_mesh: {{RADTHINDISTANCE}}
+#    action:
+#      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}/{{geoPrefix}}_iasi_metop-b.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-c.yaml
@@ -161,5 +161,7 @@
       name: reject
 #  - filter: Gaussian_Thinning # assimilate already thinned iasi data
 #    horizontal_mesh: {{RADTHINDISTANCE}}
+#    action:
+#      name: reduce obs space
 #  - filter: GOMsaver
 #    filename: {{OutDBDir}}/{{geoPrefix}}_iasi_metop-c.nc4

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
@@ -146,3 +146,5 @@
 
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
@@ -147,3 +147,5 @@
 
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
@@ -148,3 +148,5 @@
 
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
@@ -146,3 +146,5 @@
 
   - filter: Gaussian_Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space

--- a/config/jedi/ObsPlugs/hofx/filters/satwind.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/satwind.yaml
@@ -26,3 +26,5 @@
     maxvalue: 200.0
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space

--- a/config/jedi/ObsPlugs/hofx/filters/satwnd.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/satwnd.yaml
@@ -27,3 +27,5 @@
       name: reject
   - filter: Gaussian Thinning
     horizontal_mesh: {{RADTHINDISTANCE}}
+    action:
+      name: reduce obs space


### PR DESCRIPTION
### Description
Add 'reduce obs spcace' function to the thinning section to reduce memory usage.
With this function, those observations removed by thinning will not come to memory and will not be in the obsout_da files.

### Issue closed

Closes #(if applicable)

### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs

Tested it in one-time DA, both in variational and enkf tests.