### PR TITLE
Enable running the Forecast task on GPU nodes on derecho.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ When setting up symlinks, ensure the run/cylc-run/MPAS-Workflow directory is emp
 
  Execute the workflow:
  ```
- ./Run.py {{scenarioConfig}}
+ ./Run.py [-b BUNDLE_DIR] [-x SUFFIX] [-f FORECAST_DIR] [-g] {{scenarioConfig}}
+    To see Run.py options: ./Run.py -h
  #OR
  ./test.csh
 ```

--- a/Run.py
+++ b/Run.py
@@ -52,13 +52,16 @@ class Run(Logger):
     ap = argparse.ArgumentParser()
     ap.add_argument('config', type=str,
                     help='configuration file; e.g., runs/test.yaml, scenarios/{{scenarioName}}.yaml')
-    ap.add_argument('-b', '--bundle_dir', help='mpas bundle directory')
+    ap.add_argument('-b', '--bundle_dir', help='mpas bundle build directory')
     ap.add_argument('-x', '--suffix', help='experiment name suffix')
+    ap.add_argument('-f', '--forecast_dir', help='alternative build directory mpas_atmosphere e.g. a gpu build')
+    ap.add_argument('-g', '--gpu', help='use gpu devices', action="store_true")
     args = ap.parse_args()
     assert Path(args.config).is_file(), (self.logPrefix+'config ('+args.config+') does not exist')
 
     self.__configFile = args.config
