### PR TITLE
Allow specifying accounts and queue priorities from Run.py command line.

### DIFF
--- a/Run.py
+++ b/Run.py
@@ -54,11 +54,17 @@ class Run(Logger):
                     help='configuration file; e.g., runs/test.yaml, scenarios/{{scenarioName}}.yaml')
     ap.add_argument('-b', '--bundle_dir', help='mpas bundle directory')
     ap.add_argument('-x', '--suffix', help='experiment name suffix')
+    ap.add_argument('-ac', '--critical_account', help='which account to charge critical jobs to')
+    ap.add_argument('-an', '--noncritical_account', help='which account to charge noncritical jobs to')
+    ap.add_argument('-pc', '--critical_priority', help='priority for critical jobs')
+    ap.add_argument('-pn', '--noncritical_priority', help='priority for noncritical jobs')
     args = ap.parse_args()
     assert Path(args.config).is_file(), (self.logPrefix+'config ('+args.config+') does not exist')
 
     self.__configFile = args.config
-    self.__config = Config(args.config, args.bundle_dir, args.suffix)
+    self.__config = Config(args.config, args.bundle_dir, args.suffix,
+                           args.critical_account, args.noncritical_account,
+                           args.critical_priority, args.noncritical_priority)
 
   def execute(self):
     '''
@@ -81,7 +87,9 @@ class Run(Logger):
 
       self.clean(self)
 
-      scenario = Scenario(scenarioFile, self.__config._bundle_dir, self.__config._suffix)
+      scenario = Scenario(scenarioFile, self.__config._bundle_dir, self.__config._suffix,
+                   self.__config._critical_account, self.__config._noncritical_account,
+                   self.__config._critical_priority, self.__config._noncritical_priority)
       scenario.initialize()
 
       # suite name (defaults to Cycle)

--- a/Run.py
+++ b/Run.py
@@ -58,13 +58,13 @@ class Run(Logger):
     ap.add_argument('-an', '--noncritical_account', help='which account to charge noncritical jobs to')
     ap.add_argument('-pc', '--critical_priority', help='priority for critical jobs')
     ap.add_argument('-pn', '--noncritical_priority', help='priority for noncritical jobs')
-    args = ap.parse_args()
-    assert Path(args.config).is_file(), (self.logPrefix+'config ('+args.config+') does not exist')
+    self._args = ap.parse_args()
+    assert Path(self._args.config).is_file(), (self.logPrefix+'config ('+self._args.config+') does not exist')
 
-    self.__configFile = args.config
-    self.__config = Config(args.config, args.bundle_dir, args.suffix,
-                           args.critical_account, args.noncritical_account,
-                           args.critical_priority, args.noncritical_priority)
+    self.__configFile = self._args.config
+    self.__config = Config(self._args.config, self._args.bundle_dir, self._args.suffix,
+                           self._args.critical_account, self._args.noncritical_account,
+                           self._args.critical_priority, self._args.noncritical_priority)
 
   def execute(self):
     '''
@@ -87,9 +87,9 @@ class Run(Logger):
 
       self.clean(self)
 
-      scenario = Scenario(scenarioFile, self.__config._bundle_dir, self.__config._suffix,
-                   self.__config._critical_account, self.__config._noncritical_account,
-                   self.__config._critical_priority, self.__config._noncritical_priority)
+      scenario = Scenario(scenarioFile, self._args.bundle_dir, self._args.suffix,
+                   self._args.critical_account, self._args.noncritical_account,
+                   self._args.critical_priority, self._args.noncritical_priority)
       scenario.initialize()
 
       # suite name (defaults to Cycle)

--- a/initialize/config/Config.py
+++ b/initialize/config/Config.py
@@ -19,6 +19,10 @@ class Config(Logger):
       filename: str=None,
       bundle_dir: str=None,
       suffix: str=None,
+      critical_account: str = None,
+      noncritical_account: str = None,
+      critical_priority: str = None,
+      noncritical_priority: str = None,
       defaultsFile: str = None,
     ):
 
@@ -29,6 +33,10 @@ class Config(Logger):
 
    self._bundle_dir = bundle_dir
    self._suffix = suffix
+   self._critical_account = critical_account
+   self._noncritical_account = noncritical_account
+   self._critical_priority = critical_priority
+   self._noncritical_priority = noncritical_priority
    if defaultsFile is not None:
      with open(defaultsFile) as file:
        self._defaults = yaml.load(file, Loader=yaml.FullLoader)
@@ -38,7 +46,17 @@ class Config(Logger):
   def __str__(self):
     bd =  (self._bundle_dir if self._bundle_dir != None else 'None')
     suffix =  (self._suffix if self._suffix != None else 'None')
