### PR TITLE
Add 'source config/environmentJEDI.csh' to bin/ObsToIODA.csh

### DIFF
--- a/bin/ObsToIODA.csh
+++ b/bin/ObsToIODA.csh
@@ -27,6 +27,7 @@ date
 
 # Setup environment
 # =================
+source config/environmentJEDI.csh
 source config/auto/build.csh
 source config/auto/experiment.csh
 source config/auto/observations.csh


### PR DESCRIPTION
### Description
obs2ioda_v3 needs `libfabric.so.1` which isn't in the environment when the default modules are loaded on derecho. `config/environmentJEDI.csh` loads the module needed for that library.
### Issue closed

Closes #(if applicable)

### Tests completed 
#### Note: These tests require https://github.com/NCAR/MPAS-Workflow/pull/382 to Run
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x]  4denvar_OIE120km_WarmStart
 - [x]  4dhybrid_OIE120km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
