### PR TITLE
Use built-in error tables for PrepBUFR files (develop branch)

### DIFF
--- a/bin/GetObs.csh
+++ b/bin/GetObs.csh
@@ -68,13 +68,6 @@ foreach inst ( ${convertToIODAObservations} )
           echo "Source file: ${satwndBUFRDirectory}/bufr/${ccyy}/${THIS_FILE}"
           cp -p ${satwndBUFRDirectory}/bufr/${ccyy}/${THIS_FILE} .
        endif
-       # link the GDAS observation error table
-       if ( -e ${GDASObsErrtable} ) then
-          ln -sf ${GDASObsErrtable} obs_errtable
-       else
-          echo "ERROR: ${GDASObsErrtable} does NOT exist" > ./FAIL
-          exit 1
-       endif
     # for prepbufr observations
     else if ( ${inst} == prepbufr ) then
        setenv THIS_FILE prepbufr.gdas.${ccyymmdd}.t${hh}z.nr.48h
@@ -88,14 +81,6 @@ foreach inst ( ${convertToIODAObservations} )
              cp -p ${PrepBUFRDirectory}/prepnr/${ccyy}/${THIS_FILE} .
           endif
        endif
-       # use obs errors embedded in prepbufr file
-       if ( -e obs_errtable ) then
-          rm -f obs_errtable
-       endif
-       # use external obs error table
-       #if ( -e ${GDASObsErrtable} ) then
-       #   ln -sf ${GDASObsErrtable} obs_errtable
-       #endif
     # for all other observations
     else
        # set the specific file to be extracted from the tar file

--- a/bin/ObsToIODA.csh
+++ b/bin/ObsToIODA.csh
@@ -103,6 +103,10 @@ foreach gdasfile ( *"gdas."* )
      #./${obs2iodaEXE} ${SPLIThourly} ${gdasfile} >&! $log
      ./${obs2iodaEXE} ${gdasfile} >&! $log
    else if ( ${gdasfile} =~ *"prepbufr"* ) then
+     # use obs errors embedded in prepbufr file
+     if ( -e obs_errtable ) then
+       rm -f obs_errtable
+     endif
      set inst = `echo "$gdasfile" | cut -d'.' -f1`
      # run obs2ioda for preburf with additional QC as in GSI
      ./${obs2iodaEXE} ${gdasfile} >&! $log
@@ -115,6 +119,15 @@ foreach gdasfile ( *"gdas."* )
      mv -f sfc_obs_${thisCycleDate}.h5 ../sfc_obs_${thisCycleDate}.h5
      cd ..
      rm -rf sfc
+   else if ( ${gdasfile} =~ *"satwnd"* ) then
+     # link the GDAS observation error table
+     if ( -e ${GDASObsErrtable} ) then
+       ln -sf ${GDASObsErrtable} obs_errtable
+     else
+       echo "ERROR: ${GDASObsErrtable} does NOT exist" > ./FAIL
+       exit 1
+     endif
+     ./${obs2iodaEXE} ${gdasfile} >&! $log
    else
      ./${obs2iodaEXE} ${gdasfile} >&! $log
    endif


### PR DESCRIPTION
### Description

This PR enforces usage of the built-in error tables when processing PrepBUFR files with the develop branch of the workflow. This PR is analogous to [PR#366](https://github.com/NCAR/MPAS-Workflow/pull/366) that was merged into the release branch earlier.

### Issue closed

See [PR#366](https://github.com/NCAR/MPAS-Workflow/pull/366) for details.


### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [x] GenerateObs

I compared the result of the `GenerateObs` scenario to our obs in the PANDACArchiveForVarBC.


