### PR TITLE
Change the sensor type for ObsErrorFactorTopoRad entries

### DIFF
--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_metop-a.yaml
@@ -106,6 +106,9 @@
         options:
           sensor: microwave
           channels: 1-15
+          height groups:
+          - channels: 7
+            height: 4000
     <<: *multiIterationFilter
 
 #  Transmittance Top Check
@@ -239,6 +242,9 @@
           options:
             channels: 1-15
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_metop-a.yaml
@@ -104,7 +104,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: 1-15
         options:
-          sensor: amsua_metop-a
+          sensor: microwave
           channels: 1-15
     <<: *multiIterationFilter
 
@@ -238,7 +238,7 @@
           channels: 1-15
           options:
             channels: 1-15
-            sensor: amsua_metop-a
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_metop-b.yaml
@@ -106,6 +106,9 @@
         options:
           sensor: microwave
           channels: 1-15
+          height groups:
+          - channels: 7
+            height: 4000
     <<: *multiIterationFilter
 
 #  Transmittance Top Check
@@ -239,6 +242,9 @@
           options:
             channels: 1-15
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_metop-b.yaml
@@ -104,7 +104,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: 1-15
         options:
-          sensor: amsua_metop-b
+          sensor: microwave
           channels: 1-15
     <<: *multiIterationFilter
 
@@ -238,7 +238,7 @@
           channels: 1-15
           options:
             channels: 1-15
-            sensor: amsua_metop-b
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n15.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n15.yaml
@@ -106,6 +106,9 @@
         options:
           sensor: microwave
           channels: 1-15
+          height groups:
+          - channels: 7
+            height: 4000
     <<: *multiIterationFilter
 
 #  Transmittance Top Check
@@ -239,6 +242,9 @@
           options:
             channels: 1-15
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n15.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n15.yaml
@@ -104,7 +104,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: 1-15
         options:
-          sensor: amsua_n15
+          sensor: microwave
           channels: 1-15
     <<: *multiIterationFilter
 
@@ -238,7 +238,7 @@
           channels: 1-15
           options:
             channels: 1-15
-            sensor: amsua_n15
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n18.yaml
@@ -106,6 +106,9 @@
         options:
           sensor: microwave
           channels: 1-15
+          height groups:
+          - channels: 7
+            height: 4000
     <<: *multiIterationFilter
 
 #  Transmittance Top Check
@@ -239,6 +242,9 @@
           options:
             channels: 1-15
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n18.yaml
@@ -104,7 +104,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: 1-15
         options:
-          sensor: amsua_n18
+          sensor: microwave
           channels: 1-15
     <<: *multiIterationFilter
 
@@ -238,7 +238,7 @@
           channels: 1-15
           options:
             channels: 1-15
-            sensor: amsua_n18
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n19.yaml
@@ -106,6 +106,9 @@
         options:
           sensor: microwave
           channels: 1-15
+          height groups:
+          - channels: 7
+            height: 4000
     <<: *multiIterationFilter
 
 #  Transmittance Top Check
@@ -239,6 +242,9 @@
           options:
             channels: 1-15
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n19.yaml
@@ -104,7 +104,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: 1-15
         options:
-          sensor: amsua_n19
+          sensor: microwave
           channels: 1-15
     <<: *multiIterationFilter
 
@@ -238,7 +238,7 @@
           channels: 1-15
           options:
             channels: 1-15
-            sensor: amsua_n19
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n19.yaml_cold-air-outbreak
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n19.yaml_cold-air-outbreak
@@ -103,6 +103,9 @@
         options:
           sensor: microwave
           channels: 1-15
+          height groups:
+          - channels: 7
+            height: 4000
     <<: *multiIterationFilter
 
 #  Transmittance Top Check
@@ -236,6 +239,9 @@
           options:
             channels: 1-15
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n19.yaml_cold-air-outbreak
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-all_n19.yaml_cold-air-outbreak
@@ -101,7 +101,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: 1-15
         options:
-          sensor: amsua_n19
+          sensor: microwave
           channels: 1-15
     <<: *multiIterationFilter
 
@@ -235,7 +235,7 @@
           channels: 1-15
           options:
             channels: 1-15
-            sensor: amsua_n19
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: 1-15

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_metop-a.yaml
@@ -127,7 +127,7 @@
           channels: *amsua-cld_metop-a_channels
           options:
             channels: *amsua-cld_metop-a_channels
