### PR TITLE
Feature/job priority

### DIFF
--- a/initialize/applications/EnKF.py
+++ b/initialize/applications/EnKF.py
@@ -199,6 +199,7 @@ class EnKF(Component):
       'memory': {'def': '45GB', 't': str},
       'queue': {'def': hpc['CriticalQueue']},
       'account': {'def': hpc['CriticalAccount']},
+      'job_priority': {'def': hpc['CriticalPriority']},
       'email': {'def': True, 't': bool},
     }
 
@@ -279,6 +280,7 @@ class EnKF(Component):
           'memory': {'def': '235GB', 'typ': str},
           'queue': {'def': hpc['CriticalQueue']},
           'account': {'def': hpc['CriticalAccount']},
+          'job_priority': {'def': hpc['CriticalPriority']},
         }
         concatjob = Resource(self._conf, concatattr, ('concat.job'))
         concattask = TaskLookup[hpc.system](concatjob)

--- a/initialize/applications/ExtendedForecast.py
+++ b/initialize/applications/ExtendedForecast.py
@@ -104,6 +104,7 @@ class ExtendedForecast(Component):
     job._set('seconds', job['baseSeconds'] + job['secondsPerForecastHR'] * lengthHR)
     job._set('queue', hpc['NonCriticalQueue'])
     job._set('account', hpc['NonCriticalAccount'])
