### PR TITLE
Enable model space verification against multiple sources

### DIFF
--- a/bin/VerifyModel.csh
+++ b/bin/VerifyModel.csh
@@ -25,6 +25,9 @@ set ArgStatePrefix = "$4"
 # ArgNMembers: int, set > 1 to activate ensemble spread diagnostics
 set ArgNMembers = "$5"
 
+# ArgReference: reference data source
+set ArgReference = "$6"
+
 ## arg checks
 set test = `echo $ArgDT | grep '^[0-9]*$'`
 set isNotInt = ($status)
@@ -90,7 +93,7 @@ set NUMPROC=`cat $PBS_NODEFILE | wc -l`
 set EADir = ${ExperimentDirectory}/`echo "${ExternalAnalysesDirOuter}" \
   | sed 's@{{thisValidDate}}@'${thisValidDate}'@' \
   `
-setenv baseCommand "python ${mainScript}.py ${thisValidDate} -n ${NUMPROC} -r $EADir/$externalanalyses__filePrefixOuter"
+setenv baseCommand "python ${mainScript}.py ${thisValidDate} -n ${NUMPROC} -r $EADir/$externalanalyses__filePrefixOuter -R $ArgReference"
 
 # additionally analyze diagnostic variables interpolated to fixed presssure levels
 setenv baseCommand "${baseCommand} -rd $EADir/diag"

--- a/initialize/data/ExternalAnalyses.py
+++ b/initialize/data/ExternalAnalyses.py
@@ -232,9 +232,9 @@ class ExternalAnalyses(Component):
       # ungrib
       base = 'UngribExternalAnalysis'
       queue = 'UngribExternalAnalyses'
