### PR TITLE
Turn off Cloud Seeding for Hofx application

### DIFF
--- a/config/jedi/ObsPlugs/hofx/ObsAnchors.yaml
+++ b/config/jedi/ObsPlugs/hofx/ObsAnchors.yaml
@@ -19,7 +19,7 @@ _cloudy crtm: &cloudyCRTMObsOperator
   SurfaceWindGeoVars: uv
   Absorbers: [H2O, O3]
   Clouds: [Water, Ice, Rain, Snow, Graupel]
-  Cloud_Seeding: true
+  Cloud_Seeding: false
   obs options:
     <<: *CRTMObsOptions
 _multi iteration filter: &multiIterationFilter


### PR DESCRIPTION
### Description
Turn off `Cloud Seeding` when using `cloudyCRTMObsOperator` with the Hofx application used for verification purposes.

### Issue closed
None

### Tests completed
HofX of 2018 experiments 
