### PR TITLE
Prepend Deterministic to the ETKF solver names,

### DIFF
--- a/bin/EnKF.csh
+++ b/bin/EnKF.csh
@@ -25,6 +25,7 @@ source config/auto/experiment.csh
 source config/auto/enkf.csh
 source config/auto/workflow.csh
 source config/auto/model.csh
+source config/auto/observations.csh
 source config/auto/naming.csh
 set yymmdd = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 1-8`
 set hh = `echo ${CYLC_TASK_CYCLE_POINT} | cut -c 10-11`

--- a/config/jedi/applications/enkf.yaml
+++ b/config/jedi/applications/enkf.yaml
@@ -16,10 +16,10 @@ _as solver: &asSolver
   save posterior mean: true
 
 _as solver LETKF: &asLETKF
-  solver: LETKF
+  solver: Deterministic LETKF
 
 _as solver GETKF: &asGETKF
-  solver: GETKF
+  solver: Deterministic GETKF
   vertical localization: # only used by GETKF solver
     fraction of retained variance: {{fractionOfRetainedVariance}}
     lengthscale: {{verticalLocalizationLengthscale}}


### PR DESCRIPTION
LETKF becomes Deterministic LETKF, same for GETKF.

Source config/auto/observations.csh from EnKF.csh which defines OutDBDir.

### Description
The `mpasjedi_enkf.x` application now requires a solver type to be prepended to the solver method in the applications solver: specification, e.g. `solver: Deterministic LETKF`

See https://github.com/JCSDA-internal/mpas-jedi/pull/1063 for an example of the changes to mpas-jedi.

### Tests completed
#### Tier 1:
 - [x] getkf_OIE120km_WarmStart
 - [x] letkf_OIE120km_WarmStart
#### Additional scenarios tested:
 - [x] scenarios/getkf_OIE60km_WarmStart_BC.yaml

**Note:** The getkf_OIE60km_WarmStart.yaml, letkf2D_OIE60km_WarmStart.yaml, and letkf_OIE60km_WarmStart.yaml scenarios all fail due to unrelated changes. Namely, these scenarios were using first background files which have not been converted to a format compatible with MPAS-Model V8.2 and later.