### PR TITLE
Remove "activateEnsemble"  from the ExtendedForecast application

### DIFF
--- a/initialize/applications/ExtendedForecast.py
+++ b/initialize/applications/ExtendedForecast.py
@@ -208,14 +208,12 @@ class ExtendedForecast(Component):
 
   def export(self,
     dependency:str,
-    activateEnsemble:bool=False,
   ):
     '''
     dependency: single task on which extended forecast tasks depend
-    activateEnsemble: whether to activate ensemble extended forecasts (False by default)
     '''
 
-    doEnsemble = (self['ensTimes'] is not None and self.NN > 1 and activateEnsemble)
+    doEnsemble = (self['ensTimes'] is not None and self.NN > 1 )
 
     ##################
     # outputs and post

--- a/initialize/suites/CloudDirectInsertion.py
+++ b/initialize/suites/CloudDirectInsertion.py
@@ -78,7 +78,7 @@ class CloudDirectInsertion(SuiteBase):
       elif k in ['saca']:
         c_.export(self.c['forecastSACA'].previousForecast)
       elif k in ['extendedforecast']:
-        c_.export(self.c['saca'].tf.finished, activateEnsemble=False)
+        c_.export(self.c['saca'].tf.finished)
       elif k in ['forecast']:
         continue
       else:

--- a/initialize/suites/CloudDirectInsertionCycle.py
+++ b/initialize/suites/CloudDirectInsertionCycle.py
@@ -96,7 +96,7 @@ class CloudDirectInsertionCycle(SuiteBase):
           # TODO: DA.export should take Forecast.output['state']['members] as input arg
           c_.export(self.c['forecast'].previousForecast, self.c['extendedforecast'])
         elif k in ['extendedforecast']:
-          c_.export(self.c['saca'].tf.finished, activateEnsemble=False)
+          c_.export(self.c['saca'].tf.finished)
         else:
           c_.export()
       else:

--- a/initialize/suites/Cycle.py
+++ b/initialize/suites/Cycle.py
@@ -88,7 +88,7 @@ class Cycle(SuiteBase):
         # TODO: DA.export should take Forecast.output['state']['members] as input arg
         c_.export(self.c['forecast'].previousForecast, self.c['extendedforecast'])
       elif k in ['extendedforecast']:
-        c_.export(self.c['da'].tf.finished, activateEnsemble=False)
+        c_.export(self.c['da'].tf.finished)
       else:
         c_.export()
 


### PR DESCRIPTION
### Description
This PR aimed to launch the extended ensemble forecast properly, so removed "activateEnsemble" key from all places. In current code, this key can not be configurable and always set as 'False'. The expected behavior of this key is actually already configurable with setting `ensTimes` other than `None`(which is default).

You may compare two `flow.cylc` files with/without fix when setting....
```
extendedforecast:
  execute: True # uncomment if forecasts are already completed
  meanTimes: None
  ensTimes: T00
  lengthHR: 12
  outIntervalHR: 6
  DACycling: False
  updateSea: True
  post: [] #verifymodel,verifyobs
```
Please find the yaml : /glade/derecho/scratch/bjung/workflow/PR389/letkf_OIE120km_WarmStart.yaml_ExtEnsFcst

You can also compare the following two `flow.cylc` files (with `vimdiff` command).
 * /glade/derecho/scratch/bjung/workflow/PR389/flow.cylc_2_ExtEnsFcst_develop
 * /glade/derecho/scratch/bjung/workflow/PR389/flow.cylc_3_ExtEnsFcst_feature

In the `flow.cylc_2_ExtEnsFcst_develop`, the extended ensemble forecast was not created with `develop` code.
It is fixed in the `flow.cylc_3_ExtEnsFcst_feature`.

File modified
M       initialize/applications/ExtendedForecast.py
M       initialize/suites/CloudDirectInsertion.py
M       initialize/suites/CloudDirectInsertionCycle.py
M       initialize/suites/Cycle.py

### Issue closed
Closes https://github.com/NCAR/MPAS-Workflow/issues/389


### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