-            sensor: amsua_metop-a
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua-cld_metop-a_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_metop-b.yaml
@@ -128,7 +128,7 @@
           channels: *amsua-cld_metop-b_channels
           options:
             channels: *amsua-cld_metop-b_channels
-            sensor: amsua_metop-b
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua-cld_metop-b_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_metop-c.yaml
@@ -127,7 +127,7 @@
           channels: *amsua-cld_metop-c_channels
           options:
             channels: *amsua-cld_metop-c_channels
-            sensor: amsua_metop-c
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua-cld_metop-c_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_n15.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_n15.yaml
@@ -127,7 +127,7 @@
           channels: *amsua-cld_n15_channels
           options:
             channels: *amsua-cld_n15_channels
-            sensor: amsua_n15
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua-cld_n15_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_n18.yaml
@@ -127,7 +127,7 @@
           channels: *amsua-cld_n18_channels
           options:
             channels: *amsua-cld_n18_channels
-            sensor: amsua_n18
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua-cld_n18_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua-cld_n19.yaml
@@ -126,7 +126,7 @@
           channels: *amsua-cld_n19_channels
           options:
             channels: *amsua-cld_n19_channels
-            sensor: amsua_n19
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua-cld_n19_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_aqua_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_aqua_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_aqua_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_aqua_channels
         options:
-          sensor: amsua_aqua
+          sensor: microwave
           channels: *amsua_aqua_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_aqua_channels
           options:
             channels: *amsua_aqua_channels
-            sensor: amsua_aqua
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_aqua_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua_rttov.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_aqua_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_aqua_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_aqua_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_aqua_rttov.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_aqua_channels
         options:
-          sensor: amsua_aqua
+          sensor: microwave
           channels: *amsua_aqua_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_aqua_channels
           options:
             channels: *amsua_aqua_channels
-            sensor: amsua_aqua
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_aqua_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_metop-a_channels
         options:
-          sensor: amsua_metop-a
+          sensor: microwave
           channels: *amsua_metop-a_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_metop-a_channels
           options:
             channels: *amsua_metop-a_channels
-            sensor: amsua_metop-a
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_metop-a_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_metop-a_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_metop-a_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_metop-a_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a_rttov.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_metop-a_channels
         options:
-          sensor: amsua_metop-a
+          sensor: microwave
           channels: *amsua_metop-a_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_metop-a_channels
           options:
             channels: *amsua_metop-a_channels
-            sensor: amsua_metop-a
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_metop-a_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-a_rttov.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_metop-a_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_metop-a_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_metop-a_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_metop-b_channels
         options:
-          sensor: amsua_metop-b
+          sensor: microwave
           channels: *amsua_metop-b_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_metop-b_channels
           options:
             channels: *amsua_metop-b_channels
-            sensor: amsua_metop-b
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_metop-b_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_metop-b_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_metop-b_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_metop-b_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b_rttov.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_metop-b_channels
         options:
-          sensor: amsua_metop-b
+          sensor: microwave
           channels: *amsua_metop-b_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_metop-b_channels
           options:
             channels: *amsua_metop-b_channels
-            sensor: amsua_metop-b
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_metop-b_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-b_rttov.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_metop-b_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_metop-b_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_metop-b_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-c.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_metop-c_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_metop-c_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_metop-c_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_metop-c.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_metop-c_channels
         options:
-          sensor: amsua_metop-c
+          sensor: microwave
           channels: *amsua_metop-c_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_metop-c_channels
           options:
             channels: *amsua_metop-c_channels
-            sensor: amsua_metop-c
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_metop-c_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_n15_channels
         options:
-          sensor: amsua_n15
+          sensor: microwave
           channels: *amsua_n15_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_n15_channels
           options:
             channels: *amsua_n15_channels
-            sensor: amsua_n15
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n15_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_n15_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_n15_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n15_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15_rttov.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_n15_channels
         options:
-          sensor: amsua_n15
+          sensor: microwave
           channels: *amsua_n15_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_n15_channels
           options:
             channels: *amsua_n15_channels
-            sensor: amsua_n15
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n15_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n15_rttov.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_n15_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_n15_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n15_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_n18_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_n18_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n18_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_n18_channels
         options:
-          sensor: amsua_n18
+          sensor: microwave
           channels: *amsua_n18_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_n18_channels
           options:
             channels: *amsua_n18_channels
-            sensor: amsua_n18
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n18_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18_rttov.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_n18_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_n18_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n18_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n18_rttov.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_n18_channels
         options:
