### PR TITLE
Use stride of 32 when using MPAS-Model I/O routines.

### DIFF
--- a/config/mpas/forecast/namelist.atmosphere
+++ b/config/mpas/forecast/namelist.atmosphere
@@ -38,7 +38,7 @@
 /
 &io
     config_pio_num_iotasks = 0
-    config_pio_stride = 1
+    config_pio_stride = 32
 /
 &decomposition
     config_block_decomp_file_prefix = 'x{{meshRatio}}.nCells.graph.info.part.'

--- a/config/mpas/initic/namelist.init_atmosphere
+++ b/config/mpas/initic/namelist.init_atmosphere
@@ -41,7 +41,7 @@
 /
 &io
     config_pio_num_iotasks = 0
-    config_pio_stride = 1
+    config_pio_stride = 32
 /
 &decomposition
     config_block_decomp_file_prefix = 'x{{meshRatio}}.nCells.graph.info.part.'

--- a/config/mpas/saca/namelist.atmosphere
+++ b/config/mpas/saca/namelist.atmosphere
@@ -38,7 +38,7 @@
 /
 &io
     config_pio_num_iotasks = 0
-    config_pio_stride = 1
+    config_pio_stride = 32
 /
 &decomposition
     config_block_decomp_file_prefix = 'x{{meshRatio}}.nCells.graph.info.part.'

--- a/config/mpas/variational/namelist.atmosphere
+++ b/config/mpas/variational/namelist.atmosphere
@@ -38,7 +38,7 @@
 /
 &io
     config_pio_num_iotasks = 0
-    config_pio_stride = 1
+    config_pio_stride = 32
 /
 &decomposition
     config_block_decomp_file_prefix = 'blockDecompPrefix.graph.info.part.'

--- a/test/testinput/test1.yaml
+++ b/test/testinput/test1.yaml
@@ -6,8 +6,7 @@ scenarios: [
   test/testinput/3dvar_OIE120km_WarmStart.yaml,
   test/testinput/3denvar_OIE120km_IAU_WarmStart.yaml,
   test/testinput/3dvar_OIE120km_ColdStart.yaml,
-  # the 3dvar 30/60km test hangs in the variational step (see issue 384)
-  #test/testinput/3dvar_O30kmIE60km_ColdStart.yaml,
+  test/testinput/3dvar_O30kmIE60km_ColdStart.yaml,
   test/testinput/3denvar_O30kmIE60km_WarmStart.yaml,
   test/testinput/4denvar_OIE120km_WarmStart.yaml,
   test/testinput/4dhybrid_OIE120km_WarmStart.yaml,


### PR DESCRIPTION
### Description
This PR works around a bug in MPAS-Model which causes writes to hang in rare cases.
Thanks @amstokely for suggesting this workaround.
The stride value of 32 was suggested by Michael Duda.
### Issue closed
Closes #(https://github.com/NCAR/MPAS-Workflow/issues/384)

### Tests completed
#### Tier 1:
Run times of these tests were compared with run times of the tests run without this change; there were no appreciable differences. See the table below.
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs

#### Weekly cylc 3denvar simulation 
- The weekly 3denvar simulation was run with this change and showed no change in results compared to the run which didn't use this change.
See graphs [here](https://www2.mmm.ucar.edu/projects/mpas-jedi/weekly-cycling/cylc_graphs/2025-12-11-3denvar/2025-12-11_cron/model/2025-11-30/mpas_analyses/BinValAxes2D/mmgfsan/ModelLatLev2D_BinValAxes2D_0min_mpas_mmgfsan_RMS.pdf) and [here](https://www2.mmm.ucar.edu/projects/mpas-jedi/weekly-cycling/cylc_graphs/2025-12-11-3denvar/2025-12-11_cron/model/2025-11-30/mpas_analyses/BinValAxes2D/mmgfsan/ModelLonLat2D_BinValAxes2D_0min_mpas_mmgfsan_RMS.pdf)