-    return 'bundle_dir:' + bd + ' suffix:' + suffix
+    ret_str = 'bundle_dir:' + bd + ' suffix:' + suffix
+    if self._critical_account != None:
+      ret_str = ret_str + ' critical account:' + self._critical_account
+    if self._noncritical_account != None:
+      ret_str = ret_str + ' noncritical account:' + self._noncritical_account
+    if self._critical_priority != None:
+      ret_str = ret_str + ' critical priority:' + self._critical_priority
+    if self._noncritical_priority != None:
+      ret_str = ret_str + ' noncritical priority:' + self._noncritical_priority
+    self.log('ret_str'+ ret_str, level=self.MSG_DEBUG)
+    return ret_str
 
   def extract(self, subKey: str, defaultsFile:str = None):
     tab = deepcopy(self._table.get(subKey, {}))

--- a/initialize/config/Config.py
+++ b/initialize/config/Config.py
@@ -30,13 +30,20 @@ class Config(Logger):
    if filename is not None:
      with open(filename) as file:
        self._table = yaml.load(file, Loader=yaml.FullLoader)
+       # if accounts or priorities are provided on the command line,
+       # override the values specified in the scenario yaml
+       if critical_account != None:
+         self._table['hpc']['CriticalAccount'] = critical_account
+       if noncritical_account != None:
+         self._table['hpc']['NonCriticalAccount'] = noncritical_account
+       if critical_priority != None:
+         self._table['hpc']['CriticalPriority'] = critical_priority
+       if noncritical_priority != None:
+         self._table['hpc']['NonCriticalPriority'] = noncritical_priority
+       self.log('HPC:'+ str(self._table['hpc']), level=self.MSG_DEBUG)
 
    self._bundle_dir = bundle_dir
    self._suffix = suffix
-   self._critical_account = critical_account
-   self._noncritical_account = noncritical_account
-   self._critical_priority = critical_priority
-   self._noncritical_priority = noncritical_priority
    if defaultsFile is not None:
      with open(defaultsFile) as file:
        self._defaults = yaml.load(file, Loader=yaml.FullLoader)
@@ -46,17 +53,7 @@ class Config(Logger):
   def __str__(self):
     bd =  (self._bundle_dir if self._bundle_dir != None else 'None')
     suffix =  (self._suffix if self._suffix != None else 'None')
-    ret_str = 'bundle_dir:' + bd + ' suffix:' + suffix
-    if self._critical_account != None:
-      ret_str = ret_str + ' critical account:' + self._critical_account
-    if self._noncritical_account != None:
-      ret_str = ret_str + ' noncritical account:' + self._noncritical_account
-    if self._critical_priority != None:
-      ret_str = ret_str + ' critical priority:' + self._critical_priority
-    if self._noncritical_priority != None:
-      ret_str = ret_str + ' noncritical priority:' + self._noncritical_priority
-    self.log('ret_str'+ ret_str, level=self.MSG_DEBUG)
-    return ret_str
+    return 'bundle_dir:' + bd + ' suffix:' + suffix
 
   def extract(self, subKey: str, defaultsFile:str = None):
     tab = deepcopy(self._table.get(subKey, {}))

--- a/initialize/config/Config.py
+++ b/initialize/config/Config.py
@@ -32,6 +32,9 @@ class Config(Logger):
        self._table = yaml.load(file, Loader=yaml.FullLoader)
        # if accounts or priorities are provided on the command line,
        # override the values specified in the scenario yaml
+       self.log('table:'+ str(self._table), level=self.MSG_DEBUG)
+       if 'hpc' not in self._table:
+         self._table['hpc'] = {}
        if critical_account != None:
          self._table['hpc']['CriticalAccount'] = critical_account
        if noncritical_account != None:

--- a/initialize/config/Scenario.py
+++ b/initialize/config/Scenario.py
@@ -10,8 +10,12 @@
 from initialize.config.Config import Config
 
 class Scenario():
