### PR TITLE
Use default option for config_extrap_airtemp in namelist.init_atmosphere

### DIFF
--- a/config/mpas/initic/namelist.init_atmosphere
+++ b/config/mpas/initic/namelist.init_atmosphere
@@ -29,7 +29,7 @@
     config_tc_vertical_grid = true
 /
 &interpolation_control
-    config_extrap_airtemp = 'linear'
+    config_extrap_airtemp = 'lapse-rate'
 /
 &preproc_stages
     config_static_interp = false

--- a/scenarios/ForecastFromERAmlAnalyses.yaml
+++ b/scenarios/ForecastFromERAmlAnalyses.yaml
@@ -1,0 +1,40 @@
+suite: ForecastFromExternalAnalyses
+
+externalanalyses:
+  resource: "ERA5.GDEX"
+
+experiment:
+  name: 'ForecastFromERA5mlAnalyses'
+  prefix: ''
+
+extendedforecast:
+  meanTimes: T00,T12
+  lengthHR: 24
+  outIntervalHR: 12
+  #execute: False # uncomment if forecasts are already completed
+
+  # optionally turn on extended forecast post
+  post: [verifyobs, verifymodel]
+
+hpc:
+  CriticalPriority: economy
+  NonCriticalPriority: economy
+
+members:
+  n: 1
+
+model:
+  outerMesh: 120km
+  innerMesh: 120km
+
+observations: # for optional verification
+  resource: GladeRDAOnline
+
+workflow:
+  first cycle point: 20220606T00
+  final cycle point: 20220607T00
+  max active cycle points: 4
+
+verifymodel:
+  #script directory: /glade/derecho/scratch/ivette/pandac/graphics/15km_abiahi/mpas-jedi/graphics
+  anaRef: 'ERA5'


### PR DESCRIPTION
### Description
In [PR#418](https://github.com/NCAR/MPAS-Workflow/pull/418), the capability to convert ERA5 model-level analyses to the MPAS initial conditions format was added. However, when using the current `linear` option in `config/mpas/initic/namelist.init_atmosphere`, unrealistic values of potential temperature (θ) are produced (min=17K), leading to model forecast failure. In contrast, using `lapse-rate` (the default in the User’s Guide) or `constant` both yield physically realistic values. While `linear` performs well for GFS analyses and ERA5 pressure-level data,  it does not properly handle ERA5 model-level data. Therefore, in this PR, the default option is changed to `lapse-rate` as it works across all external data sources. Additionally, a new scenario is introduced to generate forecasts using ERA5 model-level data.

### Issue closed
None

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] ForecastFromGFSAnalysesMPT

#### Tier 2:
 - [x] ForecastFromGFSAnalyses
 - [x] ForecastFromERAmlAnalyses