### PR TITLE
Add a new solver field for enkf: yaml spec, solver_type.

### DIFF
--- a/bin/PrepJEDI.csh
+++ b/bin/PrepJEDI.csh
@@ -924,6 +924,10 @@ else if ("$ArgAppType" == enkf) then
 
   # Solver
   # ==================
+  #  change the 'solver:' spec to include the solver type followed by the solver method,
+  #  e.g. 'Deterministic GETKF',
+  #  then replace all of the remaining instances of localEnsembleDASolver.
+  sed -i 's@solver: {{localEnsembleDASolver}}@solver: '${solver_type}' '${solver}'@g' $prevYAML
   sed -i 's@{{localEnsembleDASolver}}@'${solver}'@g' $prevYAML
 
   # TODO:

--- a/initialize/applications/EnKF.py
+++ b/initialize/applications/EnKF.py
@@ -25,6 +25,10 @@ class EnKF(Component):
     'solver': [str,
       ['LETKF', 'GETKF'],
     ],
+    ## solver_type [Required Parameter]
+    'solver_type': [str,
+      ['Deterministic', ],
+    ],
   }
 
   variablesWithDefaults = {

--- a/scenarios/getkf_OIE60km_WarmStart.yaml
+++ b/scenarios/getkf_OIE60km_WarmStart.yaml
@@ -1,5 +1,6 @@
 enkf:
   solver: GETKF
+  solver_type: Deterministic
   horizontal localization lengthscale: 1.2e6
   vertical localization lengthscale: 10.0 # modellevel
   retainObsFeedback: False

--- a/scenarios/letkf2D_OIE60km_WarmStart.yaml
+++ b/scenarios/letkf2D_OIE60km_WarmStart.yaml
@@ -1,5 +1,6 @@
 enkf:
   solver: LETKF
+  solver_type: Deterministic
   # resource needs are much smaller for 2D than 3D
   localization dimension: 2D
   horizontal localization lengthscale: 1.2e6

--- a/scenarios/letkf_OIE60km_WarmStart.yaml
+++ b/scenarios/letkf_OIE60km_WarmStart.yaml
@@ -1,5 +1,6 @@
 enkf:
   solver: LETKF
+  solver_type: Deterministic
   horizontal localization lengthscale: 1.2e6
   vertical localization lengthscale: 6.e3
   retainObsFeedback: False

--- a/test/testinput/getkf_OIE120km_WarmStart.yaml
+++ b/test/testinput/getkf_OIE120km_WarmStart.yaml
@@ -4,6 +4,7 @@ externalanalyses:
   resource: "GFS.PANDAC"
 enkf:
   solver: GETKF
+  solver_type: Deterministic
   horizontal localization lengthscale: 1.2e6
   vertical localization lengthscale: 10.0 # modellevel
   retainObsFeedback: False

--- a/test/testinput/letkf_OIE120km_WarmStart.yaml
+++ b/test/testinput/letkf_OIE120km_WarmStart.yaml
@@ -4,6 +4,7 @@ externalanalyses:
   resource: "GFS.PANDAC"
 enkf:
   solver: LETKF
+  solver_type: Deterministic
   horizontal localization lengthscale: 1.2e6
   vertical localization lengthscale: 6.e3
   retainObsFeedback: False


### PR DESCRIPTION
Combine the solver and solver_type values when creating the yaml for the enkf app.

### Description
The `mpasjedi_enkf.x` application now requires a solver type to be prepended to the solver method in the applications solver: specification, e.g. `solver: Deterministic LETKF`

See https://github.com/JCSDA-internal/mpas-jedi/pull/1063 for an example of the changes to mpas-jedi.
### Tests completed
#### Tier 1:
 - [x] getkf_OIE120km_WarmStart
 - [x] letkf_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs

**Note:** The `solver_type [Required Parameter]` spec in EnKF.py results in a scenario failing immediately (when trying to run it with cylc) if the solver_type isn't specified in the scenario's yaml. The failure looks like:
```
Running the scenario: test/testinput/getkf_OIE120km_WarmStart.yaml
#########################################################################
Traceback (most recent call last):
...
AssertionError: key (solver_type) is invalid or has None value
```

**Note:** I have not successfully run the getkf_OIE60km_WarmStart.yaml, letkf2D_OIE60km_WarmStart.yaml, or letkf_OIE60km_WarmStart.yaml scenarios (I think the failures are for reasons unrelated to this PR).
This PR is a draft until I can get that sorted.