### PR TITLE
Add the execute conditional in EnKF.py

### DIFF
--- a/initialize/applications/EnKF.py
+++ b/initialize/applications/EnKF.py
@@ -243,7 +243,8 @@ class EnKF(Component):
     ]
     initArgs = ' '.join(['"'+str(a)+'"' for a in args])
 
-    self._tasks += ['''
+    if self['execute']:
+      self._tasks += ['''
   ## enkf tasks
   [[InitEnKF]]
     inherit = '''+self.tf.init+''', SingleBatch
@@ -261,41 +262,41 @@ class EnKF(Component):
     script = $origin/bin/EnKF.csh Solver
 '''+solvertask.job()+solvertask.directives()]
 
-    if self['diagEnKFOMA'] and self['retainObsFeedback']:
-       self._tasks += ['''
+      if self['diagEnKFOMA'] and self['retainObsFeedback']:
+         self._tasks += ['''
   [[EnKFDiagOMA]]
     inherit = '''+self.tf.execute+''', BATCH
     script = $origin/bin/EnKF.csh OMA
 '''+diagomatask.job()+diagomatask.directives()]
-       self._dependencies += ['''
+         self._dependencies += ['''
         EnKFSolver => EnKFDiagOMA => '''+self.tf.post]
 
-    if self['concatenateObsFeedback']:
-      concatattr = {
-        'seconds': {'def': 300},
-        'nodes': {'def': 1},
-        'PEPerNode': {'def': 128},
-        'memory': {'def': '235GB', 'typ': str},
-        'queue': {'def': hpc['CriticalQueue']},
-        'account': {'def': hpc['CriticalAccount']},
-      }
-      concatjob = Resource(self._conf, concatattr, ('concat.job'))
-      concattask = TaskLookup[hpc.system](concatjob)
-      args = [
-      self.lower,
-      self.workDir+'/{{thisCycleDate}}',
-      "",
-      ]
-      concatArgs = ' '.join(['"'+str(a)+'"' for a in args])
-      self._tasks += ['''
+      if self['concatenateObsFeedback']:
+        concatattr = {
+          'seconds': {'def': 300},
+          'nodes': {'def': 1},
+          'PEPerNode': {'def': 128},
+          'memory': {'def': '235GB', 'typ': str},
+          'queue': {'def': hpc['CriticalQueue']},
+          'account': {'def': hpc['CriticalAccount']},
+        }
+        concatjob = Resource(self._conf, concatattr, ('concat.job'))
+        concattask = TaskLookup[hpc.system](concatjob)
+        args = [
+        self.lower,
+        self.workDir+'/{{thisCycleDate}}',
+        "",
+        ]
+        concatArgs = ' '.join(['"'+str(a)+'"' for a in args])
+        self._tasks += ['''
   [[ConcatEnKF]]
     inherit = BATCH
     script = $origin/bin/ConcatenateObsFeedback.csh '''+concatArgs+'''
 '''+concattask.job()+concattask.directives()]
-      self._dependencies += ['''
+        self._dependencies += ['''
         EnKFSolver => ConcatEnKF => '''+self.tf.post]
 
-    self._dependencies += ['''
+      self._dependencies += ['''
 
         # EnKF
         EnKFObserver => EnKFSolver''']


### PR DESCRIPTION
### Description
This PR add the `execute` conditional in EnKF.py (i.e., when populating the EnKF task in cylc).
It was tested with a scenario based on `test/testinput/letkf_OIE120km_WarmStart.yaml`.

You may compare two `flow.cylc` files with/without fix when `execute: False` set under `EnKF`.
 * /glade/derecho/scratch/bjung/workflow/PR388/flow.cylc_develop_executeFalse
 * /glade/derecho/scratch/bjung/workflow/PR388/flow.cylc_feature_executeFalse

File modified
M       initialize/applications/EnKF.py

### Issue closed
Closes #388 

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