-  def __init__(self, file, bundle, suffix):
-    self.__conf = Config(file, bundle, suffix)
+  def __init__(self, file, bundle, suffix,
+               critical_account, noncritical_account,
+               critical_priority, noncritical_priority):
+    self.__conf = Config(file, bundle, suffix,
+                         critical_account, noncritical_account,
+                         critical_priority, noncritical_priority)
     self.__script = [
 '''#!/bin/csh -f
 

--- a/initialize/framework/HPC.py
+++ b/initialize/framework/HPC.py
@@ -55,25 +55,14 @@ class HPC(Component):
     self.logPrefix = self.__class__.__name__+': '
 
     # set system dependent defaults before invoking Component ctor
-    if config._critical_account != None:
-      self.variablesWithDefaults['CriticalAccount'] = [config._critical_account, str]
-    if config._noncritical_account != None:
-      self.variablesWithDefaults['NonCriticalAccount'] = [config._noncritical_account, str]
-
     system = os.getenv('NCAR_HOST')
     if system == 'derecho':
-      critical_priority = 'regular'
-      noncritical_priority = 'regular'
-      if config._critical_priority != None:
-        critical_priority = config._critical_priority
-      if config._noncritical_priority != None:
-        noncritical_priority = config._noncritical_priority
       topdir = '/glade/derecho/scratch'
       self.variablesWithDefaults['CriticalQueue'] = ['main', str, ['main', 'preempt']]
       self.variablesWithDefaults['NonCriticalQueue'] =  ['main', str, ['main', 'preempt']]
 #      self.variablesWithDefaults['SingleProcQueue'] = ['casper@casper-pbs', str, ['casper@casper-pbs', 'main']]
-      self.variablesWithDefaults['CriticalPriority'] = [critical_priority, str, ['premium', 'regular', 'economy', 'preempt']]
-      self.variablesWithDefaults['NonCriticalPriority'] = [noncritical_priority, str, ['premium', 'regular', 'economy', 'preempt']]
+      self.variablesWithDefaults['CriticalPriority'] = ['regular', str, ['premium', 'regular', 'economy', 'preempt']]
+      self.variablesWithDefaults['NonCriticalPriority'] = ['regular', str, ['premium', 'regular', 'economy', 'preempt']]
       self.system = system
       #config.convertToDerecho()
     elif system == 'cheyenne':

--- a/initialize/framework/HPC.py
+++ b/initialize/framework/HPC.py
@@ -55,14 +55,25 @@ class HPC(Component):
     self.logPrefix = self.__class__.__name__+': '
 
     # set system dependent defaults before invoking Component ctor
+    if config._critical_account != None:
+      self.variablesWithDefaults['CriticalAccount'] = [config._critical_account, str]
+    if config._noncritical_account != None:
+      self.variablesWithDefaults['NonCriticalAccount'] = [config._noncritical_account, str]
+
     system = os.getenv('NCAR_HOST')
     if system == 'derecho':
+      critical_priority = 'regular'
+      noncritical_priority = 'regular'
+      if config._critical_priority != None:
+        critical_priority = config._critical_priority
+      if config._noncritical_priority != None:
+        noncritical_priority = config._noncritical_priority
       topdir = '/glade/derecho/scratch'
       self.variablesWithDefaults['CriticalQueue'] = ['main', str, ['main', 'preempt']]
       self.variablesWithDefaults['NonCriticalQueue'] =  ['main', str, ['main', 'preempt']]
 #      self.variablesWithDefaults['SingleProcQueue'] = ['casper@casper-pbs', str, ['casper@casper-pbs', 'main']]
-      self.variablesWithDefaults['CriticalPriority'] = ['regular', str, ['premium', 'regular', 'economy', 'preempt']]
-      self.variablesWithDefaults['NonCriticalPriority'] = ['regular', str, ['premium', 'regular', 'economy', 'preempt']]
+      self.variablesWithDefaults['CriticalPriority'] = [critical_priority, str, ['premium', 'regular', 'economy', 'preempt']]
+      self.variablesWithDefaults['NonCriticalPriority'] = [noncritical_priority, str, ['premium', 'regular', 'economy', 'preempt']]
       self.system = system
       #config.convertToDerecho()
     elif system == 'cheyenne':


### PR DESCRIPTION
### Description
This PR enables specifying the priority of jobs and the account to be charged when running scenarios with Run.py
Usage:
```
  -ac CRITICAL_ACCOUNT, --critical_account CRITICAL_ACCOUNT
                        which account to charge critical jobs to
  -an NONCRITICAL_ACCOUNT, --noncritical_account NONCRITICAL_ACCOUNT
                        which account to charge noncritical jobs to
  -pc CRITICAL_PRIORITY, --critical_priority CRITICAL_PRIORITY
                        priority for critical jobs
  -pn NONCRITICAL_PRIORITY, --noncritical_priority NONCRITICAL_PRIORITY
                        priority for noncritical jobs
```
**Note**: Command  line values override values specified in yaml config files.

### Tests completed
**Note**: All tests were run via `Run.py -ac nmmm0043 -an nmmm0043 -pc economy -pn economy test/testinput/test1.yaml`
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