+    job._set('job_priority', hpc['NonCriticalPriority'])
     fctask = TaskLookup[hpc.system](job)
 
     self._tasks += ['''
@@ -150,6 +151,7 @@ class ExtendedForecast(Component):
       'PEPerNode': {'def': 36, 'typ': int},
       'queue': {'def': self.hpc['NonCriticalQueue']},
       'account': {'def': self.hpc['NonCriticalAccount']},
+      'job_priority': {'def': self.hpc['NonCriticalPriority']},
     }
     meanjob = Resource(self._conf, attr, ('job', 'meananalysis'))
     meantask = TaskLookup[self.hpc.system](meanjob)

--- a/initialize/applications/Forecast.py
+++ b/initialize/applications/Forecast.py
@@ -116,6 +116,7 @@ class Forecast(Component):
       'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['CriticalQueue']},
       'account': {'def': hpc['CriticalAccount']},
+      'job_priority': {'def': hpc['CriticalPriority']},
       'email': {'def': True, 'typ': bool},
     }
     # store job for ExtendedForecast to re-use
@@ -240,6 +241,7 @@ class Forecast(Component):
         'PEPerNode': {'def': 128, 'typ': int},
         'queue': {'def': self.hpc['NonCriticalQueue']},
         'account': {'def': self.hpc['NonCriticalAccount']},
+        'job_priority': {'def': self.hpc['NonCriticalPriority']},
       }
       meanjob = Resource(self._conf, attr, ('job', 'meanbackground'))
       meantask = TaskLookup[self.hpc.system](meanjob)

--- a/initialize/applications/ForecastSACA.py
+++ b/initialize/applications/ForecastSACA.py
@@ -121,6 +121,7 @@ class ForecastSACA(Component):
     job._set('seconds', job['baseSeconds'] + job['secondsPerForecastHR'] * lengthHR)
     job._set('queue', hpc['NonCriticalQueue'])
     job._set('account', hpc['NonCriticalAccount'])
+    job._set('job_priority', hpc['NonCriticalPriority'])
     task = TaskLookup[hpc.system](job)
 
     #######
@@ -247,6 +248,7 @@ class ForecastSACA(Component):
         'PEPerNode': {'def': 128, 'typ': int},
         'queue': {'def': self.hpc['NonCriticalQueue']},
         'account': {'def': self.hpc['NonCriticalAccount']},
+        'job_priority': {'def': self.hpc['NonCriticalPriority']},
       }
       meanjob = Resource(self._conf, attr, ('job', 'meanbackground'))
       meantask = TaskLookup[self.hpc.system](meanjob)

--- a/initialize/applications/HofX.py
+++ b/initialize/applications/HofX.py
@@ -189,6 +189,7 @@ class HofX(Component):
       'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['NonCriticalQueue']},
       'account': {'def': hpc['NonCriticalAccount']},
+      'job_priority': {'def': hpc['NonCriticalPriority']},
     }
     job = Resource(self._conf, attr, ('job', mesh.name))
     task = TaskLookup[hpc.system](job)
@@ -245,6 +246,7 @@ class HofX(Component):
         'memory': {'def': '235GB', 'typ': str},
         'queue': {'def': hpc['CriticalQueue']},
         'account': {'def': hpc['CriticalAccount']},
+        'job_priority': {'def': hpc['CriticalPriority']},
         }
         concatjob = Resource(self._conf, concatattr, ('concat.job'))
         concattask = TaskLookup[hpc.system](concatjob)

--- a/initialize/applications/InitIC.py
+++ b/initialize/applications/InitIC.py
@@ -39,6 +39,7 @@ class InitIC(Component):
       'PEPerNode': {'typ': int},
       'queue': {'def': hpc['CriticalQueue']},
       'account': {'def': hpc['CriticalAccount']},
+      'job_priority': {'def': hpc['CriticalPriority']},
     }
     job = Resource(self._conf, attr, ('job', meshes['Outer'].name))
     self.__task = TaskLookup[hpc.system](job)

--- a/initialize/applications/RTPP.py
+++ b/initialize/applications/RTPP.py
@@ -87,6 +87,7 @@ class RTPP(Component):
         'memory': {'def': '45GB', 'typ': str},
         'queue': {'def': hpc['CriticalQueue']},
         'account': {'def': hpc['CriticalAccount']},
+        'job_priority': {'def': hpc['CriticalPriority']},
         'email': {'def': True, 'typ': bool},
       }
       job = Resource(self._conf, attr, ('job', mesh.name))

--- a/initialize/applications/SACA.py
+++ b/initialize/applications/SACA.py
@@ -102,6 +102,7 @@ class SACA(Component):
       'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['NonCriticalQueue']},
       'account': {'def': hpc['NonCriticalAccount']},
+      'job_priority': {'def': hpc['NonCriticalPriority']},
       'email': {'def': True, 'typ': bool},
     }
     self.job = Resource(self._conf, attr, ('job', mesh.name))

--- a/initialize/applications/Variational.py
+++ b/initialize/applications/Variational.py
@@ -311,6 +311,7 @@ class Variational(Component):
       'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['CriticalQueue']},
       'account': {'def': hpc['CriticalAccount']},
+      'job_priority': {'def': hpc['CriticalPriority']},
       'email': {'def': True, 'typ': bool},
     }
     varjob = Resource(self._conf, attr, ('job', r2))
@@ -326,6 +327,7 @@ class Variational(Component):
       'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['CriticalQueue']},
       'account': {'def': hpc['CriticalAccount']},
+      'job_priority': {'def': hpc['CriticalPriority']},
     }
     concatjob = Resource(self._conf, concatattr, ('concat.job'))
     concattask = TaskLookup[hpc.system](concatjob)
@@ -411,6 +413,7 @@ class Variational(Component):
         'PEPerNode': {'def': 36},
         'queue': {'def': hpc['CriticalQueue']},
         'account': {'def': hpc['CriticalAccount']},
+        'job_priority': {'def': hpc['CriticalPriority']},
       }
       abeijob = Resource(self._conf, attr, ('abei.job', meshes['Outer'].name))
       abeitask = TaskLookup[hpc.system](abeijob)

--- a/initialize/config/Task.py
+++ b/initialize/config/Task.py
@@ -7,6 +7,7 @@
  which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 '''
 
+import sys
 from initialize.config.Resource import Resource
 
 class Task():
@@ -107,9 +108,27 @@ class DerechoTask(PBSPro):
   maxMemPerNode = "235GB"
 
   def __init__(self, r:Resource):
-    # convert any cheyenne queue's to derecho
-    #print('resource table', r._table)
+    # verify queue and priority settings
     #print('resource defaults', r._defaults)
+    if r['queue'] is not None:
+      queue = r['queue']
+      priority = r['job_priority']
+      if priority is not None:
+        r.log('calling log via resource, queue is '+queue + ' priority is '+priority, level=r.MSG_DEBUG)
+      else:
+        r.log('calling log via resource, queue is '+queue, level=r.MSG_DEBUG)
+      r.log('resource table: ' + str(r._table), level=r.MSG_NOISY)
+      derecho_queues = ['main', 'preempt', 'develop', 'casper@casper-pbs']
+      if priority is not None:
+        if queue == 'develop':
+          r.log('Warning: develop queue does not support priority, priority '+ priority + ' ignored', level=r.MSG_QUIET)
+      if queue not in derecho_queues:
+        r.log('queue ('+queue+') must be one of ' +', '.join(derecho_queues), level=r.MSG_QUIET)
+        if queue == 'economy' or queue == 'premium':
+          r.log('use either CriticalPriority or NonCriticalPriority to set priority', level=r.MSG_QUIET)
+          r.log(' e.g. CriticalPriority : '+queue, level=r.MSG_QUIET)
+        r.log('cylc task not run', level=r.MSG_QUIET)
+        sys.exit(1)
     r.convertToDerecho()
     super().__init__(r)
 

--- a/initialize/framework/HPC.py
+++ b/initialize/framework/HPC.py
@@ -33,13 +33,15 @@ class HPC(Component):
 
     # Critical*: used for all critical path jobs, single or multi-node, multi-processor only
     'CriticalAccount': ['NMMM0015', str],
-    # override this below based on host
+    # override these below based on host
     'CriticalQueue': ['economy', str, ['economy', 'regular', 'premium']],
+    'CriticalPriority' : ['regular', str, ['premium', 'regular', 'economy', 'preempt']],
 
     # NonCritical*: used non-critical path jobs, single or multi-node, multi-processor only
     'NonCriticalAccount': ['NMMM0015', str],
-    # override this below based on host
+    # override these below based on host
     'NonCriticalQueue': ['economy', str, ['economy', 'regular', 'premium']],
+    'NonCriticalPriority' : ['economy', str, ['premium', 'regular', 'economy', 'preempt']],
 
     # Shared: used for small jobs which can run on the shared development queue using < 128 cpus
     'SharedQueue': ['develop', str, ['develop', 'regular', 'premium']],
@@ -59,7 +61,8 @@ class HPC(Component):
       self.variablesWithDefaults['CriticalQueue'] = ['main', str, ['main', 'preempt']]
       self.variablesWithDefaults['NonCriticalQueue'] =  ['main', str, ['main', 'preempt']]
 #      self.variablesWithDefaults['SingleProcQueue'] = ['casper@casper-pbs', str, ['casper@casper-pbs', 'main']]
-      self.variablesWithDefaults['priority'] = ['regular', str, ['premium', 'regular', 'economy', 'preempt']]
+      self.variablesWithDefaults['CriticalPriority'] = ['regular', str, ['premium', 'regular', 'economy', 'preempt']]
+      self.variablesWithDefaults['NonCriticalPriority'] = ['regular', str, ['premium', 'regular', 'economy', 'preempt']]
       self.system = system
       #config.convertToDerecho()
     elif system == 'cheyenne':

--- a/initialize/post/Benchmark.py
+++ b/initialize/post/Benchmark.py
@@ -50,6 +50,7 @@ class Benchmark(Component):
       'seconds': {'def': 300},
       'queue': {'def': hpc['NonCriticalQueue']},
       'account': {'def': hpc['NonCriticalAccount']},
+      'job_priority': {'def': hpc['NonCriticalPriority']},
     }
     job = Resource(self._conf, attr, ('job', 'compare'))
     task = TaskLookup[hpc.system](job)

