### PR TITLE
Change the obs space name & obs operator name from "SfcPCorrected" to "SfcCorrected" 

### DIFF
--- a/config/jedi/ObsPlugs/da/base/sfc.yaml
+++ b/config/jedi/ObsPlugs/da/base/sfc.yaml
@@ -1,6 +1,6 @@
 - obs space:
     <<: *ObsSpace
-    name: SfcPCorrected
+    name: SfcCorrected
     _obsdatain: &ObsDataIn
       engine:
         type: H5File
@@ -15,8 +15,8 @@
   obs error: *ObsErrorDiagonal
   <<: *horizObsLoc #TODO: use station height for vertical localization
   obs operator:
-    name: SfcPCorrected
-    da_psfc_scheme: UKMO   # or WRFDA
+    name: SfcCorrected
+    correction scheme to use: UKMO   # or WRFDA
   linear obs operator:
     name: Identity
     observation alias file: obsop_name_map.yaml

--- a/config/jedi/ObsPlugs/hofx/base/sfc.yaml
+++ b/config/jedi/ObsPlugs/hofx/base/sfc.yaml
@@ -1,6 +1,6 @@
 - obs space:
     <<: *ObsSpace
-    name: SfcPCorrected
+    name: SfcCorrected
     obsdatain:
       engine:
         type: H5File
@@ -12,5 +12,5 @@
     simulated variables: [stationPressure]
   obs error: *ObsErrorDiagonal
   obs operator:
-    name: SfcPCorrected
-    da_psfc_scheme: UKMO   # or WRFDA
+    name: SfcCorrected
+    correction scheme to use: UKMO   # or WRFDA


### PR DESCRIPTION
### Description
* The "SfcPCorrected" operator will be removed from UFO (https://github.com/orgs/JCSDA-internal/discussions/186). This PR changes the obs space name & obs operator name from "SfcPCorrected" (fortran implementation) to "SfcCorrected" (its cpp implementation).
* **Small change in the result is expected** (https://github.com/JCSDA-internal/mpas-jedi/pull/1071#issuecomment-2919833529). 

### Issue closed

Closes #373 

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
