### PR TITLE
Enable running the Forecast task on GPU nodes on derecho.

### DIFF
--- a/bin/Forecast.csh
+++ b/bin/Forecast.csh
@@ -363,6 +363,7 @@ else
     if ( -e $f ) rm -v $f
   end
   ln -sfv ${ForecastBuildDir}/${ForecastEXE} ./
+  echo "{mpiCommand} ${mpiCommand} ./${ForecastEXE}"
   ${mpiCommand} ./${ForecastEXE}
 
 

--- a/config/environmentForecast.csh
+++ b/config/environmentForecast.csh
@@ -31,20 +31,40 @@ else
     else if ("$NCAR_HOST" == "derecho") then
       source /etc/profile.d/z00_modules.csh
       module purge
+      module load ncarenv/23.09
+      module reset
 
-      module load intel-oneapi/2023.0.0
-      module load cray-mpich/8.1.25
-      module load parallel-netcdf/1.12.3
-      module load parallelio/2.5.10
-      module load ncl/6.6.2
-      module load hdf5/1.12.2
-      module load netcdf/4.9.2
-      module load ncarcompilers/1.0.0
-      module load nco/5.1.4
-      setenv mpiCommand mpiexec
+      if ("$NGPUS" == "0") then
+        module load intel-oneapi/2023.0.0
+        module load cray-mpich/8.1.25
+        module load parallel-netcdf/1.12.3
+        module load parallelio/2.5.10
+        module load ncl/6.6.2
+        module load hdf5/1.12.2
+        module load netcdf/4.9.2
+        module load ncarcompilers/1.0.0
+        module load nco/5.1.4
+        setenv mpiCommand mpiexec
+      else if("$NGPUS" == "4") then
+        module load cuda
+        module load nvhpc/24.7
+        module load cray-mpich
+        module load cray-libsci
+        module load hdf5-mpi
+        module load netcdf-mpi
+        module load parallel-netcdf
+        module load ncarcompilers
+        setenv mpiCommand "mpiexec set_gpu_rank"
+      else
+        echo "unknown node type"
+      endif
     else
       echo "unknown NCAR_HOST: $NCAR_HOST"
     endif
+
+    echo setenv LD_LIBRARY_PATH ${forecastDirectory}/lib:$LD_LIBRARY_PATH
+    setenv LD_LIBRARY_PATH ${forecastDirectory}/lib:$LD_LIBRARY_PATH
+
     setenv F_UFMTENDIAN 'big:101-200'
     setenv FI_CXI_RX_MATCH_MODE 'hybrid'
     limit stacksize unlimited

--- a/initialize/applications/Forecast.py
+++ b/initialize/applications/Forecast.py
@@ -112,6 +112,7 @@ class Forecast(Component):
       'secondsPerForecastHR': {'typ': int},
       'nodes': {'typ': int},
       'PEPerNode': {'typ': int},
+      'GPUPerNode': {'typ': int, 'req':False},
       'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['CriticalQueue']},
       'account': {'def': hpc['CriticalAccount']},

--- a/initialize/config/Config.py
+++ b/initialize/config/Config.py
@@ -16,15 +16,16 @@ from initialize.config.Logger import Logger
 
 class Config(Logger):
   def __init__(self,
-      filename: str,
-      bundle_dir: str,
-      suffix: str,
-      defaultsFile:str = None,
+      filename: str=None,
+      bundle_dir: str=None,
+      suffix: str=None,
+      defaultsFile: str = None,
     ):
 
    super().__init__()
-   with open(filename) as file:
-     self._table = yaml.load(file, Loader=yaml.FullLoader)
+   if filename is not None:
+     with open(filename) as file:
+       self._table = yaml.load(file, Loader=yaml.FullLoader)
 
    self._bundle_dir = bundle_dir
    self._suffix = suffix
@@ -115,8 +116,8 @@ class Config(Logger):
     '''
     convert cheyenne specific items to derecho specific ites, e.g. queues, priorities
     '''
-    #print('Config resource table', self._table)
-    #print('resource defaults', self._defaults)
+    self.log('Config resource table'+ str(self._table), level=self.MSG_NOISY)
+    self.log('resource defaults'+ str(self._defaults), level=self.MSG_NOISY)
     self.__convertQueue('queue')
 
 
@@ -135,7 +136,7 @@ class Config(Logger):
         # do we ever want to use the preempt queue? this could lead to starvation.
         #if queue == 'share':
           #newqueue = 'preempt'
-        self.log('Config converting queue:', queue, ' to:', newqueue, level=self.MSG_DEBUG)
+        self.log('Config converting queue:'+ str(queue)+ ' to:'+ str(newqueue), level=self.MSG_DEBUG)
         if subtable != None:
           self.__setitem2__(subtable, attrName, newqueue)
         else:
@@ -145,8 +146,11 @@ class Config(Logger):
         #print('Config table', self._table)
         #print('job_priority:', self['job_priority'], ' ', self.has('hpc.job_priority'))
         if subtable == None and self.has('hpc.job_priority') == False and queue in ['economy', 'premium']:
-          self.__setitem__('job_priority', queue)
-          self.log('Adding job_priority ', queue, level=self.MSG_DEBUG)
+          # only add economy priority if not running on a gpu node
+          self.log('GPUPerNode:' + str(self.get('GPUPerNode')), level=self.MSG_DEBUG)
+          if queue == 'premium' or not self.has('GPUPerNode') or self.get('GPUPerNode') == 0:
+            self.__setitem__('job_priority', queue)
+            self.log('Adding job_priority '+ queue, level=self.MSG_DEBUG)
 
         '''
         print('################################################################################')

--- a/initialize/config/Resource.py
+++ b/initialize/config/Resource.py
@@ -30,9 +30,14 @@ class Resource(Config):
               'typ': type}, # e.g., int, float, str, list, optional, None when missing
            }
     '''
+    # init the logging facility
+    super().__init__()
+
     self._table = {}
     self._defaults = {}
 
+    self.log('keys:' + str(keys), level=self.MSG_NOISY)
+    self.log('resource:' + str(resource), level=self.MSG_NOISY)
     for key, att in keys.items():
       default = att.get('def', None)
       required = att.get('req', True)
@@ -44,6 +49,7 @@ class Resource(Config):
         self._table[key] = self.extractNodeOrDie(config, resource, key, typ)
       else:
         self._table[key] = self.extractNode(config, resource, key, typ)
+
 
   @staticmethod
   def extractNode(config, resource:tuple, key:str, typ=None):

--- a/initialize/config/Task.py
+++ b/initialize/config/Task.py
@@ -67,12 +67,23 @@ class PBSPro(Task):
     nodes = self.r.getOrDefault('nodes', None, int)
     if nodes is not None:
       PEPerNode = self.r['PEPerNode']
+      memory = self.r.getOrDefault('memory', None)
+
+      # if the task specifies to use GPU's modify the select statement
+      # to route the PBS job to the gpu queue.
+      gpu_str = ''
+      self.r.log('Task.directives: GPUPerNode:' + str(self.r['GPUPerNode']), level=self.r.MSG_DEBUG)
+      if self.r['GPUPerNode'] is not None and self.r['GPUPerNode'] > 0:
+        # specifying ngpus in the select statement will send the job to the gpu queue.
+        gpu_str = ':ngpus='+str(self.r['GPUPerNode'])
+        memory = None # don't specify memory, use whatever is available on the GPU node
+        if PEPerNode > self.maxProcPerGpuNode:
+          PEPerNode = self.maxProcPerGpuNode
       threads = self.r.getOrDefault('threads', 1, int)
       assert threads*PEPerNode <= self.maxProcPerNode, (
         'PBSPro: too many processors requested -->'+str(threads*PEPerNode))
 
-      memory = self.r.getOrDefault('memory', None)
-      select = str(nodes)+':ncpus='+str(PEPerNode)+':mpiprocs='+str(PEPerNode)
+      select = str(nodes)+':ncpus='+str(PEPerNode)+gpu_str+':mpiprocs='+str(PEPerNode)
       if threads > 1:
         select = str(nodes)+':ncpus='+str(self.maxProcPerNode)+':mpiprocs='+str(PEPerNode)+':ompthreads='+str(threads)
       if memory is not None:
@@ -92,6 +103,7 @@ class CheyenneTask(PBSPro):
 class DerechoTask(PBSPro):
   name = 'derecho'
   maxProcPerNode = 128
+  maxProcPerGpuNode = 64
   maxMemPerNode = "235GB"
 
   def __init__(self, r:Resource):

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -7,6 +7,7 @@
  which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 '''
 import os
+from pathlib import Path
 
 from initialize.config.Component import Component
 from initialize.config.Config import Config
@@ -118,12 +119,38 @@ class Build(Component):
       self._set('InitEXE', 'mpas_init_'+model['MPASCore'])
 
       # either use forecast executable from the bundle or a separate MPAS-Atmosphere build
+      self.log('self[mpas bundle] ' + self['mpas bundle'], level=self.MSG_DEBUG)
+      self.log('self[forecast directory] ' + self['forecast directory'], level=self.MSG_DEBUG)
       if self['forecast directory'] == 'bundle':
         self._set('ForecastBuildDir', self['mpas bundle']+'/bin')
         self._set('ForecastEXE', 'mpas_'+model['MPASCore'])
       else:
-        self._set('ForecastBuildDir', self['forecast directory'])
-        self._set('ForecastEXE', model['MPASCore']+'_model')
+        # look for atmosphere_model in the provided directory (original behavior)
+        forecastDir = self['forecast directory']
+        forecastExe = model['MPASCore']+'_model'
+        self.log('looking for ' + forecastDir + '/' + forecastExe, level = self.MSG_DEBUG)
+        if Path(forecastDir + '/' + forecastExe).is_file():
+          self._set('ForecastBuildDir', forecastDir)
+          self._set('ForecastEXE', forecastExe)
+          self.log('Setting ForecastBuildDir to ' + forecastDir + ' , ForecastEXE to ' + forecastExe, level=self.MSG_QUIET)
+        else:
+          # if atmosphere_model wasn't found look for mpas_atmosphere
+          forecastExe = 'mpas_'+model['MPASCore']
+          self.log('looking for ' + forecastDir + '/' + forecastExe, level = self.MSG_DEBUG)
+          if Path(forecastDir + '/' + forecastExe).is_file():
+            self._set('ForecastBuildDir', forecastDir)
+            self._set('ForecastEXE', forecastExe)
+            self.log('Setting ForecastBuildDir to ' + forecastDir + ' , ForecastEXE to ' + forecastExe, level=self.MSG_QUIET)
+          else:
+            # if mpas_atmosphere wasn't found in the provided directory, look in bin
+            forecastDir = forecastDir + '/bin'
+            self.log('looking for ' + forecastDir + '/' + forecastExe, level = self.MSG_DEBUG)
+            if Path(forecastDir + '/' + forecastExe).is_file():
+              self._set('ForecastBuildDir', forecastDir)
+              self._set('ForecastEXE', forecastExe)
+              self.log('Setting ForecastBuildDir to ' + forecastDir + ' , ForecastEXE to ' + forecastExe, level=self.MSG_QUIET)
+            else:
+              self.log('could not find forecast executable in ' + self['forecast directory'], level=self.MSG_QUIET)
 
       if system == 'derecho':
         self._set('MPASLookupDir', self['mpas bundle']+'/MPAS/core_atmosphere')

--- a/test/testinput/3dvar_OIE120km_WarmStart.yaml
+++ b/test/testinput/3dvar_OIE120km_WarmStart.yaml
@@ -7,6 +7,10 @@ firstbackground:
 forecast:
   # turn off post to reduce overhead
   post: []
+  job:
+    # to run forecast on gpu's, set GPUPerNode to 4 and
+    # uncomment forecast directory below
+    GPUPerNode: 0
 hpc:
   CriticalQueue: economy
   NonCriticalQueue: economy
@@ -26,3 +30,5 @@ variational:
 workflow:
   first cycle point: 20180414T18
   final cycle point: 20180415T06
+build:
+  #forecast directory: /glade/derecho/scratch/jwittig/repos-s/mpas-bundle-io/build-nvhpc


### PR DESCRIPTION
### Description
This PR enables running the forecast step on derecho GPU nodes.

To run the forecast on gpu nodes
1. provide the build directory for the GPU build of mpas_atmosphere in the top level scenario yaml:
```
    build:
      forecast directory: path-for-mpas-model-gpu-build
```
2. add the GPUPerNode attribute of the forecast job:
```
    forecast:
      job:
        GPUPerNode: 4
```

Task.py will change the select PBS directive to send a job to the gpu queue if the task has a `GPUPerNode` attribute.

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart

I ran `test/testinput/3dvar_OIE120km_WarmStart.yaml` both with specifying to use GPU nodes and without specifying to use GPU nodes.

I verified that the Forecast1 step was submitted to the gpu queue when
  1.  `GPUPerNode` was specified with a value of `4` in `test/testinput/3dvar_OIE120km_WarmStart.yaml` and 
  2.  `forecast directory` was specified in `test/testinput/3dvar_OIE120km_WarmStart.yaml`

I verified the Forecast1 step was submitted to the cpu queue when
  1.  `GPUPerNode` was specified with a value of `0` in `test/testinput/3dvar_OIE120km_WarmStart.yaml` and 
  2.  `forecast directory` was *not* specified in `test/testinput/3dvar_OIE120km_WarmStart.yaml`

I verified that the test scenario ran to successful completion regardless of the type of nodes the Forecast1 step ran on.

### Notes
1. The GPU port of the MPAS-Model dynamical core is in process. At this time it runs correctly on the GPU nodes, but performance is an issue and will remain so until the GPU port is completed
2. An updated README with instructions to get your scenario to run the forecast steps on gpu's will be in a separate PR.
