### PR TITLE
Revise `scenarios/3dhybrid_OIE120km_WarmStart_cron.yaml` of weekly cycling test

### DIFF
--- a/scenarios/3dhybrid_OIE120km_WarmStart_cron.yaml
+++ b/scenarios/3dhybrid_OIE120km_WarmStart_cron.yaml
@@ -9,9 +9,10 @@ model:
   innerMesh: 120km
   ensembleMesh: 120km
 observations:
-  resource: PANDACArchive
+  resource: PANDACArchiveForVarBC
 variational:
   DAType: 3dhybrid
+  biasCorrection: True
   ensembleCovarianceWeight: 0.5
   staticCovarianceWeight: 0.5
   ensemble:


### PR DESCRIPTION
### Description
This PR revises `scenarios/3dhybrid_OIE120km_WarmStart_cron.yaml`, which is used for weekly cycling test.
1. The observations resources has changed from `PANDACArchive` (NCDIAG-converted) to `PANDACArchiveForVarBC` (raw bufr converted).
2. VarBC was activated.

These changes are more aligned with the configuration of scientific experiments.

### Tests completed
#### Tier 1:
 - [ ] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [ ] 3dvar_OIE120km_ColdStart
 - [ ] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [ ] ForecastFromGFSAnalysesMPT
 - [ ] 4denvar_OIE120km_WarmStart
 - [ ] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs