### PR TITLE
Use built-in error tables for PrepBUFR files

### DIFF
--- a/bin/GetObs.csh
+++ b/bin/GetObs.csh
@@ -68,13 +68,6 @@ foreach inst ( ${convertToIODAObservations} )
           echo "Source file: ${satwndBUFRDirectory}/bufr/${ccyy}/${THIS_FILE}"
           cp -p ${satwndBUFRDirectory}/bufr/${ccyy}/${THIS_FILE} .
        endif
-       # link the GDAS observation error table
-       if ( -e ${GDASObsErrtable} ) then
-          ln -sf ${GDASObsErrtable} obs_errtable
-       else
-          echo "ERROR: ${GDASObsErrtable} does NOT exist" > ./FAIL
-          exit 1
-       endif
     # for prepbufr observations
     else if ( ${inst} == prepbufr ) then
        setenv THIS_FILE prepbufr.gdas.${ccyymmdd}.t${hh}z.nr.48h
@@ -88,14 +81,6 @@ foreach inst ( ${convertToIODAObservations} )
              cp -p ${PrepBUFRDirectory}/prepnr/${ccyy}/${THIS_FILE} .
           endif
        endif
-       # use obs errors embedded in prepbufr file
-       if ( -e obs_errtable ) then
-          rm -f obs_errtable
-       endif
-       # use external obs error table
-       #if ( -e ${GDASObsErrtable} ) then
-       #   ln -sf ${GDASObsErrtable} obs_errtable
-       #endif
     # for all other observations
     else
        # set the specific file to be extracted from the tar file

--- a/bin/ObsToIODA.csh
+++ b/bin/ObsToIODA.csh
@@ -102,6 +102,10 @@ foreach gdasfile ( *"gdas."* )
      #./${obs2iodaEXE} ${SPLIThourly} ${gdasfile} >&! $log
      ./${obs2iodaEXE} ${gdasfile} >&! $log
    else if ( ${gdasfile} =~ *"prepbufr"* ) then
+     # use obs errors embedded in prepbufr file
+     if ( -e obs_errtable ) then
+       rm -f obs_errtable
+     endif
      set inst = `echo "$gdasfile" | cut -d'.' -f1`
      # run obs2ioda for preburf with additional QC as in GSI
      ./${obs2iodaEXE} ${gdasfile} >&! $log
@@ -114,6 +118,15 @@ foreach gdasfile ( *"gdas."* )
      mv -f sfc_obs_${thisCycleDate}.h5 ../sfc_obs_${thisCycleDate}.h5
      cd ..
      rm -rf sfc
+   else if ( ${gdasfile} =~ *"satwnd"* ) then
+     # link the GDAS observation error table
+     if ( -e ${GDASObsErrtable} ) then
+       ln -sf ${GDASObsErrtable} obs_errtable
+     else
+       echo "ERROR: ${GDASObsErrtable} does NOT exist" > ./FAIL
+       exit 1
+     endif
+     ./${obs2iodaEXE} ${gdasfile} >&! $log
    else
      ./${obs2iodaEXE} ${gdasfile} >&! $log
    endif

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -154,9 +154,7 @@ class Build(Component):
 
     # Obs2IODA-v2
     # -----------
-    #self._set('obs2iodaEXE', 'obs2ioda-v2.x')
     self._set('obs2iodaEXE', 'obs2ioda_v2')
-    #self._set('obs2iodaBuildDir', '/glade/campaign/mmm/parc/ivette/pandac/fork_obs2ioda/obs2ioda/obs2ioda-v2/src')
     self._set('obs2iodaBuildDir', '/glade/work/stoedtli/bin/obs2ioda/2025-04-17')
     self._set('iodaUpgradeEXE1', 'ioda-upgrade-v1-to-v2.x')
     self._set('iodaUpgradeEXE2', 'ioda-upgrade-v2-to-v3.x')

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -154,8 +154,10 @@ class Build(Component):
 
     # Obs2IODA-v2
     # -----------
