### PR TITLE
"write multiple files" yaml spec has moved from the "io pool" section to the obsdataout section

### DIFF
--- a/bin/HofX.csh
+++ b/bin/HofX.csh
@@ -117,6 +117,10 @@ ln -sfv ${bgFileOther} ${bgFile}
 # use the background as the TemplateFieldsFileOuter
 ln -sfv ${bgFile} ${TemplateFieldsFileOuter}
 
+# add the 'use mutltipe files' in obsdataout spec
+# (used to be in 'io pool' section of config/jedi/ObsPlugs/hofx/ObsAnchors.yaml)
+sed -i '/obsdataout/a\        write multiple files: true' $myYAML
+
 # Run the executable
 # ==================
 ln -sfv ${myBuildDir}/${myEXE} ./

--- a/bin/HofX.csh
+++ b/bin/HofX.csh
@@ -117,7 +117,7 @@ ln -sfv ${bgFileOther} ${bgFile}
 # use the background as the TemplateFieldsFileOuter
 ln -sfv ${bgFile} ${TemplateFieldsFileOuter}
 
-# add the 'use mutltipe files' in obsdataout spec
+# add the 'write multiple files' in obsdataout spec
 # (used to be in 'io pool' section of config/jedi/ObsPlugs/hofx/ObsAnchors.yaml)
 sed -i '/obsdataout/a\        write multiple files: true' $myYAML
 

--- a/bin/Variational.csh
+++ b/bin/Variational.csh
@@ -99,6 +99,9 @@ ln -sfv ${myBuildDir}/${myEXE} ./
 sed -i 's@{{ObsDataIn}}@ObsDataIn@' $myYAML
 sed -i 's@{{ObsDataOut}}@obsdataout: *ObsDataOut@' $myYAML
 sed -i 's@{{ObsOutSuffix}}@@' $myYAML
+# add the 'use mutltipe files' in obsdataout spec
+# (used to be in 'io pool' section of config/jedi/ObsPlugs/variational/ObsAnchors.yaml)
+sed -i '/_obsdataout/a\          write multiple files: true' $myYAML
 
 mpiexec ./${myEXE} $myYAML ./jedi.log >& jedi.log.all
 

--- a/bin/Variational.csh
+++ b/bin/Variational.csh
@@ -99,7 +99,7 @@ ln -sfv ${myBuildDir}/${myEXE} ./
 sed -i 's@{{ObsDataIn}}@ObsDataIn@' $myYAML
 sed -i 's@{{ObsDataOut}}@obsdataout: *ObsDataOut@' $myYAML
 sed -i 's@{{ObsOutSuffix}}@@' $myYAML
-# add the 'use mutltipe files' in obsdataout spec
+# add the 'write multiple files' in obsdataout spec
 # (used to be in 'io pool' section of config/jedi/ObsPlugs/variational/ObsAnchors.yaml)
 sed -i '/_obsdataout/a\          write multiple files: true' $myYAML
 

--- a/config/jedi/ObsPlugs/enkf/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/enkf/ObsAnchors.yaml
@@ -39,7 +39,6 @@ _halo dist: &HaloDistribution
 _obs space: &ObsSpace
   #io pool:
   #  max pool size: {{maxIODAPoolSize}}
-  #  write multiple files: true
   distribution: *{{ObsSpaceDistribution}}
 
 _obs error diagonal: &ObsErrorDiagonal

--- a/config/jedi/ObsPlugs/hofx/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/hofx/ObsAnchors.yaml
@@ -2,7 +2,6 @@ _obs space: &ObsSpace
   obs perturbations seed: 1
   io pool:
     max pool size: {{maxIODAPoolSize}}
-    write multiple files: true
   distribution:
     name: RoundRobin
 _obs error diagonal: &ObsErrorDiagonal

--- a/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/variational/ObsAnchors.yaml
@@ -8,7 +8,6 @@ _obs space: &ObsSpace
   obs perturbations seed: 1
   io pool:
     max pool size: {{maxIODAPoolSize}}
-    write multiple files: true
   distribution:
     name: RoundRobin
 


### PR DESCRIPTION
### Description
The `write multiple files` specification is moved from the io pool section to the obsdataout section of the yaml spec.
See https://github.com/orgs/JCSDA-internal/discussions/174 for a discussion.

This PR removes the `write multiple files` spec from yaml files and inserts the spec programmatically.
Specifically, 
 - Remove the 'write multiple files: true' attribute from hofx/ObsAnchors.yaml and variational/ObsAnchors.yaml.
 - Add the 'write multiple files: true' attribute to the 'obsdataout' fieldby the HofX.csh and Variational.csh scripts.

Note: The `write multiple files` attribute wasn't added to the existing yaml files which have the `obsdataout` section because those files are used for all applications when we generate the yaml files to be used by the mpasjedi apps. Simply adding `write multiple files` to the existing `obsdataout` sections results in multiple output files getting created for all the apps, and we only want multiple files to be created for the `hofx` and `variational` apps.

There is some precedent for modifying the final yaml files on the fly, see lines 99-101 in `bin/Variational.csh` for one example.

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 ##### Note `3dvar_O30kmIE60km_ColdStart` fails because the variational step times out.
This doesn't appear to be related to this set of changes.
Using `MPAS-Workflow` without these changes, running against  the 5/31/25 build of `mpas-bundle` also fails in this way.

#### Weekly cycling test
 - [x] Four cycles of `3denvar_OIE120km_WarmStart_VarBC_cron.yaml`
 - [x] The weekly cycling test ran in full, results are unchanged from test ran before the 'write multiple' yaml change
 -- see [model comparison graphs](https://www2.mmm.ucar.edu/projects/mpas-jedi/weekly-cycling/listgraphs.php/?baseline=2025-06-15&tbl_hdrs=Date,Graph%20Type&date=2025-06-22&column1=2025-06-22&path=/projects/mpas-jedi/weekly-cycling/cylc_graphs/2025-06-22/2025-06-22_cron/model/2025-06-15/mpas_analyses&suffix=mmgfsan)
#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
