### PR TITLE
revise `geovars.yaml` for `vegetation_area_fraction`

### DIFF
--- a/config/mpas/geovars.yaml
+++ b/config/mpas/geovars.yaml
@@ -300,9 +300,9 @@ fields:
 #      this will go through (NL) Variable Change.
   - field name: vegetation_area_fraction
     mpas template field: u10
-#    mpas identity field: vegetation_area_fraction
+    mpas identity field: vegetation_area_fraction
     mpas io name: vegfra # need scaling or Variable Change
-#    mpas io scaling factor: 0.01 # from MPAS unit [percent] to generic unit [unitless]
+    mpas io scaling factor: 0.01 # from MPAS unit [percent] to generic unit [unitless]
 
   - field name: leaf_area_index
     mpas template field: u10


### PR DESCRIPTION
### Description
This PR revises `geovars.yaml` for `vegetation_area_fraction`. Rather than going through the explicit variable change routine, this uses the identity operation to the variable, which was already _scaled_ at the I/O step. This introduces some change in the result. See the discussion in #411 .

### Issue closed
Closes #411

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
