### PR TITLE
Changes for using spack-stack v1.9.1.

### DIFF
--- a/config/environmentJEDI.csh
+++ b/config/environmentJEDI.csh
@@ -2,7 +2,7 @@
 
 if ( $?config_environmentJEDI ) exit 0
 
-set spack_version="1.6.0"
+set spack_version="1.9.1"
 echo "Loading Spack-Stack $spack_version"
 setenv config_environmentJEDI 1
 
@@ -27,10 +27,12 @@ if ( "$NCAR_HOST" == "derecho" ) then
      module use /glade/work/epicufsrt/contrib/spack-stack/derecho/modulefiles
      module load ecflow/5.8.4
      module load mysql/8.0.33
-     module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-${spack_version}/envs/unified-env/install/modulefiles/Core
+     #module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-${spack_version}/envs/unified-env/install/modulefiles/Core
+     module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-${spack_version}/envs/ue-gcc-12.2.0/install/modulefiles/Core
+
      module load stack-gcc/12.2.0
-     module load stack-cray-mpich/8.1.25
-     module load stack-python/3.10.8
+     module load stack-cray-mpich/8.1.27
+     module load stack-python/3.11.7
      module load jedi-mpas-env soca-env
      #module load jedi-mpas-env
   endif

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -352,8 +352,8 @@ variational:
       # Assuming 60 total inner iterations
       120km:
         3denvar:
-          nodes: 1
-          PEPerNode: 128
+          nodes: 2
+          PEPerNode: 64
           memory: 235GB
           baseSeconds: 200
           secondsPerEnVarMember: 15


### PR DESCRIPTION
The new toolchain requires more memory when running variational.
**Note** this is a draft until we get more scenarios running to see what other resource changes may be needed.
Also, the environmentJEDI.csh hasn't been updated to use the spack-stack 1.9.1 intel toolchain (that is currently underway in mpas-bundle)

### Tests completed
The test is to run the weekly cylc scenario (120 km 3denvar varbc)
After 1 week of cycling completes we'll compare results with a spack-stack 1.6 build.

#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