-          sensor: amsua_n18
+          sensor: microwave
           channels: *amsua_n18_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_n18_channels
           options:
             channels: *amsua_n18_channels
-            sensor: amsua_n18
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n18_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_n19_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_n19_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n19_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_n19_channels
         options:
-          sensor: amsua_n19
+          sensor: microwave
           channels: *amsua_n19_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_n19_channels
           options:
             channels: *amsua_n19_channels
-            sensor: amsua_n19
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n19_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19_rttov.yaml
@@ -90,6 +90,9 @@
         options:
           sensor: microwave
           channels: *amsua_n19_channels
+          height groups:
+          - channels: 7
+            height: 4000
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:
@@ -143,6 +146,9 @@
           options:
             channels: *amsua_n19_channels
             sensor: microwave
+            height groups:
+            - channels: 7
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n19_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/amsua_n19_rttov.yaml
@@ -88,7 +88,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_n19_channels
         options:
-          sensor: amsua_n19
+          sensor: microwave
           channels: *amsua_n19_channels
 #  Transmittance Top Check
   - filter: Perform Action
@@ -142,7 +142,7 @@
           channels: *amsua_n19_channels
           options:
             channels: *amsua_n19_channels
-            sensor: amsua_n19
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *amsua_n19_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/atms_n20.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/atms_n20.yaml
@@ -325,6 +325,9 @@
           options:
             channels: *atms_n20_channels
             sensor: microwave
+            height groups:
+            - channels: 8
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *atms_n20_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/atms_n20.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/atms_n20.yaml
@@ -123,7 +123,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *atms_n20_channels
         options:
-          sensor: atms_n20
+          sensor: microwave
           channels: *atms_n20_channels
     <<: *multiIterationFilter
 #  Transmittnace Top Check
@@ -251,7 +251,7 @@
           channels: *atms_n20_channels
           options:
             channels: *atms_n20_channels
-            sensor: atms_n20
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *atms_n20_channels
@@ -318,7 +318,7 @@
           channels: *atms_n20_channels
           options:
             channels: *atms_n20_channels
-            sensor: atms_n20
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *atms_n20_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/atms_n20.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/atms_n20.yaml
@@ -125,6 +125,9 @@
         options:
           sensor: microwave
           channels: *atms_n20_channels
+          height groups:
+          - channels: 8
+            height: 4000
     <<: *multiIterationFilter
 #  Transmittnace Top Check
   - filter: BlackList
@@ -252,6 +255,9 @@
           options:
             channels: *atms_n20_channels
             sensor: microwave
+            height groups:
+            - channels: 8
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *atms_n20_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/atms_n21.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/atms_n21.yaml
@@ -123,7 +123,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *atms_n21_channels
         options:
-          sensor: atms_n21
+          sensor: microwave
           channels: *atms_n21_channels
     <<: *multiIterationFilter
 #  Transmittnace Top Check
@@ -251,7 +251,7 @@
           channels: *atms_n21_channels
           options:
             channels: *atms_n21_channels
-            sensor: atms_n21
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *atms_n21_channels
@@ -318,7 +318,7 @@
           channels: *atms_n21_channels
           options:
             channels: *atms_n21_channels
-            sensor: atms_n21
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *atms_n21_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/atms_n21.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/atms_n21.yaml
@@ -125,6 +125,9 @@
         options:
           sensor: microwave
           channels: *atms_n21_channels
+          height groups:
+          - channels: 8
+            height: 4000
     <<: *multiIterationFilter
 #  Transmittnace Top Check
   - filter: BlackList
@@ -252,6 +255,9 @@
           options:
             channels: *atms_n21_channels
             sensor: microwave
+            height groups:
+            - channels: 8
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *atms_n21_channels
@@ -319,6 +325,9 @@
           options:
             channels: *atms_n21_channels
             sensor: microwave
+            height groups:
+            - channels: 8
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *atms_n21_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/atms_npp.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/atms_npp.yaml
@@ -123,7 +123,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *atms_npp_channels
         options:
-          sensor: atms_npp
+          sensor: microwave
           channels: *atms_npp_channels
     <<: *multiIterationFilter
 #  Transmittnace Top Check
@@ -251,7 +251,7 @@
           channels: *atms_npp_channels
           options:
             channels: *atms_npp_channels
-            sensor: atms_npp
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *atms_npp_channels
@@ -318,7 +318,7 @@
           channels: *atms_npp_channels
           options:
             channels: *atms_npp_channels
