### PR TITLE
Add missing InvariantStream to GenerateExternalAnalyses.py

### DIFF
--- a/initialize/suites/GenerateExternalAnalyses.py
+++ b/initialize/suites/GenerateExternalAnalyses.py
@@ -15,6 +15,7 @@ from initialize.config.Config import Config
 
 from initialize.data.ExternalAnalyses import ExternalAnalyses
 from initialize.data.Model import Model
+from initialize.data.InvariantStream import InvariantStream
 
 from initialize.framework.Build import Build
 from initialize.framework.Experiment import Experiment
@@ -31,6 +32,7 @@ class GenerateExternalAnalyses(SuiteBase):
     self.c['externalanalyses'] = ExternalAnalyses(conf, self.c['hpc'], self.c['model'].getMeshes())
     self.c['initic'] = InitIC(conf, self.c['hpc'], self.c['model'].getMeshes(), self.c['externalanalyses'])
     self.c['experiment'] = Experiment(conf, self.c['hpc'])
+    self.c['ss'] = InvariantStream(conf, self.c['model'].getMeshes(), self.c['workflow']['FirstCycleDate'], self.c['externalanalyses'], self.c['experiment'])
     self.c['naming'] = Naming(conf, self.c['experiment'])
 
     # TODO: make members optional, modify getCycleVars


### PR DESCRIPTION
### Description
TYPE: bugfix

This PR fixes a bug which manifests in the scenario GenerateGFSAnalyses.yaml.  It is analogous to PR #340 that was recently merged into the develop branch.

### Issue closed

The scenario GenerateGFSAnalyses.yaml fails with the current version of the Workflow because bin/ExternalAnalysisToMPAS.csh tries to source config/auto/invariantstream.csh, which is not generated. This PR introduces the necessary changes to fix this bug.

Closes #(if applicable) N/A

### Tests completed
#### Tier 1:
Successfully ran test/testinput/test1.yaml
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [x] GenerateGFSAnalyses
 - [ ] GenerateObs
