### PR TITLE
Enhancement of GETKF/LETKF ensemble DA capability (release/3.0.2)

### DIFF
--- a/bin/EnKF.csh
+++ b/bin/EnKF.csh
@@ -5,14 +5,14 @@
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
-# Carry out LocalEnsembleDA (EnKF) solver stage for ensemble of first guess states
-# note: must follow successful observer stage
+# Carry out LocalEnsembleDA (EnKF) for ensemble of first guess states
 
 date
 
 # Process arguments
 # =================
 ## args
+set ArgEnKFMode = "$1"
 
 # None
 
@@ -24,14 +24,30 @@ source config/auto/build.csh
 source config/auto/experiment.csh
 source config/auto/enkf.csh
 source config/auto/workflow.csh
-source config/auto/members.csh
 source config/auto/model.csh
-source config/auto/observations.csh
+source config/auto/naming.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`
 set thisCycleDate = ${yymmdd}${hh}
 set thisValidDate = ${thisCycleDate}
 source ./bin/getCycleVars.csh
+
+# EnKF: asObserver or asDiagOMA or Solver
+if ( "$ArgEnKFMode" == "OMB" ) then
+   set appName = "observerOMB"
+else if ( "$ArgEnKFMode" == "OMA" ) then
+   set appName = "observerOMA"
+else if ( "$ArgEnKFMode" == "Solver" ) then
+   set appName = "solver"
+else
+   echo "ERROR in ${ArgEnKFMode} in EnKF Mode" > ./FAIL
+   exit 1
+endif
+
+# For Solver step, set openmpi
+if ( "$ArgEnKFMode" == "Solver" ) then
+   setenv OMP_NUM_THREADS ${solverThreads}
+endif
 
 # static work directory
 set self_WorkDir = $CyclingDADir
@@ -43,45 +59,86 @@ set myBuildDir = ${EnKFBuildDir}
 set myEXE = ${EnKFEXE}
 set myYAML = ${self_WorkDir}/${appyaml}
 
-setenv OMP_NUM_THREADS ${solverThreads}
-
 # ================================================================================================
 
-## change to run directory
+## create then change to run directory
 set runDir = run
+if ( "$ArgEnKFMode" == OMB ) then
+  rm -r ${runDir}
+  mkdir -p ${runDir}
+endif
+
+# direct to the run directory
 cd ${runDir}
 
-# Link+Run the executable
-# =======================
-ln -sfv ${myBuildDir}/${myEXE} ./
+if ( "$ArgEnKFMode" == "OMB" ) then
 
-# asSolver
-cp $myYAML solver.yaml
-sed -i 's@{{driver}}@asSolver@' solver.yaml
-sed -i 's@{{ObsDataIn}}@ObsDataOut@' solver.yaml
-sed -i 's@\ \+{{ObsDataOut}}@@' solver.yaml
-sed -i 's@{{ObsOutSuffix}}@@' solver.yaml
-sed -i 's@{{ObsSpaceDistribution}}@HaloDistribution@' solver.yaml
-mpiexec ./${myEXE} solver.yaml ./solver.log >& solver.log.all
+  ## link MPAS-Atmosphere lookup tables
+  foreach fileGlob ($MPASLookupFileGlobs)
+    ln -sfv ${MPASLookupDir}/*${fileGlob} .
+  end
 
-#WITH DEBUGGER
-#module load arm-forge/19.1
-#setenv MPI_SHEPHERD true
-#ddt --connect ./${myEXE} $myYAML ./jedi.log
+  if (${MicrophysicsOuter} == 'mp_thompson' ) then
+    ln -svf $MPThompsonTablesDir/* .
+  endif
+
+  ## link stream_list.atmosphere.* files
+  ln -sfv ${self_WorkDir}/stream_list.atmosphere.* ./
+
+  ## MPASJEDI variable configs
+  foreach file ($MPASJEDIVariablesFiles)
+    ln -sfv $ModelConfigDir/$file .
+  end
+
+  # Link+Run the executable
+  # =======================
+  ln -sfv ${myBuildDir}/${myEXE} ./
+
+endif
+
+# YAML setting
+cp $myYAML ${appName}.yaml
+
+if ( "$ArgEnKFMode" == "Solver" ) then
+   sed -i 's@{{ensembleStateDir}}@'${CyclingDADir}'/'${backgroundSubDir}'@' ${appName}.yaml
+   sed -i 's@{{ensembleStatePrefix}}@'${BGFilePrefix}'@' ${appName}.yaml
+   sed -i 's@{{driver}}@asSolver@' ${appName}.yaml
+   sed -i 's@{{ObsDataIn}}@ObsDataOut@' ${appName}.yaml
+   sed -i 's@\ \+{{ObsDataOut}}@@' ${appName}.yaml
+   sed -i 's@{{ObsOutSuffix}}@@' ${appName}.yaml
+   sed -i 's@{{ObsSpaceDistribution}}@HaloDistribution@' ${appName}.yaml
+else
+   sed -i 's@{{driver}}@asObserver@' ${appName}.yaml
+   sed -i 's@{{ObsSpaceDistribution}}@RoundRobinDistribution@' ${appName}.yaml
+   sed -i 's@{{ObsDataIn}}@ObsDataIn@' ${appName}.yaml
+   sed -i 's@{{ObsDataOut}}@obsdataout: *ObsDataOut@' ${appName}.yaml
+   if ( "$ArgEnKFMode" == "OMA" ) then
+      sed -i 's@{{ensembleStateDir}}@'${CyclingDADir}'/'${analysisSubDir}'@' ${appName}.yaml
+      sed -i 's@{{ensembleStatePrefix}}@'${ANFilePrefix}'@' ${appName}.yaml
+      sed -i 's@{{ObsOutSuffix}}@_ana@' ${appName}.yaml
+      sed -i 's@*asGETKF@*asLETKF@' ${appName}.yaml
+   else
+      sed -i 's@{{ensembleStateDir}}@'${CyclingDADir}'/'${backgroundSubDir}'@' ${appName}.yaml
+      sed -i 's@{{ensembleStatePrefix}}@'${BGFilePrefix}'@' ${appName}.yaml
+     sed -i 's@{{ObsOutSuffix}}@@' ${appName}.yaml
+   endif
+endif
+
+mpiexec ./${myEXE} ${appName}.yaml ./${appName}.log >& ${appName}.log.all
 
 # Check status
 # ============
-grep 'Run: Finishing oops.* with status = 0' solver.log
+grep 'Run: Finishing oops.* with status = 0' ${appName}.log
 if ( $status != 0 ) then
-  echo "ERROR in $0 : enkf solver failed" > ./FAIL
+  echo "ERROR in $0 : enkf ${appName} failed" > ./FAIL
   exit 1
+else
+  rm ${appName}.log.0*
 endif
-
-# ================================================================================================
 
 # Remove obs-database output files
 # ================================
-if ("$retainObsFeedback" != True) then
+if ("$retainObsFeedback" != "True" && "$ArgEnKFMode" == "Solver" ) then
   echo " ls ${self_WorkDir}/${OutDBDir}/"
   ls ${self_WorkDir}/${OutDBDir}/
   echo "rm ${self_WorkDir}/${OutDBDir}/${obsPrefix}*.h5"
@@ -91,9 +148,6 @@ if ("$retainObsFeedback" != True) then
   echo "rm ${self_WorkDir}/${OutDBDir}/${diagPrefix}*.nc4"
   rm ${self_WorkDir}/${OutDBDir}/${diagPrefix}*.nc4
 endif
-
-# Remove netcdf lock files
-rm *.nc*.lock
 
 date
 

--- a/bin/HofX.csh
+++ b/bin/HofX.csh
@@ -129,6 +129,8 @@ grep 'Run: Finishing oops.* with status = 0' jedi.log
 if ( $status != 0 ) then
   echo "ERROR in $0 : jedi application failed" > ./FAIL
   exit 1
+else
+  rm jedi.log.0*
 endif
 
 # ================================================================================================

--- a/bin/PrepJEDI.csh
+++ b/bin/PrepJEDI.csh
@@ -276,6 +276,11 @@ else
   set biasCorrectionDir = ${DAWorkDir}/$prevValidDate/dbOut
 endif
 
+# For EnKF, offline bias correction can be applied for bias correction
+if ( "$ArgAppType" == enkf ) then
+  set biasCorrectionDir = ${staticVarBcDir}/${thisValidDate}/${OutDBDir}
+endif
+
 # =============
 # Generate yaml
 # =============
@@ -331,9 +336,16 @@ foreach instrument ($observers)
     if ("$instrument" == "$i") then
       set allowsBiasCorrection = True
       # if no obs file exists, link satbias file from the previous cycle
-      if ( ! -f ${InDBDir}/${instrument}_obs_${thisValidDate}.h5 ) then
-        ln -sf ${biasCorrectionDir}/satbias_${i}.h5 ${DAWorkDir}/${thisValidDate}/dbOut
-        ln -sf ${biasCorrectionDir}/satbias_cov_${i}.h5 ${DAWorkDir}/${thisValidDate}/dbOut
+      if ( $ArgAppType == 'enkf' ) then
+        if ( ! -f ${biasCorrectionDir}/satbias_${i}.h5 ) then
+          ! Just use the initial satbias files
+          set biasCorrectionDir = ${initialVARBCcoeff}
+        endif
+      else
+        if ( ! -f ${InDBDir}/${instrument}_obs_${thisValidDate}.h5 ) then
+          ln -sf ${biasCorrectionDir}/satbias_${i}.h5 ${DAWorkDir}/${thisValidDate}/${OutDBDir}
+          ln -sf ${biasCorrectionDir}/satbias_cov_${i}.h5 ${DAWorkDir}/${thisValidDate}/${OutDBDir}
+        endif        
       endif
     endif
   end
@@ -341,7 +353,11 @@ foreach instrument ($observers)
   # declare subdirectories for YAML stubs, which depends on whether bias correction is applied
   set AppYamlDirs = (base filters)
   if ($biasCorrection == True && $allowsBiasCorrection == True) then
-    set AppYamlDirs = (base bias filtersWithBias)
+    if ( "$ArgAppType" == enkf ) then
+      set AppYamlDirs = (base biasStatic filtersWithBias)
+    else
+      set AppYamlDirs = (base bias filtersWithBias)
+    endif    
   endif
 
   foreach subdir (${AppYamlDirs})
@@ -922,58 +938,39 @@ else if ("$ArgAppType" == enkf) then
   # Solver
   # ==================
   sed -i 's@{{localEnsembleDASolver}}@'${solver}'@g' $prevYAML
-
-  # TODO:
-  # Ensemble background members
-  # ===========================
-  set yamlFiles = enkfs.txt
-  echo $appyaml > $yamlFiles
-  ## yaml indentation
-  set nEnsIndent = 2
-
-  ## members: 'background.members from template'
-
-  # performs sed substitution for EnsembleMembers
-  set enspbmemsed = EnsembleMembers
-
-  @ dateOffset = ${ArgWindowHR} + ${ensPbOffsetHR}
-  set prevDateTime = `$advanceCYMDH ${thisValidDate} -${dateOffset}`
-
-  # substitutions
-  # + previous forecast initilization date-time
-  # + ExperimentDirectory for EDA applications that use their own ensemble
-  set dir0 = `echo "${ensPbDir0}" \
-              | sed 's@{{prevDateTime}}@'${prevDateTime}'@' \
-              | sed 's@{{ExperimentDirectory}}@'${ExperimentDirectory}'@' \
-             `
-  set dir1 = `echo "${ensPbDir1}" \
-              | sed 's@{{prevDateTime}}@'${prevDateTime}'@'\
-             `
-
-  #set dir0 = "`echo "${dir0}" | sed 's@{{ExperimentDirectory}}@'${ExperimentDirectory}'@'`"
-
-  # substitute Jb members
-  setenv myCommand "${substituteEnsembleBTemplate} ${dir0} ${dir1} ${ensPbMemPrefix} ${ensPbFilePrefix}.${thisMPASFileDate}.nc ${ensPbMemNDigits} ${ensPbNMembers} $yamlFiles ${enspbmemsed} ${nEnsIndent} False"
-
-  echo "$myCommand"
-  #${substituteEnsembleBTemplate} "${ensPbDir0}" "${ensPbDir1}" ${ensPbMemPrefix} ${ensPbFilePrefix}.${thisMPASFileDate}.nc ${ensPbMemNDigits} ${ensPbNMembers} $yamlFiles ${enspbmemsed} ${nEnsIndent} $SelfExclusion
-
-  ${myCommand}
-
-  rm $yamlFiles
-
-  if ($status != 0) then
-    echo "$0 (ERROR): failed to substitute ${enspbmemsed}" > ./FAIL
-    exit 1
+  if ( $solver == 'GETKF' ) then
+     sed -i 's@{{LocalEnKFSolver}}@asGETKF@g' $prevYAML
+  else
+     sed -i 's@{{LocalEnKFSolver}}@asLETKF@g' $prevYAML
   endif
 
-  # ObsLocalization
+  # Ensemble background members
+  # ===========================
+  sed -i 's@{{ensPbMemPrefix}}@'${ensPbMemPrefix}'@' $prevYAML 
+  sed -i 's@{{MemNDigits}}@'${ensPbMemNDigits}'@' $prevYAML
+  sed -i 's@{{NumEnsMember}}@'${ensPbNMembers}'@' $prevYAML
+
+  # Localization
   # ===============
+  # horizontal obs localization
   sed -i 's@{{localizationDimension}}@'"${localizationDimension}"'@' $prevYAML
   sed -i 's@{{horizontalLocalizationMethod}}@'"${horizontalLocalizationMethod}"'@' $prevYAML
   sed -i 's@{{horizontalLocalizationLengthscale}}@'${horizontalLocalizationLengthscale}'@' $prevYAML
+  # vertical localization (GETKF: model space; LETKF: obs space)
   sed -i 's@{{verticalLocalizationFunction}}@'"${verticalLocalizationFunction}"'@' $prevYAML
   sed -i 's@{{verticalLocalizationLengthscale}}@'${verticalLocalizationLengthscale}'@' $prevYAML
+  sed -i 's@{{verticalLocalizationLengthscaleUnits}}@'${verticalLocalizationLengthscaleUnits}'@' $prevYAML
+  sed -i 's@{{fractionOfRetainedVariance}}@'${fractionOfRetainedVariance}'@' $prevYAML
+
+  # Inlfation
+  # ===============
+  sed -i 's@{{rtpsValue}}@'"${rtpsValue}"'@' $prevYAML
+  sed -i 's@{{rtppValue}}@'"${rtppValue}"'@' $prevYAML
+  sed -i 's@{{multValue}}@'"${multValue}"'@' $prevYAML
+
+  # Use linear operator
+  # ===============
+  sed -i 's@{{useLinearOperator}}@'"${useLinearOperator}"'@' $prevYAML
 
   # Jo term (member dependence)
   # ===========================
@@ -986,7 +983,6 @@ else if ("$ArgAppType" == enkf) then
 endif
 
 date
-
 
 # ==================================================================================================
 # ==================================================================================================

--- a/bin/Variational.csh
+++ b/bin/Variational.csh
@@ -113,6 +113,8 @@ grep 'Run: Finishing oops.* with status = 0' jedi.log
 if ( $status != 0 ) then
   echo "ERROR in $0 : jedi application failed" > ./FAIL
   exit 1
+else
+  rm jedi.log.0*
 endif
 
 # ================================================================================================

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -48,7 +48,7 @@ ecbuild_bundle( PROJECT ropp-ufo  GIT "https://github.com/JCSDA-internal/ropp-te
 option(BUNDLE_SKIP_RTTOV "Don't build rttov"  "ON") # Skip rttov build unless user passes -DBUNDLE_SKIP_RTTOV=OFF
 ecbuild_bundle( PROJECT rttov     GIT "https://github.com/JCSDA-internal/rttov.git"       BRANCH develop UPDATE )
 
-ecbuild_bundle( PROJECT oops      GIT "https://github.com/JCSDA-internal/oops.git"        TAG d772173 )
+ecbuild_bundle( PROJECT oops      GIT "https://github.com/JCSDA-internal/oops.git"        TAG 0d2c235 )
 ecbuild_bundle( PROJECT vader     GIT "https://github.com/JCSDA-internal/vader.git"       TAG 6d56a1e )
 ecbuild_bundle( PROJECT saber     GIT "https://github.com/JCSDA-internal/saber.git"       TAG bba6f7e )
 ecbuild_bundle( PROJECT crtm      GIT "https://github.com/JCSDA/CRTMv3.git"               TAG 73102a2 )

--- a/config/jedi/ObsPlugs/da/biasStatic/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/abi_g16.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_abi_g16.h5
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &abig16tlap {{fixedTlapmeanCov}}/abi_g16_tlapmean.txt
+      - name: lapseRate
+        tlapse: *abig16tlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/ahi_himawari8.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_ahi_himawari8.h5
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &ahihimawari8tlap {{fixedTlapmeanCov}}/ahi_himawari8_tlapmean.txt
+      - name: lapseRate
+        tlapse: *ahihimawari8tlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/amsua_aqua.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_amsua_aqua.h5
+    variational bc:
+      predictors: &predictors5
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &amsuaaquatlap {{fixedTlapmeanCov}}/amsua_aqua_tlapmean.txt
+      - name: lapseRate
+        tlapse: *amsuaaquatlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/amsua_metop-a.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_amsua_metop-a.h5
+    variational bc:
+      predictors: &predictors4
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &amsuametopatlap {{fixedTlapmeanCov}}/amsua_metop-a_tlapmean.txt
+      - name: lapseRate
+        tlapse: *amsuametopatlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/amsua_metop-b.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_amsua_metop-b.h5
+    variational bc:
+      predictors: &predictors4
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &amsuametopbtlap {{fixedTlapmeanCov}}/amsua_metop-b_tlapmean.txt
+      - name: lapseRate
+        tlapse: *amsuametopbtlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/amsua_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/amsua_metop-c.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_amsua_metop-c.h5
+    variational bc:
+      predictors: &predictors4
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &amsuametopctlap {{fixedTlapmeanCov}}/amsua_metop-c_tlapmean.txt
+      - name: lapseRate
+        tlapse: *amsuametopctlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/amsua_n15.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_amsua_n15.h5
+    variational bc:
+      predictors: &predictors2
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &amsua15tlap {{fixedTlapmeanCov}}/amsua_n15_tlapmean.txt
+      - name: lapseRate
+        tlapse: *amsua15tlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/amsua_n18.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_amsua_n18.h5
+    variational bc:
+      predictors: &predictors3
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &amsua18tlap {{fixedTlapmeanCov}}/amsua_n18_tlapmean.txt
+      - name: lapseRate
+        tlapse: *amsua18tlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/amsua_n19.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_amsua_n19.h5
+    variational bc:
+      predictors: &predictors1
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &amsua19tlap {{fixedTlapmeanCov}}/amsua_n19_tlapmean.txt
+      - name: lapseRate
+        tlapse: *amsua19tlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/iasi_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/iasi_metop-a.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_iasi_metop-a.h5
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &iasimetopatlap {{fixedTlapmeanCov}}/iasi_metop-a_tlapmean.txt
+      - name: lapseRate
+        tlapse: *iasimetopatlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/iasi_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/iasi_metop-b.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_iasi_metop-b.h5
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &iasimetopbtlap {{fixedTlapmeanCov}}/iasi_metop-b_tlapmean.txt
+      - name: lapseRate
+        tlapse: *iasimetopbtlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/iasi_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/iasi_metop-c.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_iasi_metop-c.h5
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &iasimetopctlap {{fixedTlapmeanCov}}/iasi_metop-c_tlapmean.txt
+      - name: lapseRate
+        tlapse: *iasimetopctlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/mhs_metop-a.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_mhs_metop-a.h5
+    variational bc:
+      predictors: &predictors1
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &mhsmetopatlap {{fixedTlapmeanCov}}/mhs_metop-a_tlapmean.txt
+      - name: lapseRate
+        tlapse: *mhsmetopatlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/mhs_metop-b.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_mhs_metop-b.h5
+    variational bc:
+      predictors: &predictors1
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &mhsmetopbtlap {{fixedTlapmeanCov}}/mhs_metop-b_tlapmean.txt
+      - name: lapseRate
+        tlapse: *mhsmetopbtlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/mhs_n18.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_mhs_n18.h5
+    variational bc:
+      predictors: &predictors1
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &mhs18tlap {{fixedTlapmeanCov}}/mhs_n18_tlapmean.txt
+      - name: lapseRate
+        tlapse: *mhs18tlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/da/biasStatic/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/biasStatic/mhs_n19.yaml
@@ -1,0 +1,18 @@
+  obs bias:
+    input file: {{biasCorrectionDir}}/satbias_mhs_n19.h5
+    variational bc:
+      predictors: &predictors1
+      - name: constant
+      - name: lapseRate
+        order: 2
+        tlapse: &mhs19tlap {{fixedTlapmeanCov}}/mhs_n19_tlapmean.txt
+      - name: lapseRate
+        tlapse: *mhs19tlap
+      - name: emissivityJacobian
+      - name: sensorScanAngle
+        order: 4
+      - name: sensorScanAngle
+        order: 3
+      - name: sensorScanAngle
+        order: 2
+      - name: sensorScanAngle

--- a/config/jedi/ObsPlugs/enkf/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/enkf/ObsAnchors.yaml
@@ -1,6 +1,7 @@
 _hor obs localization: &HorizObsLoc
   localization method: {{horizontalLocalizationMethod}}
   lengthscale: &HorizObsLocLengthScale {{horizontalLocalizationLengthscale}}
+  max nobs: 1000
 
 _conventional vertical localization: &HeightVertObsLoc
   localization method: Vertical localization

--- a/config/jedi/applications/enkf.yaml
+++ b/config/jedi/applications/enkf.yaml
@@ -15,6 +15,16 @@ _as solver: &asSolver
   save posterior ensemble: true
   save posterior mean: true
 
+_as solver LETKF: &asLETKF
+  solver: LETKF
+
+_as solver GETKF: &asGETKF
+  solver: GETKF
+  vertical localization: # only used by GETKF solver
+    fraction of retained variance: {{fractionOfRetainedVariance}}
+    lengthscale: {{verticalLocalizationLengthscale}}
+    lengthscale units: {{verticalLocalizationLengthscaleUnits}}
+
 _letkf geometry: &3DLETKFGeometry
   iterator dimension: 3
 
@@ -29,14 +39,19 @@ geometry:
   nml_file: {{EnKFNamelistFile}}
   streams_file: {{EnKFStreamsFile}}
   deallocate non-da fields: true
-  #interpolation type: unstructured # no Increment/State interp in enkf
 
 time window:
   begin: {{windowBegin}}
   length: {{windowLength}}
 
 background:
-{{EnsembleMembers}}
+  members from template:
+    template:
+      <<: *memberConfig
+      filename: {{ensembleStateDir}}/mem%iMember%/{{ensembleStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc
+    pattern: %iMember%
+    zero padding: {{MemNDigits}}
+    nmembers: {{NumEnsMember}}
 
 increment variables: [{{AnalysisVariables}}]
 
@@ -47,17 +62,12 @@ observations:
 driver: *{{driver}}
 
 local ensemble DA:
-  solver: {{localEnsembleDASolver}}
-  vertical localization: # only used by GETKF solver
-    fraction of retained variance: 0.95
-    lengthscale: {{verticalLocalizationLengthscale}}
-    lengthscale units: modellevel
-
-# TODO: how do inflation settings impact result?
-#  inflation:
-#    rtps: 0.5
-#    rtpp: 0.6
-#    mult: 1.1
+  <<: *{{LocalEnKFSolver}}
+  use linear observer: {{useLinearOperator}}
+  inflation:
+    rtps: {{rtpsValue}}
+    rtpp: {{rtppValue}}
+    mult: {{multValue}}
 
 output:
   filename: {{anStateDir}}/mem%{member}%/{{anStatePrefix}}.$Y-$M-$D_$h.$m.$s.nc

--- a/initialize/applications/EnKF.py
+++ b/initialize/applications/EnKF.py
@@ -28,15 +28,26 @@ class EnKF(Component):
   }
 
   variablesWithDefaults = {
-    ## observation localization parameters
+    # horizontal observation localization
     'localization dimension': ['3D', str, ['2D', '3D']],
     'horizontal localization method': ['Horizontal Gaspari-Cohn', str],
     'horizontal localization lengthscale': [1.2e6, float],
-    # LETKF
+    # vertical localization (GETKF: model spcace; LETKF: obs space)
     'vertical localization function': ['Gaspari Cohn', str],
     'vertical localization lengthscale': [6.e3, float],
-    # GETKF
-    #'vertical localization lengthscale': [5.0, float],
+    'vertical localization lengthscale units': ['height', str],
+    'fraction of retained variance': [0.95, float],
+
+    # Inflation
+    'rtpp value': [0.5, float],
+    'rtps value': [0.9, float],
+    'mult value': [1.0, float],
+
+    # Use Linear Operator
+    'useLinearOperator': ['true', str, ['true', 'false']],
+
+    # Calculate ensemble OMA
+    'diagEnKFOMA': ['True', bool, ['True', 'False']],
 
     ## observers
     # observation types assimilated in the enkf application
@@ -73,6 +84,9 @@ class EnKF(Component):
     # whether to use bias correction coefficients from VarBC
     # OPTIONS: False (not enabled yet)
     'biasCorrection': [False, bool],
+
+    # directories that stores varBC coefficients that are updated with variational DA
+    'staticVarBcDir': ['/glade/campaign/mmm/parc/ivette/pandac/year7Exp/ivette_3dhybrid-allsky-60-60-iter_O30kmI60km_ensB-SE80+RTPP70_VarBC_v3.0.2_newBenchmark_allsky-amsua/CyclingDA', str],
 
     ## tropprsMethod
     # method for the tropopause pressure determination used in the
@@ -196,6 +210,15 @@ class EnKF(Component):
     observerjob._set('seconds', observerjob['baseSeconds'] + observerjob['secondsPerMember'] * NN)
     observertask = TaskLookup[hpc.system](observerjob)
 
+    # EnKFDiagOMA
+    if self['diagEnKFOMA'] and self['retainObsFeedback']:
+      # r2observer = {{outerMesh}}.observer
+      r2diagoma = meshes['Outer'].name
+      r2diagoma += '.'+solver+'.diagoma'
+      diagomajob = Resource(self._conf, attr, ('job', r2observer))
+      diagomajob._set('seconds', observerjob['baseSeconds'] + observerjob['secondsPerMember'] * NN)
+      diagomatask = TaskLookup[hpc.system](diagomajob)
+
     # EnKF solver
     # r2solver = {{outerMesh}}.{{solver}}
     r2solver = meshes['Outer'].name
@@ -230,13 +253,22 @@ class EnKF(Component):
 
   [[EnKFObserver]]
     inherit = '''+self.tf.execute+''', BATCH
-    script = $origin/bin/EnKFObserver.csh
+    script = $origin/bin/EnKF.csh OMB
 '''+observertask.job()+observertask.directives()+'''
 
-  [[EnKF]]
+  [[EnKFSolver]]
     inherit = '''+self.tf.execute+''', BATCH
-    script = $origin/bin/EnKF.csh
+    script = $origin/bin/EnKF.csh Solver
 '''+solvertask.job()+solvertask.directives()]
+
+    if self['diagEnKFOMA'] and self['retainObsFeedback']:
+       self._tasks += ['''
+  [[EnKFDiagOMA]]
+    inherit = '''+self.tf.execute+''', BATCH
+    script = $origin/bin/EnKF.csh OMA
+'''+diagomatask.job()+diagomatask.directives()]
+       self._dependencies += ['''
+        EnKFSolver => EnKFDiagOMA => '''+self.tf.post]
 
     if self['concatenateObsFeedback']:
       concatattr = {
@@ -261,9 +293,9 @@ class EnKF(Component):
     script = $origin/bin/ConcatenateObsFeedback.csh '''+concatArgs+'''
 '''+concattask.job()+concattask.directives()]
       self._dependencies += ['''
-        EnKF => ConcatEnKF => '''+self.tf.post]
+        EnKFSolver => ConcatEnKF => '''+self.tf.post]
 
     self._dependencies += ['''
 
         # EnKF
-        EnKFObserver => EnKF''']
+        EnKFObserver => EnKFSolver''']

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -44,7 +44,7 @@ class Build(Component):
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
       else:
         self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/work/bjung/panda-c/build/mpas-bundle-release-v3.0.2/build_single', str] ## release-v3.0.2
+          ['/glade/work/taosun/Derecho/JEDI/mpas-bundle-v3.0.2/build', str] ## release-v3.0.2
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]
       self.variablesWithDefaults['forecast directory'] = ['bundle', str]

--- a/scenarios/defaults/enkf.yaml
+++ b/scenarios/defaults/enkf.yaml
@@ -11,7 +11,6 @@ enkf:
       # cylc retry string
       retry: '2*PT30S'
 
-
     ## FORMAT
     #{{outerMesh}}:
     #  {{solver}}: # i.e., LETKF, GETKF
@@ -57,6 +56,12 @@ enkf:
           memory: 235GB
           baseSeconds: 200
           secondsPerMember: 290
+        diagoma:
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
+          baseSeconds: 100
+          secondsPerMember: 7
       GETKF:
         observer:
           # cost for record (20 members, 95% variance retained [13 eig], PBS JOB email)
@@ -77,6 +82,12 @@ enkf:
           memory: 235GB
           baseSeconds: 200
           secondsPerMember: 500
+        diagoma:
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
+          baseSeconds: 100
+          secondsPerMember: 7
     120km:
       LETKF:
         observer:
@@ -103,6 +114,17 @@ enkf:
           memory: 235GB
           baseSeconds: 300
           secondsPerMember: 150
+        diagoma:
+          # cost for record (5 members, PBS JOB email)
+          # 2 x 32 PE : 1.7 min., 14.6 GB (single precision)
+          # 2 x 32 PE : 3.5 min., 31 GB (double precision)
+          # cost for record (20 members, PBS JOB email)
+          # 2 x 32 PE : 3.0 min., 31.7 GB (single precision)
+          nodes: 1
+          PEPerNode: 128
+          memory: 235GB
+          baseSeconds: 300
+          secondsPerMember: 3
       GETKF:
         observer:
           # cost for record (20 members, 95% variance retained [13 eig], PBS JOB email)
@@ -110,8 +132,8 @@ enkf:
           nodes: 2
           PEPerNode: 128
           memory: 235GB
-          baseSeconds: 750
-          secondsPerMember: 45
+          baseSeconds: 800
+          secondsPerMember: 50
         solver:
           # cost for record (5 members, PBS JOB email)
           # 4 x 32 PE : ?.? min., ?? GB (single precision)
@@ -121,3 +143,14 @@ enkf:
           memory: 235GB
           baseSeconds: 200
           secondsPerMember: 300
+        diagoma:
+          # cost for record (5 members, PBS JOB email)
+          # 2 x 32 PE : 1.7 min., 14.6 GB (single precision)
+          # 2 x 32 PE : 3.5 min., 31 GB (double precision)
+          # cost for record (20 members, PBS JOB email)
+          # 2 x 32 PE : 3.0 min., 31.7 GB (single precision)
+          nodes: 2
+          PEPerNode: 128
+          memory: 235GB
+          baseSeconds: 300
+          secondsPerMember: 3

--- a/scenarios/getkf_OIE60km_WarmStart_StaticBC.yaml
+++ b/scenarios/getkf_OIE60km_WarmStart_StaticBC.yaml
@@ -1,27 +1,30 @@
+experiment:
+  name: 'getkf_OIE60km_WarmStart_StaticBC'
 enkf:
   solver: GETKF
   horizontal localization lengthscale: 1.2e6
   vertical localization lengthscale: 10.0 # modellevel
-  retainObsFeedback: False
+  vertical localization lengthscale units: modellevel
+  staticVarBcDir: /glade/campaign/mmm/parc/jban/pandac/year7Exp/jban_3dhybrid-60-60-iter_O30kmI60km_mhsRaw_clrsky/CyclingDA
+  biasCorrection: True
+  retainObsFeedback: True
   post: []
 externalanalyses:
   resource: "GFS.PANDAC"
 firstbackground:
-  resource: "PANDAC.LaggedGEFS"
+  resource: "PANDAC.EnsPertB"
 forecast:
-  post: [verifymodel] #verifyobs
+  post: []
 hofx:
   retainObsFeedback: False
 members:
   n: 20
 model:
   outerMesh: 60km
-  # TODO: make inner and ensemble meshes unnecessary
-  # related to {{PrepareExternalAnalysisInner}} and {{PrepareExternalAnalysisEnsemble}}
   innerMesh: 60km
   ensembleMesh: 60km
 observations:
-  resource: PANDACArchive
+  resource: PANDACArchiveForVarBC
   resources:
     PANDACArchive:
       IODADirectory:

--- a/scenarios/getkf_OIE60km_WarmStart_StaticBC.yaml
+++ b/scenarios/getkf_OIE60km_WarmStart_StaticBC.yaml
@@ -25,22 +25,8 @@ model:
   ensembleMesh: 60km
 observations:
   resource: PANDACArchiveForVarBC
-  resources:
-    PANDACArchive:
-      IODADirectory:
-        da:
-          abi_g16: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          ahi_himawari8: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
-          ahi-clr_himawari8: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
-        hofx:
-          abi_g16: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          abi-clr_g16: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/ABIASR/IODANC_THIN15KM_SUPEROB15X15_no-bias-correct
-          ahi_himawari8: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
-          ahi-clr_himawari8: /glade/campaign/mmm/parc/liuz/pandac_common/obs/ioda_v3/2018/AHIASR/IODANC_SUPEROB15X15_no-bias-correct
-      IODASuperObGrid:
-        abi_g16: 15X15
-        ahi_himawari8: 15X15
+build:
+  mpas bundle: /glade/work/taosun/Derecho/JEDI/mpas-bundle-v3.0.2/build
 workflow:
   first cycle point: 20180414T18
   final cycle point: 20180415T00

--- a/scenarios/letkf2D_OIE60km_WarmStart.yaml
+++ b/scenarios/letkf2D_OIE60km_WarmStart.yaml
@@ -36,8 +36,6 @@ observations:
       IODASuperObGrid:
         abi_g16: 15X15
         ahi_himawari8: 15X15
-rtpp:
-  relaxationFactor: 0.8
 workflow:
   first cycle point: 20180414T18
   final cycle point: 20180415T00

--- a/scenarios/letkf_OIE60km_WarmStart.yaml
+++ b/scenarios/letkf_OIE60km_WarmStart.yaml
@@ -38,8 +38,6 @@ observations:
       IODASuperObGrid:
         abi_g16: 15X15
         ahi_himawari8: 15X15
-rtpp:
-  relaxationFactor: 0.8
 workflow:
   first cycle point: 20180414T18
   final cycle point: 20180415T00

--- a/test/testinput/getkf_OIE120km_WarmStart.yaml
+++ b/test/testinput/getkf_OIE120km_WarmStart.yaml
@@ -6,7 +6,9 @@ enkf:
   solver: GETKF
   horizontal localization lengthscale: 1.2e6
   vertical localization lengthscale: 10.0 # modellevel
-  retainObsFeedback: False
+  vertical localization lengthscale units: modellevel
+  retainObsFeedback: True
+  diagEnKFOMA: True
   post: []
 firstbackground:
   resource: "PANDAC.EnsPertB"
@@ -27,8 +29,6 @@ model:
   ensembleMesh: 120km
 observations:
   resource: PANDACArchive
-rtpp:
-  relaxationFactor: 0.8
 workflow:
   first cycle point: 20180414T18
   final cycle point: 20180415T00

--- a/test/testinput/letkf_OIE120km_WarmStart.yaml
+++ b/test/testinput/letkf_OIE120km_WarmStart.yaml
@@ -6,7 +6,8 @@ enkf:
   solver: LETKF
   horizontal localization lengthscale: 1.2e6
   vertical localization lengthscale: 6.e3
-  retainObsFeedback: False
+  retainObsFeedback: True
+  diagEnKFOMA: True
   post: []
 firstbackground:
   resource: "PANDAC.EnsPertB"
@@ -27,8 +28,6 @@ model:
   ensembleMesh: 120km
 observations:
   resource: PANDACArchive
-rtpp:
-  relaxationFactor: 0.8
 workflow:
   first cycle point: 20180414T18
   final cycle point: 20180415T00


### PR DESCRIPTION
### Description
This PR introduces various new features in LETKF/GETKF:

use the linear operator as default for more efficient observer step;
Enable inflation within LETKF/GETKF itself, instead of using the RTPP application;
Enable offline bias correction in LETKF/GETKF.
Calculate HofX of ensemble analyses (EnKFDiagOMA), separately from the Observer and Solver steps.

### Issue closed

Closes #(if applicable)

### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs

It should be noted that mpas-jedi 3.0.2 cannot work well with 'reduce obs space' in L/GETKF. Also, the 'linear operator' version L/GETKF has a minor bug. Therefore, a modified version of mpas-bundle 3.0.2 under /glade/work/taosun/Derecho/JEDI/mpas-bundle-v3.0.2 should be used for L/GETKF.