### PR TITLE
Remove the obsolete key for bump localization

### DIFF
--- a/config/jedi/applications/3denvar-crossed.yaml
+++ b/config/jedi/applications/3denvar-crossed.yaml
@@ -56,8 +56,6 @@ cost function:
           drivers:
             multivariate strategy: crossed
             read local nicas: true
-          model:
-            level for 2d variables: last
           #TODO: update following keys
           #io_keys: [temperature-temperature,spechum-spechum,uReconstructZonal-uReconstructZonal,uReconstructMeridional-uReconstructMeridional,surface_pressure-surface_pressure,qc-qc,qi-qi,qr-qr,qs-qs,qg-qg]
           ##io_values: [dynamic,dynamic,dynamic,dynamic,dynamic,cloud,cloud,cloud,cloud,cloud]

--- a/config/jedi/applications/3denvar.yaml
+++ b/config/jedi/applications/3denvar.yaml
@@ -56,8 +56,6 @@ cost function:
           drivers:
             multivariate strategy: duplicated
             read local nicas: true
-          model:
-            level for 2d variables: last
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3dhybrid-allsky.yaml
+++ b/config/jedi/applications/3dhybrid-allsky.yaml
@@ -107,8 +107,6 @@ cost function:
               drivers:
                 multivariate strategy: duplicated
                 read local nicas: true
-              model:
-                level for 2d variables: last
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -103,8 +103,6 @@ cost function:
               drivers:
                 multivariate strategy: duplicated
                 read local nicas: true
-              model:
-                level for 2d variables: last
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/4denvar_3slots.yaml
+++ b/config/jedi/applications/4denvar_3slots.yaml
@@ -70,8 +70,6 @@ cost function:
           drivers:
             multivariate strategy: duplicated
             read local nicas: true
-          model:
-            level for 2d variables: last
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/4denvar_7slots.yaml
+++ b/config/jedi/applications/4denvar_7slots.yaml
@@ -96,8 +96,6 @@ cost function:
           drivers:
             multivariate strategy: duplicated
             read local nicas: true
-          model:
-            level for 2d variables: last
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:

--- a/config/jedi/applications/4dhybrid.yaml
+++ b/config/jedi/applications/4dhybrid.yaml
@@ -141,8 +141,6 @@ cost function:
               drivers:
                 multivariate strategy: duplicated
                 read local nicas: true
-              model:
-                level for 2d variables: last
 {{EnsemblePbMembers}}
 {{EnsemblePbInflation}}
   observations:


### PR DESCRIPTION
### Description
This PR is a companion PR of https://github.com/JCSDA-internal/mpas-jedi/pull/1075. With this, we don't need to set the following for bump localization. No impact on the EnVar results.
```
          model:
            level for 2d variables: last
```

### Issue closed

Closes #400

### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [ ] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
