### PR TITLE
Use spack-stack1.9.2 as runtime environment.

### DIFF
--- a/config/environmentJEDI.csh
+++ b/config/environmentJEDI.csh
@@ -2,7 +2,7 @@
 
 if ( $?config_environmentJEDI ) exit 0
 
-set spack_version="1.8.0"
+set spack_version="1.9.2"
 echo "Loading Spack-Stack $spack_version"
 setenv config_environmentJEDI 1
 
@@ -13,13 +13,12 @@ if ( "$NCAR_HOST" == "derecho" ) then
   module purge
   setenv LMOD_TMOD_FIND_FIRST yes
   if ( "$bundleCompilerUsed" =~  *"intel"* ) then
-     module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra
-     module use /lustre/desc1/scratch/epicufsrt/contrib/modulefiles
+     module use /glade/work/epicufsrt/contrib/spack-stack/derecho/modulefiles
      module load ecflow/5.8.4
      module load mysql/8.0.33
-     module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-${spack_version}/envs/ue-intel-2021.10.0/install/modulefiles/Core
-     module load stack-intel/2021.10.0
-     module load stack-cray-mpich/8.1.25
+     module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-${spack_version}/envs/ue-oneapi-2024.2.1/install/modulefiles/Core
+     module load stack-oneapi
+     module load stack-cray-mpich/8.1.29
      module load stack-python/3.11.7
      module load jedi-mpas-env
   else if ( "$bundleCompilerUsed" =~  *"gnu"* ) then
@@ -28,11 +27,12 @@ if ( "$NCAR_HOST" == "derecho" ) then
      module load ecflow/5.8.4
      module load mysql/8.0.33
      module use /glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-${spack_version}/envs/ue-gcc-12.2.0/install/modulefiles/Core
+
      module load stack-gcc/12.2.0
-     module load stack-cray-mpich/8.1.25
+     module load stack-cray-mpich/8.1.27
      module load stack-python/3.11.7
-     module load jedi-mpas-env soca-env
-     #module load jedi-mpas-env
+     #module load jedi-mpas-env soca-env
+     module load jedi-mpas-env
   endif
 
   echo setenv LD_LIBRARY_PATH ${mpasBundle}/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
### Description
This PR changes the runtime environment for our jobs to use spack-stack1.9.2.

This PR should be merged in conjunction with the corresponding [mpas-bundle PR](https://github.com/JCSDA-internal/mpas-bundle/pull/177)

### Tests completed 
#### None- waiting for more core hours
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