-            sensor: atms_npp
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *atms_npp_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/atms_npp.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/atms_npp.yaml
@@ -125,6 +125,9 @@
         options:
           sensor: microwave
           channels: *atms_npp_channels
+          height groups:
+          - channels: 8
+            height: 4000
     <<: *multiIterationFilter
 #  Transmittnace Top Check
   - filter: BlackList
@@ -252,6 +255,9 @@
           options:
             channels: *atms_npp_channels
             sensor: microwave
+            height groups:
+            - channels: 8
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *atms_npp_channels
@@ -319,6 +325,9 @@
           options:
             channels: *atms_npp_channels
             sensor: microwave
+            height groups:
+            - channels: 8
+              height: 4000
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *atms_npp_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/cris-fsr_n20.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/cris-fsr_n20.yaml
@@ -71,7 +71,7 @@
         channels: *cris-fsr_n20_channels
         options:
           channels: *cris-fsr_n20_channels
-          sensor: cris-fsr_n20
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/cris-fsr_n21.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/cris-fsr_n21.yaml
@@ -71,7 +71,7 @@
         channels: *cris-fsr_n21_channels
         options:
           channels: *cris-fsr_n21_channels
-          sensor: cris-fsr_n21
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/cris-fsr_npp.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/cris-fsr_npp.yaml
@@ -66,7 +66,7 @@
         channels: *cris-fsr_npp_channels
         options:
           channels: *cris-fsr_npp_channels
-          sensor: cris-fsr_npp
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/cris_n20.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/cris_n20.yaml
@@ -67,7 +67,7 @@
         channels: *cris_n20_channels
         options:
           channels: *cris_n20_channels
-          sensor: cris_n20
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/cris_npp.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/cris_npp.yaml
@@ -70,7 +70,7 @@
         channels: *cris_npp_channels
         options:
           channels: *cris_npp_channels
-          sensor: cris_npp
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml
@@ -72,7 +72,7 @@
         channels: *iasi_metop-a_channels
         options:
           channels: *iasi_metop-a_channels
-          sensor: iasi_metop-a
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml_66ch
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml_66ch
@@ -61,7 +61,7 @@
         channels: *iasi_metop-a_channels
         options:
           channels: *iasi_metop-a_channels
-          sensor: iasi_metop-a
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml_88ch
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a.yaml_88ch
@@ -84,7 +84,7 @@
         channels: *iasi_metop-a_channels
         options:
           channels: *iasi_metop-a_channels
-          sensor: iasi_metop-a
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-a_rttov.yaml
@@ -61,7 +61,7 @@
         channels: *iasi_metop-a_channels
         options:
           channels: *iasi_metop-a_channels
-          sensor: iasi_metop-a
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml
@@ -72,7 +72,7 @@
         channels: *iasi_metop-b_channels
         options:
           channels: *iasi_metop-b_channels
-          sensor: iasi_metop-b
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml_66ch
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml_66ch
@@ -61,7 +61,7 @@
         channels: *iasi_metop-b_channels
         options:
           channels: *iasi_metop-b_channels
-          sensor: iasi_metop-b
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml_88ch
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-b.yaml_88ch
@@ -84,7 +84,7 @@
         channels: *iasi_metop-b_channels
         options:
           channels: *iasi_metop-b_channels
-          sensor: iasi_metop-b
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/iasi_metop-c.yaml
@@ -84,7 +84,7 @@
         channels: *iasi_metop-c_channels
         options:
           channels: *iasi_metop-c_channels
-          sensor: iasi_metop-c
+          sensor: infrared
 #  Transmittance Top Check
   - filter: Perform Action
     filter variables:

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs-cld_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs-cld_metop-a.yaml
@@ -106,7 +106,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_metop-a_channels
         options:
-          sensor: mhs_metop-a
+          sensor: microwave
           channels: *mhs_metop-a_channels
     <<: *multiIterationFilter
 #  Transmittnace Top Check
@@ -153,7 +153,7 @@
           channels: *mhs_metop-a_channels
           options:
             channels: *mhs_metop-a_channels
-            sensor: mhs_metop-a
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *mhs_metop-a_channels
@@ -205,7 +205,7 @@
           channels: *mhs_metop-a_channels
           options:
             channels: *mhs_metop-a_channels
-            sensor: mhs_metop-a
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *mhs_metop-a_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs-cld_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs-cld_metop-b.yaml
@@ -107,7 +107,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_metop-b_channels
         options:
-          sensor: mhs_metop-b
+          sensor: microwave
           channels: *mhs_metop-b_channels
     <<: *multiIterationFilter
 #  Transmittnace Top Check
@@ -155,7 +155,7 @@
           channels: *mhs_metop-b_channels
           options:
             channels: *mhs_metop-b_channels
-            sensor: mhs_metop-b
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *mhs_metop-b_channels
@@ -207,7 +207,7 @@
           channels: *mhs_metop-b_channels
           options:
             channels: *mhs_metop-b_channels
-            sensor: mhs_metop-b
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *mhs_metop-b_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs-cld_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs-cld_metop-c.yaml
@@ -106,7 +106,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_metop-c_channels
         options:
-          sensor: mhs_metop-c
+          sensor: microwave
           channels: *mhs_metop-c_channels
     <<: *multiIterationFilter
 #  Transmittnace Top Check
@@ -153,7 +153,7 @@
           channels: *mhs_metop-c_channels
           options:
             channels: *mhs_metop-c_channels
-            sensor: mhs_metop-c
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *mhs_metop-c_channels
@@ -205,7 +205,7 @@
           channels: *mhs_metop-c_channels
           options:
             channels: *mhs_metop-c_channels
-            sensor: mhs_metop-c
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *mhs_metop-c_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs-cld_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs-cld_n18.yaml
@@ -107,7 +107,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_n18_channels
         options:
-          sensor: mhs_n18
+          sensor: microwave
           channels: *mhs_n18_channels
     <<: *multiIterationFilter
 #  Transmittnace Top Check
@@ -154,7 +154,7 @@
           channels: *mhs_n18_channels
           options:
             channels: *mhs_n18_channels
-            sensor: mhs_n18
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *mhs_n18_channels
@@ -205,7 +205,7 @@
           channels: *mhs_n18_channels
           options:
             channels: *mhs_n18_channels
-            sensor: mhs_n18
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *mhs_n18_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs-cld_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs-cld_n19.yaml
@@ -107,7 +107,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_n19_channels
         options:
-          sensor: mhs_n19
+          sensor: microwave
           channels: *mhs_n19_channels
     <<: *multiIterationFilter
 #  Transmittnace Top Check
@@ -154,7 +154,7 @@
           channels: *mhs_n19_channels
           options:
             channels: *mhs_n19_channels
-            sensor: mhs_n19
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelRamp
           channels: *mhs_n19_channels
@@ -206,7 +206,7 @@
           channels: *mhs_n19_channels
           options:
             channels: *mhs_n19_channels
-            sensor: mhs_n19
+            sensor: microwave
         obserr_function:
           name: ObsFunction/ObsErrorModelQuad
           channels: *mhs_n19_channels

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a.yaml
@@ -83,7 +83,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_metop-a_channels
         options:
-          sensor: mhs_metop-a
+          sensor: microwave
           channels: *mhs_metop-a_channels
     <<: *multiIterationFilter
 # Transmittnace Top Check
@@ -126,7 +126,7 @@
           channels: *mhs_metop-a_channels
           options:
             channels: *mhs_metop-a_channels
-            sensor: mhs_metop-a
+            sensor: microwave
         error parameter vector:
                   [ 2.5, 2.5, 2.5, 2.0, 2.0]
         obserr_bound_max: [5.0, 5.0, 10.0, 10.0, 10.0]

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-a_rttov.yaml
@@ -97,7 +97,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_metop-a_channels
         options:
-          sensor: mhs_metop-a
+          sensor: microwave
           channels: *mhs_metop-a_channels
     <<: *multiIterationFilter
 # Transmittnace Top Check
@@ -140,7 +140,7 @@
           channels: *mhs_metop-a_channels
           options:
             channels: *mhs_metop-a_channels
-            sensor: mhs_metop-a
+            sensor: microwave
         error parameter vector:
                   [ 2.5, 2.5, 2.5, 2.0, 2.0]
         obserr_bound_max: [5.0, 5.0, 10.0, 10.0, 10.0]

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b.yaml
@@ -83,7 +83,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_metop-b_channels
         options:
-          sensor: mhs_metop-b
+          sensor: microwave
           channels: *mhs_metop-b_channels
     <<: *multiIterationFilter
 
@@ -127,7 +127,7 @@
           channels: *mhs_metop-b_channels
           options:
             channels: *mhs_metop-b_channels
-            sensor: mhs_metop-b
+            sensor: microwave
         error parameter vector:
                   [ 2.5, 2.5, 2.5, 2.0, 2.0]
         obserr_bound_max: [5.0, 5.0, 10.0, 10.0, 10.0]

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-b_rttov.yaml
@@ -97,7 +97,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_metop-b_channels
         options:
-          sensor: mhs_metop-b
+          sensor: microwave
           channels: *mhs_metop-b_channels
     <<: *multiIterationFilter
 
@@ -141,7 +141,7 @@
           channels: *mhs_metop-b_channels
           options:
             channels: *mhs_metop-b_channels
-            sensor: mhs_metop-b
+            sensor: microwave
         error parameter vector:
                   [ 2.5, 2.5, 2.5, 2.0, 2.0]
         obserr_bound_max: [5.0, 5.0, 10.0, 10.0, 10.0]

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-c.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_metop-c.yaml
@@ -83,7 +83,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_metop-c_channels
         options:
-          sensor: mhs_metop-c
+          sensor: microwave
           channels: *mhs_metop-c_channels
     <<: *multiIterationFilter
 # Transmittnace Top Check
@@ -126,7 +126,7 @@
           channels: *mhs_metop-c_channels
           options:
             channels: *mhs_metop-c_channels
-            sensor: mhs_metop-c
+            sensor: microwave
         error parameter vector:
                   [ 2.5, 2.5, 2.5, 2.0, 2.0]
         obserr_bound_max: [5.0, 5.0, 10.0, 10.0, 10.0]

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18.yaml
@@ -83,7 +83,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_n18_channels
         options:
-          sensor: mhs_n18
+          sensor: microwave
           channels: *mhs_n18_channels
     <<: *multiIterationFilter
 
@@ -127,7 +127,7 @@
           channels: *mhs_n18_channels
           options:
             channels: *mhs_n18_channels
-            sensor: mhs_n18
+            sensor: microwave
         error parameter vector:
                   [ 2.5, 2.5, 2.5, 2.0, 2.0]
         obserr_bound_max: [5.0, 5.0, 10.0, 10.0, 10.0]

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n18_rttov.yaml
@@ -97,7 +97,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_n18_channels
         options:
-          sensor: mhs_n18
+          sensor: microwave
           channels: *mhs_n18_channels
     <<: *multiIterationFilter
 
@@ -141,7 +141,7 @@
           channels: *mhs_n18_channels
           options:
             channels: *mhs_n18_channels
-            sensor: mhs_n18
+            sensor: microwave
         error parameter vector:
                   [ 2.5, 2.5, 2.5, 2.0, 2.0]
         obserr_bound_max: [5.0, 5.0, 10.0, 10.0, 10.0]

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19.yaml
@@ -81,7 +81,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_n19_channels
         options:
-          sensor: mhs_n19
+          sensor: microwave
           channels: *mhs_n19_channels
     <<: *multiIterationFilter
 
@@ -125,7 +125,7 @@
           channels: *mhs_n19_channels
           options:
             channels: *mhs_n19_channels
-            sensor: mhs_n19
+            sensor: microwave
         error parameter vector:
                   [ 2.5, 2.5, 3.0, 2.5, 2.5]
         obserr_bound_max: [5.0, 5.0, 3.0, 5.0, 5.0]

--- a/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19_rttov.yaml
+++ b/config/jedi/ObsPlugs/da/filtersWithBias/mhs_n19_rttov.yaml
@@ -95,7 +95,7 @@
         name: ObsFunction/ObsErrorFactorTopoRad
         channels: *mhs_n19_channels
         options:
-          sensor: mhs_n19
+          sensor: microwave
           channels: *mhs_n19_channels
     <<: *multiIterationFilter
 
@@ -139,7 +139,7 @@
           channels: *mhs_n19_channels
           options:
             channels: *mhs_n19_channels
-            sensor: mhs_n19
+            sensor: microwave
         error parameter vector:
                   [ 2.5, 2.5, 3.0, 2.5, 2.5]
         obserr_bound_max: [5.0, 5.0, 3.0, 5.0, 5.0]


### PR DESCRIPTION
### Description
[ufo PR 4253](https://github.com/JCSDA-internal/ufo/pull/4253) requires the sensor type for ObsErrorFactorTopoRad entries to be either `microwave` or `infrared`.

### Issue closed

Closes #429

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [ ] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [ ] 3denvar_O30kmIE60km_WarmStart
 - [ ] eda_OIE120km_WarmStart
 - [ ] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [ ] 4denvar_OIE120km_WarmStart
 - [ ] 4dhybrid_OIE120km_WarmStart
 The remaining tier 1 tests weren't run due to them failing for causes unrelated to this PR.

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs
