### PR TITLE
Update obs2ioda executable and enable h5 extension output in ObsToIODA

### DIFF
--- a/bin/ObsToIODA.csh
+++ b/bin/ObsToIODA.csh
@@ -114,7 +114,7 @@ foreach gdasfile ( *"gdas."* )
      mkdir -p sfc
      cd sfc
      ln -sfv ${obs2iodaBuildDir}/${obs2iodaEXE} ./
-     ./${obs2iodaEXE} -e h5${noGSIQCFilters} ../${gdasfile} >&! ../logs/log-converter_sfc
+     ./${obs2iodaEXE} -e h5 ${noGSIQCFilters} ../${gdasfile} >&! ../logs/log-converter_sfc
      # replace surface obs file with file created without additional QC
      mv -f sfc_obs_${thisCycleDate}.h5 ../sfc_obs_${thisCycleDate}.h5
      cd ..

--- a/bin/ObsToIODA.csh
+++ b/bin/ObsToIODA.csh
@@ -101,7 +101,7 @@ foreach gdasfile ( *"gdas."* )
 
    if ( ${gdasfile} =~ *"mtiasi"* ) then
      #./${obs2iodaEXE} ${SPLIThourly} ${gdasfile} >&! $log
-     ./${obs2iodaEXE} ${gdasfile} >&! $log
+     ./${obs2iodaEXE} -e h5 ${gdasfile} >&! $log
    else if ( ${gdasfile} =~ *"prepbufr"* ) then
      # use obs errors embedded in prepbufr file
      if ( -e obs_errtable ) then
@@ -109,12 +109,12 @@ foreach gdasfile ( *"gdas."* )
      endif
      set inst = `echo "$gdasfile" | cut -d'.' -f1`
      # run obs2ioda for preburf with additional QC as in GSI
-     ./${obs2iodaEXE} ${gdasfile} >&! $log
+     ./${obs2iodaEXE} -e h5 ${gdasfile} >&! $log
      # for surface obs, run obs2ioda for prepbufr without additional QC
      mkdir -p sfc
      cd sfc
      ln -sfv ${obs2iodaBuildDir}/${obs2iodaEXE} ./
-     ./${obs2iodaEXE} ${noGSIQCFilters} ../${gdasfile} >&! ../logs/log-converter_sfc
+     ./${obs2iodaEXE} -e h5${noGSIQCFilters} ../${gdasfile} >&! ../logs/log-converter_sfc
      # replace surface obs file with file created without additional QC
      mv -f sfc_obs_${thisCycleDate}.h5 ../sfc_obs_${thisCycleDate}.h5
      cd ..
@@ -127,9 +127,9 @@ foreach gdasfile ( *"gdas."* )
        echo "ERROR: ${GDASObsErrtable} does NOT exist" > ./FAIL
        exit 1
      endif
-     ./${obs2iodaEXE} ${gdasfile} >&! $log
+     ./${obs2iodaEXE} -e h5 ${gdasfile} >&! $log
    else
-     ./${obs2iodaEXE} ${gdasfile} >&! $log
+     ./${obs2iodaEXE} -e h5 ${gdasfile} >&! $log
    endif
 
    # Check status

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -186,7 +186,7 @@ class Build(Component):
     # Obs2IODA-v3
     # -----------
     self._set('obs2iodaEXE', 'obs2ioda')
-    self._set('obs2iodaBuildDir', '/glade/derecho/scratch/jwittig/repos-s/mpas-bundle-cron/build-gnu-1p_26_06_17/bin')
+    self._set('obs2iodaBuildDir', self['mpas bundle'] + '/bin')
 
     # Mean state calculator
     # ---------------------

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -185,8 +185,8 @@ class Build(Component):
 
     # Obs2IODA-v3
     # -----------
-    self._set('obs2iodaEXE', 'obs2ioda_v3')
-    self._set('obs2iodaBuildDir', '/glade/campaign/mmm/parc/ivette/pandac/codeBuild/obs2iodaV3/build/bin')
+    self._set('obs2iodaEXE', 'obs2ioda')
+    self._set('obs2iodaBuildDir', '/glade/derecho/scratch/jwittig/repos-s/mpas-bundle-cron/build-gnu-2p/bin')
 
     # Mean state calculator
     # ---------------------

--- a/initialize/framework/Build.py
+++ b/initialize/framework/Build.py
@@ -186,7 +186,7 @@ class Build(Component):
     # Obs2IODA-v3
     # -----------
     self._set('obs2iodaEXE', 'obs2ioda')
-    self._set('obs2iodaBuildDir', '/glade/derecho/scratch/jwittig/repos-s/mpas-bundle-cron/build-gnu-2p/bin')
+    self._set('obs2iodaBuildDir', '/glade/derecho/scratch/jwittig/repos-s/mpas-bundle-cron/build-gnu-1p_26_06_17/bin')
 
     # Mean state calculator
     # ---------------------


### PR DESCRIPTION
### Description
This PR updates the `obs2ioda` executable to use the version from `ioda-converters` compiled with the latest nightly mpas-bundle build and incorporates recent changes to `ObsToIODA` for writing  output files with h5 extension. This extension is in alignment with current practices used in scientific experiments.

### Issue closed
None

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart

#### Tier 2:
 - [x] GenerateObs
