### PR TITLE
The `write multiple files` specification is moved from `io pool` to `obsdataout`

### DIFF
--- a/config/jedi/ObsPlugs/da/base/abi-clr_g16.yaml
+++ b/config/jedi/ObsPlugs/da/base/abi-clr_g16.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/abi_g16_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_abi-clr_g16{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/da/base/abi_g16.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/abi_g16_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_abi_g16{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/ahi-clr_himawari8.yaml
+++ b/config/jedi/ObsPlugs/da/base/ahi-clr_himawari8.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/ahi_himawari8_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_ahi-clr_himawari8{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/da/base/ahi_himawari8.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/ahi_himawari8_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_ahi_himawari8{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/aircraft.yaml
+++ b/config/jedi/ObsPlugs/da/base/aircraft.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/aircraft_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_aircraft{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_aqua.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_aqua_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_aqua{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_metop-a.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_metop-a_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_metop-a{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_metop-b.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_metop-b_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_metop-b{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_n15.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_n15.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_n15_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_n15{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_n18.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_n18.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_n18_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_n18{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua-cld_n19.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua-cld_n19.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_n19_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua-cld_n19{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_aqua.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_aqua_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_aqua{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_metop-a.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_metop-a_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_metop-a{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_metop-b.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_metop-b_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_metop-b{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_metop-c.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_metop-c_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_metop-c{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_n15.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_n15_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_n15{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_n18.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_n18_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_n18{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/da/base/amsua_n19.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_n19_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_amsua_n19{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/gnssrobndmo-nopseudo.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrobndmo-nopseudo.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/gnssrobndmo-nopseudo_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_gnssrobndmo-nopseudo{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/gnssrobndmo.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrobndmo.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/gnssrobndmo_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_gnssrobndmo{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/gnssrobndnbam.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrobndnbam.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/gnssrobndnbam_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_gnssrobndnbam{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/gnssrobndropp1d.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrobndropp1d.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/gnssrobndropp1d_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_gnssrobndropp1d{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/gnssrorefncep.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrorefncep.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/gnssrorefncep_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_gnssrorefncep{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/gnssrorefncep_tunedErrors.yaml
+++ b/config/jedi/ObsPlugs/da/base/gnssrorefncep_tunedErrors.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/gnssrorefncep_tunedErrors_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_gnssrorefncep_tunedErrors{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/iasi_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/iasi_metop-a.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/iasi_metop-a_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_iasi_metop-a{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/iasi_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/iasi_metop-b.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/iasi_metop-b_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_iasi_metop-b{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/iasi_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/base/iasi_metop-c.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/iasi_metop-c_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_iasi_metop-c{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_metop-a.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/mhs_metop-a_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_mhs_metop-a{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_metop-b.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/mhs_metop-b_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_mhs_metop-b{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_n18.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/mhs_n18_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_mhs_n18{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/base/mhs_n19.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/mhs_n19_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_mhs_n19{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/satwind.yaml
+++ b/config/jedi/ObsPlugs/da/base/satwind.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/satwind_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_satwind{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/satwnd.yaml
+++ b/config/jedi/ObsPlugs/da/base/satwnd.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/satwnd_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_satwnd{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/sfc.yaml
+++ b/config/jedi/ObsPlugs/da/base/sfc.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/sfc_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_sfc{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/sondes-2018043006.yaml
+++ b/config/jedi/ObsPlugs/da/base/sondes-2018043006.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/sondes_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_sondes{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/da/base/sondes.yaml
+++ b/config/jedi/ObsPlugs/da/base/sondes.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/sondes_obs_{{thisValidDate}}.h5
     _obsdataout: &ObsDataOut
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}{{MemberDir}}/{{obsPrefix}}_sondes{{ObsOutSuffix}}.h5

--- a/config/jedi/ObsPlugs/hofx/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/hofx/ObsAnchors.yaml
@@ -2,7 +2,6 @@ _obs space: &ObsSpace
   obs perturbations seed: 1
   io pool:
     max pool size: {{maxIODAPoolSize}}
-    write multiple files: true
   distribution:
     name: RoundRobin
 _obs error diagonal: &ObsErrorDiagonal

--- a/config/jedi/ObsPlugs/hofx/base/abi-clr_g16.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/abi-clr_g16.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/abi_g16_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_abi-clr_g16.h5

--- a/config/jedi/ObsPlugs/hofx/base/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/abi_g16.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/abi_g16_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_abi_g16.h5

--- a/config/jedi/ObsPlugs/hofx/base/ahi-clr_himawari8.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/ahi-clr_himawari8.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/ahi_himawari8_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_ahi-clr_himawari8.h5

--- a/config/jedi/ObsPlugs/hofx/base/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/ahi_himawari8.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/ahi_himawari8_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_ahi_himawari8.h5

--- a/config/jedi/ObsPlugs/hofx/base/aircraft.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/aircraft.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/aircraft_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_aircraft.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_aqua.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_aqua.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua-cld_aqua_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_aqua.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-a.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua-cld_metop-a_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_metop-a.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_metop-b.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua-cld_metop-b_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_metop-b.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_n15.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_n15.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua-cld_n15_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_n15.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_n18.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_n18.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua-cld_n18_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_n18.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua-cld_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua-cld_n19.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua-cld_n19_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua-cld_n19.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_aqua.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_aqua_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_aqua.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_metop-a.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_metop-a_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_metop-a.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_metop-b.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_metop-b_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_metop-b.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua_metop-c.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_metop-c.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_metop-c_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_metop-c.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_n15.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_n15_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_n15.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_n18.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_n18_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_n18.h5

--- a/config/jedi/ObsPlugs/hofx/base/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/amsua_n19.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/amsua_n19_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_amsua_n19.h5

--- a/config/jedi/ObsPlugs/hofx/base/gnssrobndmo-nopseudo.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrobndmo-nopseudo.yaml
@@ -8,6 +8,7 @@
       obsgrouping:
         group variables: [ sequenceNumber ]
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_gnssrobndmo-nopseudo.h5

--- a/config/jedi/ObsPlugs/hofx/base/gnssrobndmo.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrobndmo.yaml
@@ -8,6 +8,7 @@
       obsgrouping:
         group variables: [ sequenceNumber ]
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_gnssrobndmo.h5

--- a/config/jedi/ObsPlugs/hofx/base/gnssrobndnbam.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrobndnbam.yaml
@@ -10,6 +10,7 @@
         sort variable: impactHeightRO
         sort order: ascending
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_gnssrobndnbam.h5

--- a/config/jedi/ObsPlugs/hofx/base/gnssrobndropp1d.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrobndropp1d.yaml
@@ -10,6 +10,7 @@
         sort variable: impactHeightRO
         sort order: ascending
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_gnssrobndropp1d.h5

--- a/config/jedi/ObsPlugs/hofx/base/gnssrorefncep.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrorefncep.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/gnssrorefncep_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_gnssrorefncep.h5

--- a/config/jedi/ObsPlugs/hofx/base/gnssrorefncep_tunedErrors.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/gnssrorefncep_tunedErrors.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/gnssrorefncep_tunedErrors_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_gnssrorefncep_tunedErrors.h5

--- a/config/jedi/ObsPlugs/hofx/base/iasi_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/iasi_metop-a.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/iasi_metop-a_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_iasi_metop-a.h5

--- a/config/jedi/ObsPlugs/hofx/base/iasi_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/iasi_metop-b.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/iasi_metop-b_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_iasi_metop-b.h5

--- a/config/jedi/ObsPlugs/hofx/base/iasi_metop-c.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/iasi_metop-c.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/iasi_metop-c_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_iasi_metop-c.h5

--- a/config/jedi/ObsPlugs/hofx/base/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/mhs_metop-a.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/mhs_metop-a_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_mhs_metop-a.h5

--- a/config/jedi/ObsPlugs/hofx/base/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/mhs_metop-b.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/mhs_metop-b_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_mhs_metop-b.h5

--- a/config/jedi/ObsPlugs/hofx/base/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/mhs_n18.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/mhs_n18_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_mhs_n18.h5

--- a/config/jedi/ObsPlugs/hofx/base/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/mhs_n19.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/mhs_n19_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_mhs_n19.h5

--- a/config/jedi/ObsPlugs/hofx/base/satwind.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/satwind.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/satwind_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_satwind.h5

--- a/config/jedi/ObsPlugs/hofx/base/satwnd.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/satwnd.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/satwnd_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_satwnd.h5

--- a/config/jedi/ObsPlugs/hofx/base/sfc.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/sfc.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/sfc_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_sfc.h5

--- a/config/jedi/ObsPlugs/hofx/base/sondes-2018043006.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/sondes-2018043006.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/sondes_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_sondes.h5

--- a/config/jedi/ObsPlugs/hofx/base/sondes.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/sondes.yaml
@@ -6,6 +6,7 @@
         type: H5File
         obsfile: {{InDBDir}}/sondes_obs_{{thisValidDate}}.h5
     obsdataout:
+      write multiple files: true
       engine:
         type: H5File
         obsfile: {{OutDBDir}}/{{obsPrefix}}_sondes.h5

--- a/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
@@ -8,7 +8,6 @@ _obs space: &ObsSpace
   obs perturbations seed: 1
   io pool:
     max pool size: {{maxIODAPoolSize}}
-    write multiple files: true
   distribution:
     name: RoundRobin
 


### PR DESCRIPTION
### Description
The `write multiple files` specification is moved from the `io pool` section to the `obsdataout` section of the yaml spec.
See https://github.com/orgs/JCSDA-internal/discussions/174 for a discussion.

### Issue closed
https://github.com/JCSDA-internal/mpas-jedi/issues/1069

### Tests completed
##### ~~This PR will be a draft until the tests can be run, and the weekly cycling test gets run.~~ 
#### This PR doesn't work, as the yaml files with the newly added `write multiple files` spec are used by both applications which require multiple output files (hofx, variational) as well as applications which cannot parse multiple output files (enkf).

#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
