### PR TITLE
regenerate 60 & 120km static B files and distinguish 2D and 3D variables in NICAS (covariance)

### DIFF
--- a/config/jedi/applications/3dhybrid-allsky.yaml
+++ b/config/jedi/applications/3dhybrid-allsky.yaml
@@ -61,6 +61,11 @@ cost function:
             drivers:
               multivariate strategy: univariate
               read local nicas: true
+            grids:
+              - model:
+                  variables: [air_horizontal_streamfunction,air_horizontal_velocity_potential,air_temperature,water_vapor_mixing_ratio_wrt_moist_air]
+              - model:
+                  variables: [air_pressure_at_surface]
         saber outer blocks:
         - saber block name: StdDev
           read:

--- a/config/jedi/applications/3dhybrid.yaml
+++ b/config/jedi/applications/3dhybrid.yaml
@@ -59,6 +59,11 @@ cost function:
             drivers:
               multivariate strategy: univariate
               read local nicas: true
+            grids:
+              - model:
+                  variables: [air_horizontal_streamfunction,air_horizontal_velocity_potential,air_temperature,water_vapor_mixing_ratio_wrt_moist_air]
+              - model:
+                  variables: [air_pressure_at_surface]
         saber outer blocks:
         - saber block name: StdDev
           read:

--- a/config/jedi/applications/3dvar.yaml
+++ b/config/jedi/applications/3dvar.yaml
@@ -42,6 +42,11 @@ cost function:
         drivers:
           multivariate strategy: univariate
           read local nicas: true
+        grids:
+          - model:
+              variables: [air_horizontal_streamfunction,air_horizontal_velocity_potential,air_temperature,water_vapor_mixing_ratio_wrt_moist_air]
+          - model:
+              variables: [air_pressure_at_surface]
     saber outer blocks:
     - saber block name: StdDev
       read:

--- a/config/jedi/applications/4dhybrid.yaml
+++ b/config/jedi/applications/4dhybrid.yaml
@@ -97,6 +97,11 @@ cost function:
             drivers:
               multivariate strategy: univariate
               read local nicas: true
+            grids:
+              - model:
+                  variables: [air_horizontal_streamfunction,air_horizontal_velocity_potential,air_temperature,water_vapor_mixing_ratio_wrt_moist_air]
+              - model:
+                  variables: [air_pressure_at_surface]
         saber outer blocks:
         - saber block name: StdDev
           read:

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -149,13 +149,13 @@ variational:
       hybridCoefficientsDir: None
     60km:
       hybridCoefficientsDir: /glade/campaign/mmm/parc/liuz/pandac_hybrid/60km.allsky_hybrid
-      bumpCovDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.NICAS_00global
-      bumpCovStdDevFile: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/60km.VBAL_00
+      bumpCovDir: /glade/campaign/mmm/parc/bjung/pandac_common/Bflow/20251204/60km/NICAS
+      bumpCovStdDevFile: /glade/campaign/mmm/parc/bjung/pandac_common/Bflow/20251204/60km/mpas.stddev.nc
+      bumpCovVBalDir: /glade/campaign/mmm/parc/bjung/pandac_common/Bflow/20251204/60km/VBAL
     120km:
-      bumpCovDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/120km.NICAS_00
-      bumpCovStdDevFile: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/120km.CMAT_00/mpas.stddev_0p33.2018-04-15_00.00.00.nc
-      bumpCovVBalDir: /glade/campaign/mmm/parc/bjung/pandac_common/BUMP_files.generic_names/120km.VBAL_00
+      bumpCovDir: /glade/campaign/mmm/parc/bjung/pandac_common/Bflow/20251204/120km/NICAS
+      bumpCovStdDevFile: /glade/campaign/mmm/parc/bjung/pandac_common/Bflow/20251204/120km/mpas.stddev.nc
+      bumpCovVBalDir: /glade/campaign/mmm/parc/bjung/pandac_common/Bflow/20251204/120km/VBAL
       hybridCoefficientsDir: /glade/campaign/mmm/parc/liuz/pandac_hybrid/120km.allsky_hybrid
 
   # resource requirements

--- a/scenarios/defaults/variational.yaml
+++ b/scenarios/defaults/variational.yaml
@@ -135,8 +135,8 @@ variational:
     - air_temperature
     - water_vapor_mixing_ratio_wrt_moist_air
     - air_pressure_at_surface
-    bumpCovPrefix: mpas_parametersbump_cov
-    bumpCovVBalPrefix: mpas_vbal
+    bumpCovPrefix: mpas
+    bumpCovVBalPrefix: mpas
     #{{innerMesh}}:
     #  bumpCovDir: str
     #  bumpCovStdDevFile: str


### PR DESCRIPTION
### Description
* This PR includes the re-generated 60km and 120 km static B files, which will affect the DA result.
* This also distinguishes 2D and 3D variables in NICAS when it is used for covariance. This procedure will be in a better form (instead of hard-coded variable names there) in the upcoming merge of release/3.0.3.

### Issue closed
Closes #402

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
