### PR TITLE
Enable creating the weekly cylc job graphs on casper.

### DIFF
--- a/env-setup/machine.csh
+++ b/env-setup/machine.csh
@@ -6,7 +6,7 @@ if ($? == 0) then
   conda deactivate
 endif
 
-if ( "$NCAR_HOST" == "derecho" ) then
+if ( "$NCAR_HOST" == "derecho" || "$NCAR_HOST" == "casper" ) then
   if ( ! $?CYLC_ENV ) then
     echo 'CYLC_ENV environment variable is not set, setting it to /glade/work/jwittig/conda-envs/my-cylc8.2'
     setenv CYLC_ENV /glade/work/jwittig/conda-envs/my-cylc8.2

--- a/env-setup/machine.sh
+++ b/env-setup/machine.sh
@@ -6,7 +6,7 @@ if [ $? -eq 0 ]; then
   conda deactivate
 fi
 
-if [[ "$NCAR_HOST" == "derecho" ]]; then
+if [[ "$NCAR_HOST" == "derecho" || "$NCAR_HOST" == "casper" ]]; then
   if [[ "$CYLC_ENV" == "" ]]; then
     echo 'CYLC_ENV environment variable is not set, setting it to /glade/work/jwittig/conda-envs/my-cylc8.2'
     export CYLC_ENV=/glade/work/jwittig/conda-envs/my-cylc8.2

--- a/env-setup/run_cylc.sh
+++ b/env-setup/run_cylc.sh
@@ -280,7 +280,14 @@ make_graphs()
   local new_run="" # the current job
   local prev_run="" # the job run prior to the current run
   # PBS directives
-  local readonly queue="-q develop"
+  if [[ "$NCAR_HOST" == "derecho" ]]; then
+    local readonly queue="-q develop"
+  elif [[ "$NCAR_HOST" == "casper" ]]; then
+    local readonly queue="-q casper"
+  else
+    log "unknown host: $NCAR_HOST, not making graphs"
+    return
+  fi
   local readonly account="-a nmmm0015"
   local readonly memory="-m 12"
   # SpawnAnalyzeStats arguments


### PR DESCRIPTION
### Description
This PR enables creating the weekly cylc graphs on casper.

### Tests completed
Ran the weekly cron job which creates graphs of the weekly cylc run on casper and verified the graphs were created and the web site (https://www2.mmm.ucar.edu/projects/mpas-jedi/weekly-cycling/) was updated.