-    self._set('obs2iodaEXE', 'obs2ioda-v2.x')
-    self._set('obs2iodaBuildDir', '/glade/campaign/mmm/parc/ivette/pandac/fork_obs2ioda/obs2ioda/obs2ioda-v2/src')
+    #self._set('obs2iodaEXE', 'obs2ioda-v2.x')
+    self._set('obs2iodaEXE', 'obs2ioda_v2')
+    #self._set('obs2iodaBuildDir', '/glade/campaign/mmm/parc/ivette/pandac/fork_obs2ioda/obs2ioda/obs2ioda-v2/src')
+    self._set('obs2iodaBuildDir', '/glade/work/stoedtli/bin/obs2ioda/2025-04-17')
     self._set('iodaUpgradeEXE1', 'ioda-upgrade-v1-to-v2.x')
     self._set('iodaUpgradeEXE2', 'ioda-upgrade-v2-to-v3.x')
     self._set('iodaUpgradeBuildDir', self['mpas bundle']+'/bin')


### PR DESCRIPTION
### Description
This PR enforces usage of the built-in error tables when processing PrepBUFR files.

### Issue closed
Error tables are required to assign an observation error when processing PrepBUFR and satwnd BUFR files. Satwnd files require an external error table. PrepBUFR files on the other hand offer a choice: we can either use the built-in error table or we can use an external one. The desired behavior for global runs is to use the built-in error tables.

The behavior of the `obs2ioda` converter is determined by the presence of an external error table file named `obs_errtable` in the working directory: the converter uses the external table if the file `obs_errtable` is present and the built-in error table otherwise. To guarantee the desired behavior, the workflow needs to:
- Create a file (link) `obs_errtable` (if not yet present) before processing satwnd observations
- Delete the file (link) `obs_errtable` (if present) before processing PrepBUFR observations

This PR makes the necessary changes to the workflow scripts. It also updates the obs2ioda executable build to commit hash [a99dae6](https://github.com/NCAR/obs2ioda/commit/a99dae6a9a4ef41644a7a8157aa55266739e92d0), which enables hourly GNSSRO output and includes the bugfix to the AMSUA-N15 obs error. This build still uses the old Fortran NetCDF interface and requires the subsequent calls to upgrade the IODA files to v3.


### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [x] GenerateObs

I compared the result of the `GenerateObs` scenario to our obs in the PANDACArchiveForVarBC.

PrepBUFR observations, e.g. aircraft:
- ObsError is identical up to numerical precision
- A few instances of `epochtime` are off by 1s. Not sure why, perhaps we changed the integer arithmetics in the calculation at some point.
- All other entries are identical

```sh
$ nccmp -ldmegfs -S aircraft_obs_2018041500.h5 $PANDACArchiveForVarBC/aircraft_obs_2018041500.h5
Variable         Group     Count         Sum      AbsSum          Min         Max       Range        Mean      StdDev
dateTime         /MetaData    50           2          50           -1           1           2        0.04     1.00934
specificHumidity /ObsError  7347 7.28983e-09 6.88424e-07 -9.31323e-10 9.31323e-10 1.86265e-09 9.92218e-13 1.41336e-10
```

Satwnd observations:
- Small difference in ObsValue. Not sure why, perhaps we changed the floating point precision, made changes to the arithmetics, etc. at some point.
- All other entries, including ObsError, are identical

```sh
$ nccmp -ldmegfs -S satwnd_obs_2018041500.h5 $PANDACArchiveForVarBC/satwnd_obs_2018041500.h5
Variable      Group     Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
windEastward  /ObsValue  2263 -7.75158e-05 0.000527889 -9.53674e-07 9.53674e-07 1.90735e-06 -3.42536e-08 2.70973e-07
windNorthward /ObsValue  8120 -0.000296593  0.00200391 -1.90735e-06 4.76837e-07 2.38419e-06 -3.65262e-08 3.00073e-07
```