-    self.__config = Config(args.config, args.bundle_dir, args.suffix)
+    self.__config = Config(args.config, args.bundle_dir, args.suffix, args.forecast_dir, args.gpu)
+    self.log('config:' + str(self.__config), level=self.MSG_DEBUG)
 
   def execute(self):
     '''
@@ -81,7 +84,7 @@ class Run(Logger):
 
       self.clean(self)
 
-      scenario = Scenario(scenarioFile, self.__config._bundle_dir, self.__config._suffix)
+      scenario = Scenario(scenarioFile, self.__config._bundle_dir, self.__config._suffix, self.__config._forecast_dir, self.__config._use_gpus)
       scenario.initialize()
 
       # suite name (defaults to Cycle)

--- a/config/environmentForecast.csh
+++ b/config/environmentForecast.csh
@@ -32,19 +32,37 @@ else
       source /etc/profile.d/z00_modules.csh
       module purge
 
-      module load intel-oneapi/2023.0.0
-      module load cray-mpich/8.1.25
-      module load parallel-netcdf/1.12.3
-      module load parallelio/2.5.10
-      module load ncl/6.6.2
-      module load hdf5/1.12.2
-      module load netcdf/4.9.2
-      module load ncarcompilers/1.0.0
-      module load nco/5.1.4
-      setenv mpiCommand mpiexec
+      if ("$NGPUS" == "0") then
+        module load intel-oneapi/2023.0.0
+        module load cray-mpich/8.1.25
+        module load parallel-netcdf/1.12.3
+        module load parallelio/2.5.10
+        module load ncl/6.6.2
+        module load hdf5/1.12.2
+        module load netcdf/4.9.2
+        module load ncarcompilers/1.0.0
+        module load nco/5.1.4
+        setenv mpiCommand mpiexec
+      else if("$NGPUS" == "4") then
+        module load cuda
+        module load nvhpc/24.7
+        module load cray-mpich
+        module load cray-libsci
+        module load hdf5-mpi
+        module load netcdf-mpi
+        module load parallel-netcdf
+        module load ncarcompilers
+        setenv mpiCommand mpiexec
+      else
+        echo "unknown node type"
+      endif
     else
       echo "unknown NCAR_HOST: $NCAR_HOST"
     endif
+
+    echo setenv LD_LIBRARY_PATH ${forecastDirectory}/lib:$LD_LIBRARY_PATH
+    setenv LD_LIBRARY_PATH ${forecastDirectory}/lib:$LD_LIBRARY_PATH
+
     setenv F_UFMTENDIAN 'big:101-200'
     setenv FI_CXI_RX_MATCH_MODE 'hybrid'
     limit stacksize unlimited

--- a/initialize/applications/Forecast.py
+++ b/initialize/applications/Forecast.py
@@ -112,6 +112,7 @@ class Forecast(Component):
       'secondsPerForecastHR': {'typ': int},
       'nodes': {'typ': int},
       'PEPerNode': {'typ': int},
+      'GPUPerNode': {'typ': int, 'req':False},
       'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['CriticalQueue']},
       'account': {'def': hpc['CriticalAccount']},

--- a/initialize/config/Config.py
+++ b/initialize/config/Config.py
@@ -15,19 +15,25 @@ import traceback
 from initialize.config.Logger import Logger
 
 class Config(Logger):
+
   def __init__(self,
       filename: str,
       bundle_dir: str,
       suffix: str,
+      forecast_dir: str,
+      use_gpus: bool,
       defaultsFile:str = None,
     ):
 
    super().__init__()
-   with open(filename) as file:
-     self._table = yaml.load(file, Loader=yaml.FullLoader)
+   if filename is not None:
+     with open(filename) as file:
+       self._table = yaml.load(file, Loader=yaml.FullLoader)
 
    self._bundle_dir = bundle_dir
    self._suffix = suffix
+   self._forecast_dir = forecast_dir
+   self._use_gpus = use_gpus
    if defaultsFile is not None:
      with open(defaultsFile) as file:
        self._defaults = yaml.load(file, Loader=yaml.FullLoader)
@@ -37,7 +43,8 @@ class Config(Logger):
   def __str__(self):
     bd =  (self._bundle_dir if self._bundle_dir != None else 'None')
     suffix =  (self._suffix if self._suffix != None else 'None')
-    return 'bundle_dir:' + bd + ' suffix:' + suffix
+    fd =  (self._forecast_dir if self._forecast_dir != None else 'None')
+    return 'bundle_dir:' + bd + ' suffix:' + suffix + ' forecast_dir:' + fd + ' use_gpus:' + str(self._use_gpus)
 
   def extract(self, subKey: str, defaultsFile:str = None):
     tab = deepcopy(self._table.get(subKey, {}))

--- a/initialize/config/Resource.py
+++ b/initialize/config/Resource.py
@@ -19,6 +19,8 @@ class Resource(Config):
   useful for extracting resource-dependent or mesh-dependent subconfigurations
   '''
   def __init__(self, config:Config, keys:dict, resource:tuple):
+    super().__init__(None,  config._bundle_dir, config._suffix, config._forecast_dir, config._use_gpus)
+
     '''
     keys: {key1[str]: {
               'def': default value, # optional

--- a/initialize/config/Scenario.py
+++ b/initialize/config/Scenario.py
@@ -10,8 +10,9 @@
 from initialize.config.Config import Config
 
 class Scenario():
-  def __init__(self, file, bundle, suffix):
-    self.__conf = Config(file, bundle, suffix)
+  def __init__(self, file, bundle, suffix, forecast, use_gpu):
+    self.__conf = Config(file, bundle, suffix, forecast, use_gpu)
+    self.__conf.log('Scenario:conf:' + str(self.__conf), level=self.__conf.MSG_DEBUG)
     self.__script = [
 '''#!/bin/csh -f
 

--- a/initialize/config/SubConfig.py
+++ b/initialize/config/SubConfig.py
@@ -11,9 +11,13 @@ from initialize.config.Config import Config
 
 class SubConfig(Config):
   def __init__(self,
+      use_gpus:bool,
       table:dict = {},
       defaults:dict = {},
     ):
+
+    # must save whether to use gpu's or not.
+    super().__init__(None, None, None, None, use_gpus)
     self._table = table
     self._defaults = defaults
 