--- a/initialize/post/VerifyModel.py
+++ b/initialize/post/VerifyModel.py
@@ -91,6 +91,7 @@ class VerifyModel(Component):
       'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['NonCriticalQueue']},
       'account': {'def': hpc['NonCriticalAccount']},
+      'job_priority': {'def': hpc['NonCriticalPriority']},
     }
     job = Resource(self._conf, attr, ('job', mesh.name))
     job['seconds'] += job['secondsPerMember'] * memberMultiplier

--- a/initialize/post/VerifyObs.py
+++ b/initialize/post/VerifyObs.py
@@ -100,6 +100,7 @@ class VerifyObs(Component):
       'memory': {'def': '235GB', 'typ': str},
       'queue': {'def': hpc['NonCriticalQueue']},
       'account': {'def': hpc['NonCriticalAccount']},
+      'job_priority': {'def': hpc['NonCriticalPriority']},
     }
     job = Resource(self._conf, attr, ('job',))
     job['seconds'] += job['secondsPerMember'] * memberMultiplier

--- a/scenarios/3denvar_OIE120km_WarmStart_VarBC_cron.yaml
+++ b/scenarios/3denvar_OIE120km_WarmStart_VarBC_cron.yaml
@@ -40,5 +40,5 @@ workflow:
 hpc:
   #CriticalAccount: nmmm0043
   #NonCriticalAccount: nmmm0043
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy

