### PR TITLE
Use new dataset identifiers for rda/data files. (#377)

### DIFF
--- a/bin/GetGFSAnalysisFromRDA.csh
+++ b/bin/GetGFSAnalysisFromRDA.csh
@@ -71,7 +71,7 @@ rm -rf GRIBFILE.*
 
 echo "Getting GFS analysis from RDA"
 # RDA GFS forecasts directory
-set GFSgribdirRDA = /glade/campaign/collections/rda/data/ds084.1
+set GFSgribdirRDA = /glade/campaign/collections/rda/data/d084001
 
 if ( ! -e ${GFSgribdirRDA}/${gribFile} ) then
    set preVyymmdd = `echo ${prevValidDate} | cut -c 1-8`

--- a/bin/GetObs.csh
+++ b/bin/GetObs.csh
@@ -54,9 +54,9 @@ cd ${self_WorkDir}
 # ================================================================================================
 
 set dataRoot = /glade/campaign/collections
-set defaultBUFRDirectory = $dataRoot//rda/data/ds735.0
-set satwndBUFRDirectory = $dataRoot/rda/data/ds351.0
-set PrepBUFRDirectory = $dataRoot/rda/data/ds337.0
+set defaultBUFRDirectory = $dataRoot//rda/data/d735000
+set satwndBUFRDirectory = $dataRoot/rda/data/d351000
+set PrepBUFRDirectory = $dataRoot/rda/data/d337000
 
 foreach inst ( ${convertToIODAObservations} )
   if ( "${observations__resource}" == "GladeRDAOnline" ) then


### PR DESCRIPTION
The legacy RDA dataset identifiers were removed on July 9, 2025. This PR uses the new dataset identifiers, e.g.
/glade/campaign/collections/rda/data/ds<NNN.X> is now /glade/campaign/collections/rda/data/d<NNN>00<X>

### Description

### Issue closed

Closes #(if applicable)

### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