@@ -24,4 +28,4 @@ class SubConfig(Config):
       defaultsFile:str = None,
     ):
     table, defaults = parent.extract(subKey, defaultsFile)
-    return cls(table, defaults)
+    return cls(parent._use_gpus, table, defaults)

--- a/initialize/config/Task.py
+++ b/initialize/config/Task.py
@@ -12,6 +12,7 @@ from initialize.config.Resource import Resource
 class Task():
   def __init__(self, r:Resource):
     self.r = r
+    self.r.log('Task:__init__:' + str(self.r), level=self.r.MSG_DEBUG)
     #TODO: add email() method when more systems are supported
     self.email = r.getOrDefault('email', False)
     self.batchSystem = 'background'
@@ -67,12 +68,23 @@ class PBSPro(Task):
     nodes = self.r.getOrDefault('nodes', None, int)
     if nodes is not None:
       PEPerNode = self.r['PEPerNode']
+      memory = self.r.getOrDefault('memory', None)
+
+      # if gpu usage been requested and the task specifies to use GPU's modify the select statement
+      # to route the PBS job to the gpu queue.
+      gpu_str = ''
+      self.r.log('Task.directives:config:' + str(self.r) + ' GPUPerNode:' + str(self.r['GPUPerNode']), level=self.r.MSG_NOISY)
+      if self.r._use_gpus and self.r['GPUPerNode'] is not None:
+        # specifying ngpus in the select statement will send the job to the gpu queue.
+        gpu_str = ':ngpus='+str(self.r['GPUPerNode'])
+        memory = None # don't specify memory, use whatever is available on the GPU node
+        if PEPerNode > self.maxProcPerGpuNode:
+          PEPerNode = self.maxProcPerGpuNode
       threads = self.r.getOrDefault('threads', 1, int)
       assert threads*PEPerNode <= self.maxProcPerNode, (
         'PBSPro: too many processors requested -->'+str(threads*PEPerNode))
 
-      memory = self.r.getOrDefault('memory', None)
-      select = str(nodes)+':ncpus='+str(PEPerNode)+':mpiprocs='+str(PEPerNode)
+      select = str(nodes)+':ncpus='+str(PEPerNode)+gpu_str+':mpiprocs='+str(PEPerNode)
       if threads > 1:
         select = str(nodes)+':ncpus='+str(self.maxProcPerNode)+':mpiprocs='+str(PEPerNode)+':ompthreads='+str(threads)
       if memory is not None:
@@ -92,6 +104,7 @@ class CheyenneTask(PBSPro):
 class DerechoTask(PBSPro):
   name = 'derecho'
   maxProcPerNode = 128