--- a/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_allConfig.yaml
+++ b/scenarios/3dhybrid_O30kmIE60km_SpecifiedEnsemble_VarBC_allConfig.yaml
@@ -15,7 +15,8 @@ hpc:
   CriticalAccount: NMMM0015
   CriticalQueue: main
   NonCriticalAccount: NMMM0015
-  NonCriticalQueue: economy
+  NonCriticalQueue: main
+  NonCriticalPriority: economy
   SingleProcAccount: NMMM0015
   SingleProcQueue: casper@casper-pbs
 

--- a/scenarios/ABIAHI120km3denvar.yaml
+++ b/scenarios/ABIAHI120km3denvar.yaml
@@ -52,7 +52,7 @@ variational:
     ahi_himawari8,
   ]
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 verifyobs:
   script directory: /glade/work/ivette/pandac/mpas-jedi/graphics

--- a/scenarios/CloudDirectInsertion.yaml
+++ b/scenarios/CloudDirectInsertion.yaml
@@ -36,8 +36,8 @@ hofx:
   IRVISlandCoeff: IGBP
 
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 
 members:
   n: 1

--- a/scenarios/ForecastFromGFSAnalyses.yaml
+++ b/scenarios/ForecastFromGFSAnalyses.yaml
@@ -17,8 +17,8 @@ extendedforecast:
   post: [verifyobs, verifymodel]
 
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 
 members:
   n: 1

--- a/scenarios/ForecastFromGFSAnalysesVariableMesh.yaml
+++ b/scenarios/ForecastFromGFSAnalysesVariableMesh.yaml
@@ -22,8 +22,8 @@ hofx:
   IRVISlandCoeff: IGBP
 
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 
 members:
   n: 1

--- a/scenarios/GenerateGFSAnalyses.yaml
+++ b/scenarios/GenerateGFSAnalyses.yaml
@@ -9,8 +9,8 @@ experiment:
 model:
   outerMesh: 120km
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
   #CriticalQueue: main
   #NonCriticalQueue: main
 workflow:

--- a/scenarios/GenerateObs.yaml
+++ b/scenarios/GenerateObs.yaml
@@ -15,8 +15,8 @@ experiment:
   name: 'GenerateObs'
   prefix: ''
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 workflow:
   first cycle point: 20220606T00
   final cycle point: 20220608T00

--- a/scenarios/GetGDASanalysis.yaml
+++ b/scenarios/GetGDASanalysis.yaml
@@ -6,8 +6,8 @@ experiment:
   name: 'DownloadGDASAnalysis'
   prefix: ''
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 workflow:
   # test a recent date
   first cycle point: 20220819T00

--- a/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
+++ b/test/testinput/3denvar_O30kmIE60km_WarmStart.yaml
@@ -7,8 +7,8 @@ forecast:
 firstbackground:
   resource: "PANDAC.GFS"
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 1
 model:

--- a/test/testinput/3denvar_OIE120km_IAU_WarmStart.yaml
+++ b/test/testinput/3denvar_OIE120km_IAU_WarmStart.yaml
@@ -8,8 +8,8 @@ forecast:
   IAU: True
   post: [verifyobs, verifymodel]
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 1
 model:

--- a/test/testinput/3dvar_O30kmIE60km_ColdStart.yaml
+++ b/test/testinput/3dvar_O30kmIE60km_ColdStart.yaml
@@ -5,8 +5,8 @@ experiment:
 forecast:
   post: [verifyobs, verifymodel]
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 1
 model:

--- a/test/testinput/3dvar_OIE120km_ColdStart.yaml
+++ b/test/testinput/3dvar_OIE120km_ColdStart.yaml
@@ -5,8 +5,8 @@ externalanalyses:
 forecast:
   post: []
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 1
 model:

--- a/test/testinput/3dvar_OIE120km_WarmStart.yaml
+++ b/test/testinput/3dvar_OIE120km_WarmStart.yaml
@@ -12,8 +12,8 @@ forecast:
     # uncomment forecast directory below
     GPUPerNode: 0
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 1
 model:

--- a/test/testinput/3dvar_OIE120km_WarmStart_PostProcess.yaml
+++ b/test/testinput/3dvar_OIE120km_WarmStart_PostProcess.yaml
@@ -15,8 +15,8 @@ forecast:
   execute: False
   post: [verifyobs, verifymodel]
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 1
 model:

--- a/test/testinput/4denvar_OIE120km_WarmStart.yaml
+++ b/test/testinput/4denvar_OIE120km_WarmStart.yaml
@@ -8,8 +8,8 @@ forecast:
   FourD: True
   post: [verifyobs, verifymodel]
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 1
 model:

--- a/test/testinput/4dhybrid_OIE120km_WarmStart.yaml
+++ b/test/testinput/4dhybrid_OIE120km_WarmStart.yaml
@@ -8,8 +8,8 @@ forecast:
   FourD: True
   post: [verifyobs, verifymodel]
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 1
 model:

--- a/test/testinput/ForecastFromGFSAnalysesMPT.yaml
+++ b/test/testinput/ForecastFromGFSAnalysesMPT.yaml
@@ -19,8 +19,8 @@ extendedforecast:
   post: []
 
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 
 members:
   n: 1

--- a/test/testinput/eda_OIE120km_WarmStart.yaml
+++ b/test/testinput/eda_OIE120km_WarmStart.yaml
@@ -9,8 +9,8 @@ forecast:
 hofx:
   retainObsFeedback: False
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 5
 model:

--- a/test/testinput/getkf_OIE120km_WarmStart.yaml
+++ b/test/testinput/getkf_OIE120km_WarmStart.yaml
@@ -17,8 +17,8 @@ forecast:
 hofx:
   retainObsFeedback: False
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 5
 model:

--- a/test/testinput/letkf_OIE120km_WarmStart.yaml
+++ b/test/testinput/letkf_OIE120km_WarmStart.yaml
@@ -15,8 +15,8 @@ forecast:
 hofx:
   retainObsFeedback: False
 hpc:
-  CriticalQueue: economy
-  NonCriticalQueue: economy
+  CriticalPriority: economy
+  NonCriticalPriority: economy
 members:
   n: 5
 model:


### PR DESCRIPTION
### Description
This PR adds new keywords for specifying job_priority in scenario yaml files.
The new keywords are
- NonCriticalPriority
- CriticalPriority

The recommended priorities include `regular`, `premium`, and `economy`.
The default prioirty is `regular` when no priority is specified.
See [the HPC documentation](https://ncar-hpc-docs.readthedocs.io/en/latest/pbs/charging/#job-priority)

#### Note
Setting the `economy` priority via the `CriticalQueue` and `NonCriticalQueue` attributes no longer works and will generate an error message when starting a cylc job.

### Issue closed

Closes #395

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 -- Note this requires a modified version of MPAS-Model, see [issue 384](https://github.com/NCAR/MPAS-Workflow/issues/384)
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] 4denvar_OIE120km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
