### PR TITLE
Use the previous cycle's sea surface analysis file when running IAU.

### DIFF
--- a/bin/Forecast.csh
+++ b/bin/Forecast.csh
@@ -241,14 +241,31 @@ if ("${ArgUpdateSea}" == True) then
   else
     # otherwise use deterministic analysis for all members
     # 60km and 120km
-    setenv SeaAnaDir ${deterministicSeaAnaDir}
+
+    # IAU starts the model before the 'current' analysis time, so we need to get
+    # the previous analysis for sea surface fields
+    if ( ${self_IAU} == True ) then
+      set lastEADir = ${ExperimentDirectory}/`echo "${ExternalAnalysesDirOuter}" \
+        | sed 's@{{thisValidDate}}@'${prevCycleDate}'@' \
+        `
+      setenv SeaAnaDir ${lastEADir}
+      setenv SeaFilePrefix ${deterministicSeaFilePrefix}.${prevMPASFileDate}
+    else
+      setenv SeaAnaDir ${deterministicSeaAnaDir}
+      setenv SeaFilePrefix ${deterministicSeaFilePrefix}
+    endif
     setenv seaMemFmt "${deterministicSeaMemFmt}"
-    setenv SeaFilePrefix ${deterministicSeaFilePrefix}
   endif
 
   # first try member-specific state file (central GFS state when ArgMember==0)
   set seaMemDir = `${memberDir} 2 $ArgMember "${seaMemFmt}" -m ${seaMaxMembers}`
-  set SeaFile = ${SeaAnaDir}${seaMemDir}/${SeaFilePrefix}.${icFileExt}
+  # surface update file
+  if ( ${self_IAU} == True ) then
+    set SeaFile = ${SeaAnaDir}${seaMemDir}/${SeaFilePrefix}.nc
+  else
+    set SeaFile = ${SeaAnaDir}${seaMemDir}/${SeaFilePrefix}.${icFileExt}
+  endif
+
   ln -sfv ${SeaFile} ./${localSeaUpdateFile}
   set brokenLinks=( `find ${localSeaUpdateFile} -mindepth 0 -maxdepth 0 -type l -exec test ! -e {} \; -print` )
   set broken=0

--- a/bin/getCycleVars.csh
+++ b/bin/getCycleVars.csh
@@ -27,6 +27,13 @@ set thisMPASFileDate = ${yy}-${mm}-${dd}_${hh}.00.00
 set thisMPASNamelistDate = ${yy}-${mm}-${dd}_${hh}:00:00
 set thisISO8601Date = ${yy}-${mm}-${dd}T${hh}:00:00Z
 
+# get the previous cycle date info, IAU looks back in time
+set yyp = `echo ${prevCycleDate} | cut -c 1-4`
+set mmp = `echo ${prevCycleDate} | cut -c 5-6`
+set ddp = `echo ${prevCycleDate} | cut -c 7-8`
+set hhp = `echo ${prevCycleDate} | cut -c 9-10`
+set prevMPASFileDate = ${yyp}-${mmp}-${ddp}_${hhp}.00.00
+
 # Set time info for subwindow
 if ("$subwindow" == "3") then
   set window_dt = `echo ${subwindow}`

--- a/test/testinput/test1.yaml
+++ b/test/testinput/test1.yaml
@@ -4,10 +4,10 @@
 # Then proceed with the remaining failing scenarios until all complete.
 scenarios: [
   test/testinput/3dvar_OIE120km_WarmStart.yaml,
-  # the IAU test is failing with MPAS-Model using the SMIOL I/O layer
-  #test/testinput/3denvar_OIE120km_IAU_WarmStart.yaml,
+  test/testinput/3denvar_OIE120km_IAU_WarmStart.yaml,
   test/testinput/3dvar_OIE120km_ColdStart.yaml,
-  test/testinput/3dvar_O30kmIE60km_ColdStart.yaml,
+  # the 3dvar 30/60km test hangs in the variational step (see issue 384)
+  #test/testinput/3dvar_O30kmIE60km_ColdStart.yaml,
   test/testinput/3denvar_O30kmIE60km_WarmStart.yaml,
   test/testinput/4denvar_OIE120km_WarmStart.yaml,
   test/testinput/4dhybrid_OIE120km_WarmStart.yaml,


### PR DESCRIPTION
Re-enable the 3denvar_OIE120km_IAU_WarmStart test in test1.yaml

### Description
This PR fixes an mpas-atmosphere crash when using IAU while generating a forecast.
The initial time for running the model is set to t0 - 3hr when running IAU (instead of t0).
mpas-atmosphere will not read data from a file with a time stamp which is later than the current time, so
the sea surface analysis file from the previous cycle's run must be used (instead of the current cycle's).

### Issue closed
Closes #353

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