+  maxProcPerGpuNode = 64
   maxMemPerNode = "235GB"
 
   def __init__(self, r:Resource):

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -7,6 +7,7 @@
  which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 '''
 import os
+from pathlib import Path
 
 from initialize.config.Component import Component
 from initialize.config.Config import Config
@@ -42,13 +43,17 @@ class Build(Component):
     if system == 'derecho':
       if config._bundle_dir != None:
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
+        assert Path(config._bundle_dir).is_dir(), (self.logPrefix+'bundle dir ('+args.bundle_dir+') is not a directory')
       else:
         self.variablesWithDefaults['mpas bundle'] = \
           ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_16Dec2024/build_SP', str] ## develop
 
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]
-      self.variablesWithDefaults['forecast directory'] = ['bundle', str]
+      if config._forecast_dir != None:
+        self.variablesWithDefaults['forecast directory'] = [config._forecast_dir, str]
+      else:
+        self.variablesWithDefaults['forecast directory'] = ['bundle', str]
 
       # Ungrib
       wpsBuildDir = '/glade/work/jwittig/repos1/WPS/'
@@ -75,6 +80,7 @@ class Build(Component):
       meanStateBuildDir = ''
 
     super().__init__(config)
+    self.log("config:" + str(config), level=self.MSG_DEBUG)
 
     ###################
     # derived variables
@@ -121,6 +127,12 @@ class Build(Component):
       if self['forecast directory'] == 'bundle':
         self._set('ForecastBuildDir', self['mpas bundle']+'/bin')
         self._set('ForecastEXE', 'mpas_'+model['MPASCore'])
+      elif config._forecast_dir != None:
+        self._set('ForecastBuildDir', config._forecast_dir+'/bin')
+        self._set('ForecastEXE', 'mpas_'+model['MPASCore'])
+        forecast=self.__getitem__('ForecastBuildDir') + '/' + self.__getitem__('ForecastEXE')
+        self.log('forecast:' + forecast, level=self.MSG_DEBUG)
+        assert Path(forecast).is_file(), (self.logPrefix+forecast+' is not a file')
       else:
         self._set('ForecastBuildDir', self['forecast directory'])
         self._set('ForecastEXE', model['MPASCore']+'_model')

--- a/initialize/suites/SuiteBase.py
+++ b/initialize/suites/SuiteBase.py
@@ -19,6 +19,7 @@ from initialize.framework.Workflow import Workflow
 
 class SuiteBase(Logger):
   def __init__(self, conf:Config):
+    conf.log('SuiteBase:init:' + str(conf), level=conf.MSG_DEBUG)
     super().__init__()
     self.c = {}
     self.c['hpc'] = HPC(conf)

--- a/scenarios/defaults/forecast.yaml
+++ b/scenarios/defaults/forecast.yaml
@@ -6,6 +6,7 @@ forecast:
       PEPerNode: 128
       baseSeconds: 60
       secondsPerForecastHR: 500
+      GPUPerNode: 4
 
       # cylc retry string
       retry: '0*PT30S'


### PR DESCRIPTION
## Don't bother to read this draft- it is likely going to change significantly.
### Description
This PR enables running the forecast step on derecho GPU nodes.

To run the forecast on gpu nodes provide the build directory for the GPU build of mpas_atmosphere and the -g flag to Run.py:
   ./Run.py -f <path_to_mpas-bundle_build_dir_built with GPU toolchain> -g

forecast.yaml has a new attribute, "GPUPerNode: 4" which is only used if the -g flag is provided to Run.py 
Derecho GPU nodes have 4 gpu's on each node.

Task.py will change the select PBS directive to send a job to the gpu queue if
1. Run.py is provided with the -g switch
2. The task has a 'GPUPerNode' attribute.

### Tests completed
I ran `test/testinput/3dvar_OIE120km_WarmStart.yaml` both with specifying to use GPU nodes and without specifying to use GPU nodes.

I verified that the Forecast1 step was submitted to the gpu queue when `-g` was provided to Run.py
I verified the Forecast1 step was submitted to the cpu queue when `-g` was not provided to Run.py.
I verified that the test scenario ran to successful completion regardless of the type of nodes the Forecast1 step ran on.

Commands I used for the GPU run:
```
export gpudir=/glade/derecho/scratch/jwittig/repos-s/mpas-bundle-io/build-nvhpc
./Run.py -b /glade/work/jwittig/repos1/mpas-bundle-cron/build-gnu-1p -g -f $gpudir test/testinput/3dvar_OIE120km_WarmStart.yaml -x _nvhpc
```

The command for running the scenario for the CPU run:
```
./Run.py -b /glade/work/jwittig/repos1/mpas-bundle-cron/build-gnu-1p test/testinput/3dvar_OIE120km_WarmStart.yaml
```

### Notes
1. The cpu build at `/glade/work/jwittig/repos1/mpas-bundle-cron/build-gnu-1p` is the automated weekly build.
2. The GPU port of the MPAS-Model dynamical core is in process. At this time it runs correctly on the GPU nodes, but performance is an issue and will remain so until the GPU port is completed