-      if base in self['PrepareExternalAnalysisOuter'] and self['externalanalyses__UngribPrefixOuter'] != 'ERA5':
-        subqueues.append(queue)
-        taskNames[base] = base+dtLen
+      subqueues.append(queue)
+      taskNames[base] = base+dtLen
+      if self.__ungribtask is not None:
         self._tasks += ['''
 [['''+taskNames[base]+''']]
   inherit = '''+queue+''', BATCH

--- a/initialize/post/VerifyModel.py
+++ b/initialize/post/VerifyModel.py
@@ -27,8 +27,7 @@ class VerifyModel(Component):
   diagnosticsDir = 'diagnostic_stats/model'
   variablesWithDefaults = {
       'script directory': [
-          '/glade/campaign/mmm/parc/ivette/pandac/codeBuild/'
-          'mpasBundle_25Nov2024/code/mpas-jedi/graphics',
+          '/glade/work/jwittig/repos1/mpas-bundle-cron-src/mpas-bundle/mpas-jedi/graphics',
           str
       ],
       'anaRef': ['GFS', str],  # Reference data source (GFS, ERA5, or EC), default is GFS

--- a/initialize/post/VerifyModel.py
+++ b/initialize/post/VerifyModel.py
@@ -26,20 +26,31 @@ class VerifyModel(Component):
   workDir = 'Verification'
   diagnosticsDir = 'diagnostic_stats/model'
   variablesWithDefaults = {
-    'script directory': ['/glade/work/ivette/pandac/graphics/graphics_7SEPT2023', str],
+      'script directory': [
+          '/glade/campaign/mmm/parc/ivette/pandac/codeBuild/'
+          'mpasBundle_25Nov2024/code/mpas-jedi/graphics',
+          str
+      ],
+      'anaRef': ['GFS', str],  # Reference data source (GFS, ERA5, or EC), default is GFS
   }
 
   def __init__(self,
     config:Config,
     localConf:dict,
   ):
-    # adjust script directory for derecho
-    hname = os.getenv('NCAR_HOST')
-    if  hname == "derecho":
-      self.variablesWithDefaults['script directory'] = \
-          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_25Nov2024/code/mpas-jedi/graphics', str]
 
     super().__init__(config)
+
+    # ---------------------------
+    # Validate anaRef
+    # ---------------------------
+    valid_refs = ['GFS', 'ERA5', 'EC']
+    anaRef = self['anaRef']
+    if anaRef not in valid_refs:
+        raise ValueError(
+            f"Invalid anaRef '{self.anaRef}'. "
+            f"Must be one of {valid_refs}."
+        )
 
     hpc = localConf['hpc']; assert isinstance(hpc, HPC), self.base+': incorrect type for hpc'
     mesh = localConf['mesh']; assert isinstance(mesh, Mesh), self.base+': incorrect type for mesh'
@@ -110,6 +121,7 @@ class VerifyModel(Component):
         state.directory(),
         state.prefix(),
         memberMultiplier,
+        anaRef
       ]
       runArgs = ' '.join(['"'+str(a)+'"' for a in args])
 

--- a/initialize/post/VerifyModel.py
+++ b/initialize/post/VerifyModel.py
@@ -48,7 +48,7 @@ class VerifyModel(Component):
     anaRef = self['anaRef']
     if anaRef not in valid_refs:
         raise ValueError(
-            f"Invalid anaRef '{self.anaRef}'. "
+            f"Invalid anaRef '{anaRef}'. "
             f"Must be one of {valid_refs}."
         )
 

--- a/initialize/post/VerifyObs.py
+++ b/initialize/post/VerifyObs.py
@@ -28,8 +28,7 @@ class VerifyObs(Component):
   diagnosticsDir = 'diagnostic_stats/obs'
   variablesWithDefaults = {
       'script directory': [
-          '/glade/campaign/mmm/parc/ivette/pandac/codeBuild/'
-          'mpasBundle_25Nov2024/code/mpas-jedi/graphics',
+          '/glade/work/jwittig/repos1/mpas-bundle-cron-src/mpas-bundle/mpas-jedi/graphics',
           str
       ],
   }

--- a/initialize/post/VerifyObs.py
+++ b/initialize/post/VerifyObs.py
@@ -27,17 +27,18 @@ class VerifyObs(Component):
   workDir = 'Verification'
   diagnosticsDir = 'diagnostic_stats/obs'
   variablesWithDefaults = {
-    'script directory': ['/glade/work/ivette/pandac/graphics/graphics_7SEPT2023', str],
+      'script directory': [
+          '/glade/campaign/mmm/parc/ivette/pandac/codeBuild/'
+          'mpasBundle_25Nov2024/code/mpas-jedi/graphics',
+          str
+      ],
   }
 
   def __init__(self,
     config:Config,
     localConf:dict,
   ):
-    hname = os.getenv('NCAR_HOST')
-    if  hname == "derecho":
-      self.variablesWithDefaults['script directory'] = \
-          ['/glade/campaign/mmm/parc/ivette/pandac/codeBuild/mpasBundle_25Nov2024/code/mpas-jedi/graphics', str]
+
     super().__init__(config)
 
     hpc = localConf['hpc']; assert isinstance(hpc, HPC), self.base+': incorrect type for hpc'

--- a/scenarios/ForecastFromGFSAnalyses.yaml
+++ b/scenarios/ForecastFromGFSAnalyses.yaml
@@ -25,6 +25,7 @@ members:
 
 model:
   outerMesh: 120km
+  innerMesh: 120km
 
 observations: # for optional verification
   resource: GladeRDAOnline

--- a/scenarios/ForecastFromGFSAnalyses.yaml
+++ b/scenarios/ForecastFromGFSAnalyses.yaml
@@ -33,3 +33,7 @@ workflow:
   first cycle point: 20220606T00
   final cycle point: 20220607T00
   max active cycle points: 4
+
+verifymodel:
+  #script directory: /glade/derecho/scratch/ivette/pandac/graphics/15km_abiahi/mpas-jedi/graphics
+  anaRef: 'GFS'


### PR DESCRIPTION
### Description
The graphics package can already handle multiple reference datasets for model-space verification (see [JCSDA-internal/mpas-jedi#1096]). However, this capability has not been integrated into the MPAS-Workflow. This PR introduces support for specifying the reference dataset (-R {GFS, ERA5, EC}) at the statistics generation stage, i.e., in the verifymodel task. This change is needed because the statistics files themselves contain the reference dataset definition. For example,  `"log_mogfsan", "mmgfsan"`, indicates GFS as the reference dataset used in the statistics. Here, it was added a new configurable variable `anaRef` in the VerifyModel component that will be passed to the verifymodel.csh script as an argument (-R $anaRef). The option was added to `ForecastFromGFSAnalyses` and it works as expected.

Additionally, the `script directory` variable is returned to be user-configurable in both VerifyModel and VerifyObs. The path was updated to use the tip of the develop branch similar to the build.

### Issue closed
Closes https://github.com/NCAR/MPAS-Workflow/issues/419
Fixes the issue mentioned by @jim-p-w in https://github.com/NCAR/MPAS-Workflow/pull/418#discussion_r2892316046
            

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (:
 - [x] ForecastFromGFSAnalyses
 
Under `diagnostic_stats/model`, `myCommand` successfully shows:
 `python DiagnoseModelStatistics.py 2018041500 -n 128 -r /glade/derecho/scratch/ivette/pandac/ivette_eda_OIE120km_WarmStart_TEST/ExternalAnalyses/120km/2018041500/x1.40962.init -R GFS -rd /glade/derecho/scratch/ivette/pandac/ivette_eda_OIE120km_WarmStart_TEST/ExternalAnalyses/120km/2018041500/diag -m 5
`