### PR TITLE
Change the default SfcLayer scheme from sf_monin_obukhov to sf_monin_obukhov_rev for mesoscale_reference suite

### DIFF
--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_allConfig.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_allConfig.yaml
@@ -53,8 +53,8 @@ model:
       RadiationCloud: cld_fraction
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
-      SfcLayer: sf_monin_obukhov
-      LSM: noah
+      SfcLayer: sf_monin_obukhov_rev
+      LSM: sf_noah
     60km:
       meshRatio: 1
       nCells: 163842
@@ -70,8 +70,8 @@ model:
       RadiationCloud: cld_fraction
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
-      SfcLayer: sf_monin_obukhov
-      LSM: noah
+      SfcLayer: sf_monin_obukhov_rev
+      LSM: sf_noah
   GraphInfoDir: /glade/campaign/mmm/parc/liuz/pandac_common/static_from_duda
   precision: single
   MPThompsonTablesDir: /glade/campaign/mmm/parc/ivette/pandac/saca/thompson_tables

--- a/scenarios/defaults/model.yaml
+++ b/scenarios/defaults/model.yaml
@@ -52,7 +52,7 @@ model:
       RadiationCloud: cld_fraction
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
-      SfcLayer: sf_monin_obukhov
+      SfcLayer: sf_monin_obukhov_rev
       LSM: sf_noah
     60km:
       meshRatio: 1
@@ -69,7 +69,7 @@ model:
       RadiationCloud: cld_fraction
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
-      SfcLayer: sf_monin_obukhov
+      SfcLayer: sf_monin_obukhov_rev
       LSM: sf_noah
     120km:
       meshRatio: 1
@@ -86,5 +86,5 @@ model:
       RadiationCloud: cld_fraction
       RadiationLW: rrtmg_lw
       RadiationSW: rrtmg_sw
-      SfcLayer: sf_monin_obukhov
+      SfcLayer: sf_monin_obukhov_rev
       LSM: sf_noah


### PR DESCRIPTION
### Description
* This PR changes the surface layer scheme, specified in `scenarios/defaults/model.yaml`, from `sf_monin_obukhov` to `sf_monin_obukhov_rev` for "mesoscale_reference" suite.
*  **A change in the result is expected.**

### Issue closed

Closes #(if applicable)

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
