### PR TITLE
Rename SymmCldImpact function per latest UFO code change(#431)

### DIFF
--- a/config/jedi/ObsPlugs/da/filters/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/da/filters/abi_g16.yaml
@@ -65,7 +65,7 @@
           <<: *abi_g16_SymmCldFits{{ABISUPEROBGRID}}-{{HofXMeshDescriptor}}
           channels: *abi_g16_channels
           xvar:
-            name: ObsFunction/SymmCldImpactIR
+            name: ObsFunction/SymmCldImpact
             channels: *abi_g16_channels
             options:
               channels: *abi_g16_channels
@@ -81,7 +81,7 @@
 #    where:
 #    - variable:
 ##        name: MetaData/cloudAmount
-#        name: ObsFunction/SymmCldImpactIR
+#        name: ObsFunction/SymmCldImpact
 #        channels: *abi_g16_channels
 #        options:
 #          channels: *abi_g16_channels

--- a/config/jedi/ObsPlugs/da/filters/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/da/filters/ahi_himawari8.yaml
@@ -50,7 +50,7 @@
           <<: *ahi_himawari8_SymmCldFits{{AHISUPEROBGRID}}-{{HofXMeshDescriptor}}
           channels: *ahi_himawari8_channels
           xvar:
-            name: ObsFunction/SymmCldImpactIR
+            name: ObsFunction/SymmCldImpact
             channels: *ahi_himawari8_channels
             options:
               channels: *ahi_himawari8_channels

--- a/config/jedi/ObsPlugs/hofx/filters/abi_g16.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/abi_g16.yaml
@@ -59,7 +59,7 @@
           <<: *abi_g16_SymmCldFits{{ABISUPEROBGRID}}-{{HofXMeshDescriptor}}
           channels: *abi_channels
           xvar:
-            name: ObsFunction/SymmCldImpactIR
+            name: ObsFunction/SymmCldImpact
             channels: *abi_channels
             options:
               channels: *abi_channels

--- a/config/jedi/ObsPlugs/hofx/filters/ahi_himawari8.yaml
+++ b/config/jedi/ObsPlugs/hofx/filters/ahi_himawari8.yaml
@@ -51,7 +51,7 @@
           <<: *ahi_himawari8_SymmCldFits{{AHISUPEROBGRID}}-{{HofXMeshDescriptor}}
           channels: *ahi_channels
           xvar:
-            name: ObsFunction/SymmCldImpactIR
+            name: ObsFunction/SymmCldImpact
             channels: *ahi_channels
             options:
               channels: *ahi_channels


### PR DESCRIPTION
### Description
Following JCSDA-internal/ufo#4148 (merged on 7/13/26), the SymmCldImpactIR ObsFunction was renamed to SymmCldImpact. This PR accounts for that change, so tests running model verification using ABI and AHI won't fail.

This is a cherry-pick of PR 431
### Issue closed

Closes #(if applicable)

### Tests completed
#### Tier 1:
 - [x] 3dvar_OIE120km_WarmStart
 - [x] 3denvar_OIE120km_IAU_WarmStart
 - [x] 3dvar_OIE120km_ColdStart
 - [x] 3dvar_O30kmIE60km_ColdStart
 - [x] 3denvar_O30kmIE60km_WarmStart
 - [x] eda_OIE120km_WarmStart
 - [x] getkf_OIE120km_WarmStart
 - [x] ForecastFromGFSAnalysesMPT
 - [x] 4denvar_OIE120km_WarmStart
 - [x] 4dhybrid_OIE120km_WarmStart

#### Tier 2 (optional):
 - [ ] GenerateGFSAnalyses
 - [ ] GenerateObs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>