### PR TITLE
Use the spack-stack 1.8.0 environment when running on derecho.

### DIFF
--- a/config/environmentJEDI.csh
+++ b/config/environmentJEDI.csh
@@ -2,7 +2,7 @@
 
 if ( $?config_environmentJEDI ) exit 0
 
-set spack_version="1.6.0"
+set spack_version="1.8.0"
 echo "Loading Spack-Stack $spack_version"
 setenv config_environmentJEDI 1
 
@@ -17,20 +17,20 @@ if ( "$NCAR_HOST" == "derecho" ) then
      module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles
      module load ecflow/5.8.4
      module load mysql/8.0.33
-     module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-${spack_version}/envs/unified-env/install/modulefiles/Core
+     module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-${spack_version}/envs/ue-intel-2021.10.0/install/modulefiles/Core
      module load stack-intel/2021.10.0
      module load stack-cray-mpich/8.1.25
-     module load stack-python/3.10.8
+     module load stack-python/3.11.7
      module load jedi-mpas-env
   else if ( "$bundleCompilerUsed" =~  *"gnu"* ) then
      module load ncarenv/23.09
      module use /glade/work/epicufsrt/contrib/spack-stack/derecho/modulefiles
      module load ecflow/5.8.4
      module load mysql/8.0.33
-     module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-${spack_version}/envs/unified-env/install/modulefiles/Core
+     module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-${spack_version}/envs/ue-gcc-12.2.0/install/modulefiles/Core
      module load stack-gcc/12.2.0
      module load stack-cray-mpich/8.1.25
-     module load stack-python/3.10.8
+     module load stack-python/3.11.7
      module load jedi-mpas-env soca-env
      #module load jedi-mpas-env
   endif

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -45,7 +45,7 @@ class Build(Component):
         self.variablesWithDefaults['mpas bundle'] = [config._bundle_dir, str]
       else:
         self.variablesWithDefaults['mpas bundle'] = \
-          ['/glade/work/bjung/panda-c/build/mpas-bundle_20250218/build_single', str] ## develop
+          ['/glade/derecho/scratch/jwittig/repos-s/mpas-bundle-cron/build-gnu-1p_latest', str] ## develop
 
       self.variablesWithDefaults['bundle compiler used'] = ['gnu-cray', str,
         ['gnu-cray', 'intel-cray']]
@@ -56,8 +56,7 @@ class Build(Component):
       # Mean state calculator
       # FIXME the source for the app in this directory was copied from
       # /glade/work/guerrett/pandac/work/meanState/spack-stack_gcc-10.1.0_openmpi-4.1.1
-      # meanStateBuildDir = '/glade/work/jwittig/repos1/mpas-bundle-r2.0/build-gnu-derecho-single/bin'
-      meanStateBuildDir = '/glade/work/jwittig/repos1/mpas-bundle-dev-new/build-gnu-1p-ss1.6.0/bin'
+      meanStateBuildDir = '/glade/campaign/mmm/parc/jwittig/meanState/bin'
     elif system == 'cheyenne':
       self.variablesWithDefaults['mpas bundle'] = \
         ['/glade/p/mmm/parc/liuz/pandac_common/mpas-bundle-code-build/mpas_bundle_2.0_gnuSP/build', str]
@@ -194,5 +193,7 @@ class Build(Component):
     #self._set('meanStateBuildDir', '/glade/work/taosun/Derecho/MPAS/JEDI_MPAS/build_intel'+'/bin')
     self._set('meanStateExe', 'average_netcdf_files_parallel_mpas.x')
     self._set('meanStateBuildDir', meanStateBuildDir)
+    self.log('self meanStateBuildDir ' + self['meanStateBuildDir'], level=self.MSG_DEBUG)
 
     self._cshVars = list(self._vtable.keys())
+    self.log('self._cshVars ' + str(self._cshVars), level=self.MSG_NOISY)


### PR DESCRIPTION
Use the spack-stack 1.8.0 (ss1.8) mpas-bundle build.

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] 4denvar_OIE120km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs

#### Integration
Ran the weekly cycling test with the gnu single precision build and compared the results with a spack-stack 1.6 build.
The results are the same.
See graphs at https://www2.mmm.ucar.edu/projects/mpas-jedi/weekly-cycling/
The 2025-04-14 run is with the SS1.8 build, the 2025-04-13 run is with the SS 1.6 build.

Verified the memory used by the Variational step was comparable between the ss1.6 and ss1.8 builds, as were the runtimes.
[Here are the oops statistics for ss1.6, ss1.8, and ss1.9](https://docs.google.com/spreadsheets/d/1HmRrAe2Wj2hf8T1vziXF3EOTM8U7kwza6hkfkq8IzVk/edit?gid=758141153#gid=758141153)