### PR TITLE
Run obs2ioda_v3 and ungrib.exe using the shared develop queue on derecho

### DIFF
--- a/initialize/config/Config.py
+++ b/initialize/config/Config.py
@@ -122,7 +122,7 @@ class Config(Logger):
 
 
   def __convertQueue(self, attrName:str, subtable:str=None):
-    derecho_queues = ['main', 'preempt', 'casper@casper-pbs']
+    derecho_queues = ['main', 'preempt', 'develop', 'casper@casper-pbs']
 
     if subtable != None:
       qAttrName = subtable + '.' + attrName

--- a/initialize/data/ExternalAnalyses.py
+++ b/initialize/data/ExternalAnalyses.py
@@ -107,12 +107,13 @@ class ExternalAnalyses(Component):
     attr = {
       'seconds': {'def': 300},
       'nodes': {'def': 1},
-      'PEPerNode': {'def': 128},
+      'PEPerNode': {'def': 8},
+      'memory': {'def': '8GB', 'typ': str},
       'retry': {'def': '2*PT30S'},
       # currently UngribExternalAnalysis has to be on Derecho, because ungrib.exe is built there
       # TODO: build ungrib.exe on casper, remove Critical directives below, deferring to
       #       SingleBatch inheritance
-      'queue': {'def': hpc['CriticalQueue']},
+      'queue': {'def': hpc['SharedQueue']},
       'account': {'def': hpc['CriticalAccount']},
     }
     ungribjob = Resource(self._conf, attr, ('job', 'ungrib'))

--- a/initialize/data/Observations.py
+++ b/initialize/data/Observations.py
@@ -131,7 +131,7 @@ class Observations(Component):
     self._set(key, value)
     self.workflow = key
 
-    self.Queue = hpc['CriticalQueue']
+    self.Queue = hpc['SharedQueue']
     self.Account = hpc['CriticalAccount']
 
     '''
@@ -141,8 +141,8 @@ class Observations(Component):
     attr = {
       'seconds': {'def': 900, 'typ': int},
       'nodes': {'def': 1, 'typ': int},
-      'PEPerNode': {'def': 128, 'typ': int},
-      'memory': {'def': '125GB', 'typ': str},
+      'PEPerNode': {'def': 8, 'typ': int},
+      'memory': {'def': '8GB', 'typ': str},
       'queue': {'def': self.Queue},
       'account': {'def': self.Account},
       'email': {'def': True, 'typ': bool},

--- a/initialize/framework/HPC.py
+++ b/initialize/framework/HPC.py
@@ -41,6 +41,9 @@ class HPC(Component):
     # override this below based on host
     'NonCriticalQueue': ['economy', str, ['economy', 'regular', 'premium']],
 
+    # Shared: used for small jobs which can run on the shared development queue using < 128 cpus
+    'SharedQueue': ['develop', str, ['develop', 'regular', 'premium']],
+
     # SingleProc*: used for single-processor jobs, both critical and non-critical paths
     # IMPORTANT: must NOT be executed on login node to comply with CISL requirements
     'SingleProcAccount': ['NMMM0015', str],


### PR DESCRIPTION
### Description
This allows the ObsToIODA and UngribExternalAnalysis to run expediently when the cpu queue on derecho is backed up.

There is minimal cost savings because these jobs are very short.

Here are the PBS stats for these steps. Note using 8 cpu's only uses ~12 % of the available cpus.
```
Job ID  Exit Status  Nodes  Elap(h)  Wall(h)  Mem(GB)  RMem(GB) NCPUs CPU(%)  Queue Job Name            
2209074 0            1      0.02     0.25     1.4      8.0      8     12.0    cpudev ObsToIODA.20220201T0600Z.MPAS-Workflow-jwittig_3dvar_O30kmIE60km_ColdStart_TEST_develQ
2209079 0            1      0.01     0.08     2.7      8.0      8     11.0    cpudev UngribExternalAnalysis.20220201T0600Z.MPAS-Workflow-jwittig_3dvar_O30kmIE60km_ColdStart_TEST_develQ
2209073 0            1      0.01     0.08     2.7      8.0      8     12.2    cpudev UngribExternalAnalysis.20220201T0000Z.MPAS-Workflow-jwittig_3dvar_O30kmIE60km_ColdStart_TEST_develQ
```
### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
