### PR TITLE
Add a scenario for running the weekly cylc job via cron.

### DIFF
--- a/scenarios/3denvar_OIE120km_WarmStart_VarBC_cron.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart_VarBC_cron.yaml
@@ -1,0 +1,44 @@
+observations:
+  resource: PANDACArchiveForVarBC
+experiment:
+  suffix: '_VarBC'
+members:
+  n: 1
+model:
+  outerMesh: 120km
+  innerMesh: 120km
+  ensembleMesh: 120km
+firstbackground:
+  resource: "PANDAC.GFS"
+externalanalyses:
+  resource: "GFS.PANDAC"
+variational:
+  DAType: 3denvar
+  biasCorrection: True
+  ensemble:
+    forecasts:
+      resource: "PANDAC.GEFS"
+  #execute: False # the default is True
+  #post: [] # this turns off verifyobs
+forecast:
+  #execute: False # the default is True
+  #post: [] # use this when doing extended forecast
+  post: [verifymodel] # this turns off verifyobs
+#extendedforecast:
+#  meanTimes: T00 # T00, T12
+#  lengthHR: 120
+#  outIntervalHR: 24
+#  execute: True # this is the default setting
+#  post: [verifymodel,verifyobs] # can be replaced by [verifyobs,verifymodel]
+workflow:
+  first cycle point: 20180414T18
+  #restart cycle point: 20180418T00
+  final cycle point: 20180421T18
+  #final cycle point: 20180514T18
+  #CyclingWindowHR: 24 # default is 6 for cycling DA
+  #max active cycle points: 4 # used for independent 'extendedforecast'
+hpc:
+  #CriticalAccount: nmmm0043
+  #NonCriticalAccount: nmmm0043
+  CriticalQueue: economy
+  NonCriticalQueue: economy


### PR DESCRIPTION
This is the same scenario as scenarios/3denvar_OIE120km_WarmStart_VarBC.yaml, but the end point is 20180421T18 and it uses the economy queue.

### Tests completed
I verified the weekly cron job is running this scenario, and the scenario is completing successfully.